### PR TITLE
feat: add repair agent JSON schema validation and side issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Workflow control plane for OpenSWE-backed issue execution"
 readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "cracklings3d" }]
-dependencies = []
+dependencies = ["jsonschema>=4.26.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -290,7 +290,7 @@ class RunCoordinator:
         store.write_evaluation_result(run_dir, evaluation_result)
         verdict = apply_governance(intake, execution_result, evaluation_result)
         store.write_governance_verdict(run_dir, verdict)
-        publish_plan = build_publish_plan(intake, record, verdict)
+        publish_plan = build_publish_plan(intake, record, verdict, repair_result)
         store.write_publish_plan(run_dir, publish_plan)
         publish_result = dependencies.execute_publish_plan(
             intake,

--- a/src/precision_squad/data/repair-result-schema.json
+++ b/src/precision_squad/data/repair-result-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "string",
+      "description": "What the agent did — one paragraph max."
+    },
+    "side_issues": {
+      "type": "array",
+      "description": "Secondary issues discovered that are unrelated to the primary issue being worked.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "One-line issue identifier."
+          },
+          "summary": {
+            "type": "string",
+            "description": "Concise synthesis of the finding — what needs fixing and why. Aim for ~500 chars."
+          },
+          "body": {
+            "type": "string",
+            "description": "Full verbose output for audit purposes. Not used in publish context."
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "GitHub labels to apply to the follow-up issue."
+          }
+        },
+        "required": ["title", "summary", "body"]
+      }
+    }
+  },
+  "required": ["summary"]
+}

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -110,6 +110,16 @@ class EvaluationResult:
 
 
 @dataclass(frozen=True, slots=True)
+class SideIssue:
+    """A secondary issue discovered during repair that is unrelated to the primary issue."""
+
+    title: str
+    summary: str
+    body: str
+    labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RepairResult:
     """Normalized result for the post-synthesis repair stage."""
 
@@ -120,7 +130,7 @@ class RepairResult:
     patch_path: str | None = None
     stdout_path: str | None = None
     stderr_path: str | None = None
-    side_issues: tuple[str, ...] = ()
+    side_issues: tuple[SideIssue, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -17,7 +17,7 @@ from .docs_remediation import (
     normalize_docs_findings,
 )
 from .intake import is_docs_remediation_issue
-from .models import GovernanceVerdict, IssueIntake, PublishPlan, RunRecord
+from .models import GovernanceVerdict, IssueIntake, PublishPlan, RepairResult, RunRecord
 from .rerun_context import latest_rejected_pull_request
 
 
@@ -25,6 +25,7 @@ def build_publish_plan(
     intake: IssueIntake,
     run_record: RunRecord,
     verdict: GovernanceVerdict,
+    repair_result: RepairResult | None = None,
 ) -> PublishPlan:
     """Prepare the first publish plan without calling GitHub yet."""
     if verdict.status == "approved":
@@ -90,6 +91,36 @@ def build_publish_plan(
             ),
             reason_codes=verdict.reason_codes,
         )
+
+    if verdict.status == "blocked":
+        side_issues = repair_result.side_issues if repair_result else ()
+        if side_issues:
+            side_issues_lines = []
+            for si in side_issues:
+                labels_str = ", ".join(f"`{l}`" for l in si.labels) if si.labels else "no labels"
+                side_issues_lines.append(
+                    f"### {si.title}\n"
+                    f"**Labels:** {labels_str}\n\n"
+                    f"{si.summary}\n"
+                )
+            side_issues_body = "\n---\n\n".join(side_issues_lines)
+            return PublishPlan(
+                status="follow_up_issue",
+                title=f"Side issues surfaced while repairing #{intake.issue.reference.number}",
+                body=(
+                    f"## Side Issues Surfaced\n"
+                    f"- Surfaced while repairing: `{intake.issue.reference}`\n"
+                    f"- Source issue URL: {intake.issue.html_url}\n"
+                    f"- Requested change: {intake.summary}\n"
+                    f"- Run ID: `{run_record.run_id}`\n"
+                    f"- Governance verdict: `{verdict.status}`\n"
+                    f"- Summary: {verdict.summary}\n"
+                    "\n"
+                    "## Side Issues\n"
+                    f"{side_issues_body}\n"
+                ),
+                reason_codes=verdict.reason_codes,
+            )
 
     reason_lines = "\n".join(f"- {code}" for code in verdict.reason_codes) or "- blocked"
     return PublishPlan(

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -7,10 +7,51 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from jsonschema import ValidationError, validate
+
 from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
-from ..models import IssueIntake, RepairResult, RunRecord
+from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
+
+REPAIR_RESULT_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "What the agent did — one paragraph max.",
+        },
+        "side_issues": {
+            "type": "array",
+            "description": "Secondary issues discovered that are unrelated to the primary issue.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "One-line issue identifier.",
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "Concise synthesis of the finding — what needs fixing and why. Aim for ~500 chars.",
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Full verbose output for audit purposes.",
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "GitHub labels to apply to the follow-up issue.",
+                    },
+                },
+                "required": ["title", "summary", "body"],
+            },
+        },
+    },
+    "required": ["summary"],
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,15 +157,64 @@ class OpenCodeRepairAdapter:
                 stderr_path=str(stderr_path),
             )
 
+        repair_json = _parse_repair_json(command_result.stdout)
+        side_issues: tuple[SideIssue, ...] = ()
+        if repair_json is not None:
+            side_issues = _extract_side_issues(repair_json)
+
         return RepairResult(
             status="completed",
-            summary="Repair agent completed and produced source changes.",
+            summary=repair_json.get("summary") if repair_json else "Repair agent completed and produced source changes.",
             detail_codes=("repair_stage_completed",),
             workspace_path=str(repo_workspace.parent),
             patch_path=str(patch_path),
             stdout_path=str(stdout_path),
             stderr_path=str(stderr_path),
+            side_issues=side_issues,
         )
+
+
+def _parse_repair_json(stdout: str) -> dict | None:
+    """Parse and validate JSON output from the repair agent."""
+    events = _extract_json_events(stdout)
+    if not events:
+        return None
+    last_event = events[-1]
+    if not isinstance(last_event, dict):
+        return None
+    try:
+        validate(instance=last_event, schema=REPAIR_RESULT_SCHEMA)
+    except ValidationError:
+        return None
+    return last_event
+
+
+def _extract_side_issues(repair_json: dict) -> tuple[SideIssue, ...]:
+    """Extract side issues from parsed JSON, returning empty tuple on validation failure."""
+    side_issues_data = repair_json.get("side_issues")
+    if not isinstance(side_issues_data, list):
+        return ()
+    side_issues: list[SideIssue] = []
+    for item in side_issues_data:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        summary = item.get("summary")
+        body = item.get("body", "")
+        if not isinstance(title, str) or not isinstance(summary, str):
+            continue
+        labels_raw = item.get("labels", [])
+        if isinstance(labels_raw, list):
+            labels = tuple(str(l) for l in labels_raw if isinstance(l, str))
+        else:
+            labels = ()
+        side_issues.append(SideIssue(
+            title=title,
+            summary=summary,
+            body=body,
+            labels=labels,
+        ))
+    return tuple(side_issues)
 
 
 def _build_repair_prompt(
@@ -137,6 +227,19 @@ def _build_repair_prompt(
     qa_feedback: str | None,
 ) -> str:
     docs_fix_prompt_path = contract_artifact_dir / "docs-fix-prompt.txt"
+    docs_fix_prompt_content = ""
+    if docs_fix_prompt_path.exists():
+        docs_fix_prompt_content = docs_fix_prompt_path.read_text(encoding="utf-8")
+
+    json_instruction = (
+        "Output a single JSON object with at least a `summary` field describing what you did. "
+        "If you discover secondary issues unrelated to the primary issue, include them in a `side_issues` array. "
+        "Each side issue must have `title` (one-line identifier), `summary` (concise synthesis, aim for ~500 chars), "
+        "`body` (full verbose output for audit), and `labels` (array of GitHub label strings). "
+        "Schema:\n"
+        + json.dumps(REPAIR_RESULT_SCHEMA, indent=2)
+    )
+
     if is_docs_remediation_issue(intake):
         target_rule_ids = {
             str(finding.get("rule_id", "")).strip()
@@ -150,7 +253,7 @@ def _build_repair_prompt(
             "Requirements:",
             "- Update repository documentation in the current workspace to resolve the issue.",
             "- Treat this as a docs-remediation issue, not a product code change.",
-            "- Use the docs-fix prompt, execution contract, and executor logs as "
+            "- Use the docs-fix prompt (inlined below), execution contract, and executor logs as "
             "the source of truth.",
             "- Eliminate every tracked target finding in this issue's hidden "
             "target-findings metadata.",
@@ -166,15 +269,17 @@ def _build_repair_prompt(
             "- Keep changes minimal and focused.",
             "- Do not ask questions.",
             "- Do not commit.",
-            "- After edits, stop with a short summary.",
+            "- After edits, output your JSON result.",
             "Context files:",
             f"- Issue statement: {run_dir / 'issue.md'}",
-            f"- Docs fix prompt: {docs_fix_prompt_path}",
+            f"- Docs fix prompt (inlined):\n\n{docs_fix_prompt_content}\n",
             f"- Execution contract: {contract_artifact_dir / 'contract.json'}",
             f"- README snapshot: {contract_artifact_dir / 'README.snapshot.md'}",
             f"- Executor stdout log: {run_dir / 'executor.stdout.log'}",
             f"- Executor stderr log: {run_dir / 'executor.stderr.log'}",
             f"Workspace repo: {repo_workspace}",
+            "",
+            json_instruction,
         ]
         if "docs_setup_prerequisite_manual_only" in target_rule_ids:
             lines.insert(
@@ -209,7 +314,7 @@ def _build_repair_prompt(
             "- Do not ask questions.",
             "- Keep changes minimal and focused.",
             "- Do not commit.",
-            "- After edits, stop with a short summary.",
+            "- After edits, output your JSON result.",
             "Context files:",
             f"- Issue statement: {run_dir / 'issue.md'}",
             f"- Execution contract: {contract_artifact_dir / 'contract.json'}",
@@ -218,8 +323,15 @@ def _build_repair_prompt(
             f"- Executor stderr log: {run_dir / 'executor.stderr.log'}",
             f"Workspace repo: {repo_workspace}",
         ]
-        if docs_fix_prompt_path.exists():
-            lines.insert(-1, f"- Docs fix prompt: {docs_fix_prompt_path}")
+        if docs_fix_prompt_content:
+            lines.insert(
+                -2,
+                "- The following secondary issues were detected in the documentation "
+                "but are not the primary focus of this repair. "
+                "Recommend surfacing them as separate GitHub issues via the JSON output:\n"
+                + f"\n{docs_fix_prompt_content}\n",
+            )
+        lines.insert(-1, json_instruction)
     if qa_feedback:
         lines.extend(["QA feedback from the previous attempt:", qa_feedback])
     return "\n".join(lines)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,410 @@
+"""Tests for repair adapter JSON parsing, side issue extraction, and prompt construction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from precision_squad.models import (
+    GitHubIssue,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    RunRecord,
+)
+from precision_squad.repair.adapter import (
+    _build_repair_prompt,
+    _extract_json_events,
+    _extract_side_issues,
+    _parse_repair_json,
+)
+
+# ---------------------------------------------------------------------------
+# _extract_json_events
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_events_from_ndjson() -> None:
+    stdout = '{"event": "start"}\n{"event": "end", "summary": "done"}\n'
+    events = _extract_json_events(stdout)
+    assert len(events) == 2
+    assert events[0]["event"] == "start"
+    assert events[1]["event"] == "end"
+
+
+def test_extract_json_events_skips_non_json_lines() -> None:
+    stdout = "some log line\n{invalid json\n{\"valid\": true}\n"
+    events = _extract_json_events(stdout)
+    assert len(events) == 1
+    assert events[0] == {"valid": True}
+
+
+def test_extract_json_events_empty_stdout() -> None:
+    assert _extract_json_events("") == []
+
+
+def test_extract_json_events_no_dicts() -> None:
+    stdout = '"just a string"\n123\n[1, 2, 3]\n'
+    assert _extract_json_events(stdout) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_repair_json
+# ---------------------------------------------------------------------------
+
+
+def test_parse_repair_json_valid_summary_only() -> None:
+    stdout = json.dumps({"summary": "Fixed the bug."})
+    result = _parse_repair_json(stdout)
+    assert result is not None
+    assert result["summary"] == "Fixed the bug."
+
+
+def test_parse_repair_json_valid_with_side_issues() -> None:
+    payload = {
+        "summary": "Fixed the bug.",
+        "side_issues": [
+            {
+                "title": "Other bug",
+                "summary": "Found another bug",
+                "body": "Details here",
+                "labels": ["bug"],
+            }
+        ],
+    }
+    stdout = json.dumps(payload)
+    result = _parse_repair_json(stdout)
+    assert result is not None
+    assert len(result["side_issues"]) == 1
+
+
+def test_parse_repair_json_empty_stdout() -> None:
+    assert _parse_repair_json("") is None
+
+
+def test_parse_repair_json_no_json_events() -> None:
+    assert _parse_repair_json("just some log output\n") is None
+
+
+def test_parse_repair_json_last_event_not_dict_skipped() -> None:
+    stdout = '{"summary": "first"}\n"not a dict"\n'
+    result = _parse_repair_json(stdout)
+    # _extract_json_events filters non-dicts, so last event is the dict
+    assert result is not None
+    assert result["summary"] == "first"
+
+
+def test_parse_repair_json_missing_summary() -> None:
+    stdout = json.dumps({"side_issues": []})
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_summary_wrong_type() -> None:
+    stdout = json.dumps({"summary": 123})
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_uses_last_event() -> None:
+    stdout = (
+        json.dumps({"summary": "first", "extra": 1}) + "\n"
+        + json.dumps({"summary": "second", "extra": 2}) + "\n"
+    )
+    result = _parse_repair_json(stdout)
+    assert result is not None
+    assert result["summary"] == "second"
+    assert result["extra"] == 2
+
+
+def test_parse_repair_json_side_issues_wrong_type() -> None:
+    stdout = json.dumps({"summary": "done", "side_issues": "not a list"})
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_side_issue_missing_required_fields() -> None:
+    stdout = json.dumps({
+        "summary": "done",
+        "side_issues": [{"title": "Only title"}],
+    })
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_side_issue_wrong_field_types() -> None:
+    stdout = json.dumps({
+        "summary": "done",
+        "side_issues": [{"title": 123, "summary": "ok", "body": "ok"}],
+    })
+    assert _parse_repair_json(stdout) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_side_issues
+# ---------------------------------------------------------------------------
+
+
+def test_extract_side_issues_valid() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [
+            {
+                "title": "Bug A",
+                "summary": "Found bug A",
+                "body": "Full details",
+                "labels": ["bug", "p1"],
+            }
+        ],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 1
+    assert issues[0].title == "Bug A"
+    assert issues[0].summary == "Found bug A"
+    assert issues[0].body == "Full details"
+    assert issues[0].labels == ("bug", "p1")
+
+
+def test_extract_side_issues_no_key() -> None:
+    assert _extract_side_issues({"summary": "done"}) == ()
+
+
+def test_extract_side_issues_not_a_list() -> None:
+    assert _extract_side_issues({"summary": "done", "side_issues": "bad"}) == ()
+
+
+def test_extract_side_issues_item_not_dict() -> None:
+    data = {"summary": "done", "side_issues": ["not a dict", 42]}
+    assert _extract_side_issues(data) == ()
+
+
+def test_extract_side_issues_missing_title() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"summary": "s", "body": "b"}],
+    }
+    assert _extract_side_issues(data) == ()
+
+
+def test_extract_side_issues_missing_summary() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": "t", "body": "b"}],
+    }
+    assert _extract_side_issues(data) == ()
+
+
+def test_extract_side_issues_title_not_string() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": 123, "summary": "s", "body": "b"}],
+    }
+    assert _extract_side_issues(data) == ()
+
+
+def test_extract_side_issues_summary_not_string() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": "t", "summary": 456, "body": "b"}],
+    }
+    assert _extract_side_issues(data) == ()
+
+
+def test_extract_side_issues_missing_body_defaults_empty() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": "t", "summary": "s"}],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 1
+    assert issues[0].body == ""
+
+
+def test_extract_side_issues_labels_not_list() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": "t", "summary": "s", "body": "b", "labels": "bad"}],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 1
+    assert issues[0].labels == ()
+
+
+def test_extract_side_issues_labels_non_string_items_filtered() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [
+            {"title": "t", "summary": "s", "body": "b", "labels": ["good", 123, "also-good"]}
+        ],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 1
+    assert issues[0].labels == ("good", "also-good")
+
+
+def test_extract_side_issues_no_labels_defaults_empty() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [{"title": "t", "summary": "s", "body": "b"}],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 1
+    assert issues[0].labels == ()
+
+
+def test_extract_side_issues_mixed_valid_and_invalid() -> None:
+    data = {
+        "summary": "done",
+        "side_issues": [
+            {"title": "valid", "summary": "ok", "body": "ok"},
+            "not a dict",
+            {"title": "missing summary"},
+            {"title": "also valid", "summary": "also ok", "body": "also ok"},
+        ],
+    }
+    issues = _extract_side_issues(data)
+    assert len(issues) == 2
+    assert issues[0].title == "valid"
+    assert issues[1].title == "also valid"
+
+
+# ---------------------------------------------------------------------------
+# _build_repair_prompt
+# ---------------------------------------------------------------------------
+
+
+def _make_intake(*, body: str = "Fix the bug.", labels: tuple[str, ...] = ()) -> IssueIntake:
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Test issue",
+            body=body,
+            labels=labels,
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Test issue",
+        problem_statement="Fix the bug.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+
+def _make_run_record() -> RunRecord:
+    return RunRecord(
+        run_id="run-test",
+        issue_ref="owner/repo#1",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=".precision-squad/runs/run-test",
+    )
+
+
+def test_build_repair_prompt_non_docs_no_docs_fix_prompt(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    prompt = _build_repair_prompt(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback=None,
+    )
+
+    assert "Modify code" in prompt
+    assert "Output a single JSON object" in prompt
+    assert '"summary"' in prompt
+    assert "Recommend surfacing" not in prompt
+
+
+def test_build_repair_prompt_non_docs_with_docs_fix_prompt(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    (contract_dir / "docs-fix-prompt.txt").write_text("Fix the README.", encoding="utf-8")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    prompt = _build_repair_prompt(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback=None,
+    )
+
+    assert "Modify code" in prompt
+    assert "Recommend surfacing them as separate GitHub issues" in prompt
+    assert "Fix the README." in prompt
+
+
+def test_build_repair_prompt_docs_remediation_inlines_fix_prompt(tmp_path: Path) -> None:
+    intake = _make_intake(
+        body="<!-- precision-squad:docs-remediation -->\nFix the docs.",
+        labels=(),
+    )
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    (contract_dir / "docs-fix-prompt.txt").write_text("Inline this content.", encoding="utf-8")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    prompt = _build_repair_prompt(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback=None,
+    )
+
+    assert "Update repository documentation" in prompt
+    assert "Inline this content." in prompt
+    assert "Recommend surfacing" not in prompt
+
+
+def test_build_repair_prompt_includes_json_schema(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    prompt = _build_repair_prompt(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback=None,
+    )
+
+    assert "$schema" in prompt
+    assert "summary" in prompt
+    assert "side_issues" in prompt
+
+
+def test_build_repair_prompt_appends_qa_feedback(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    prompt = _build_repair_prompt(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback="Tests failed: test_foo",
+    )
+
+    assert "QA feedback from the previous attempt:" in prompt
+    assert "Tests failed: test_foo" in prompt

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -658,7 +658,7 @@ def test_opencode_repair_adapter_uses_docs_remediation_prompt_for_docs_issue(
     )
 
     assert "Treat this as a docs-remediation issue" in seen_prompt["value"]
-    assert str(contract_dir / "docs-fix-prompt.txt") in seen_prompt["value"]
+    assert "Update README only" in seen_prompt["value"]
     assert "Eliminate every tracked target finding" in seen_prompt["value"]
     assert "include at least one exact executable acquisition or install command" in seen_prompt["value"]
     assert "explicitly label the canonical source as one of: `release artifact`, `package manager`, or `source build`" in seen_prompt["value"]
@@ -1120,3 +1120,177 @@ def test_finalize_qa_result_accepts_strict_baseline_improvement(tmp_path: Path) 
     assert result.phase == "final"
     assert result.quality == "improved"
     assert "qa_baseline_improved" not in result.detail_codes
+
+
+def test_parse_repair_json_extracts_summary() -> None:
+    from precision_squad.repair.adapter import _parse_repair_json
+
+    stdout = '{"type":"text","part":{"text":"done"}}\n{"summary":"Fixed the issue by updating README"}\n'
+    result = _parse_repair_json(stdout)
+    assert result is not None
+    assert result["summary"] == "Fixed the issue by updating README"
+
+
+def test_parse_repair_json_returns_none_when_no_summary() -> None:
+    from precision_squad.repair.adapter import _parse_repair_json
+
+    stdout = '{"type":"text","part":{"text":"done"}}\n{"other":"field"}\n'
+    result = _parse_repair_json(stdout)
+    assert result is None
+
+
+def test_parse_repair_json_returns_none_when_no_json() -> None:
+    from precision_squad.repair.adapter import _parse_repair_json
+
+    stdout = '{"type":"text","part":{"text":"done"}}\njust plain text\n'
+    result = _parse_repair_json(stdout)
+    assert result is None
+
+
+def test_extract_side_issues_parses_valid_data() -> None:
+    from precision_squad.repair.adapter import _extract_side_issues
+
+    repair_json = {
+        "summary": "Fixed issue",
+        "side_issues": [
+            {
+                "title": "Missing version pin",
+                "summary": "requirements.txt lacks version pin for pytest",
+                "body": "Full details about missing version pin...",
+                "labels": ["docs", "bug"],
+            },
+            {
+                "title": "CI badge broken",
+                "summary": "Travis CI badge returns 404",
+                "body": "The Travis CI badge URL has changed",
+                "labels": ["ci"],
+            },
+        ],
+    }
+    result = _extract_side_issues(repair_json)
+    assert len(result) == 2
+    assert result[0].title == "Missing version pin"
+    assert result[0].summary == "requirements.txt lacks version pin for pytest"
+    assert result[0].body == "Full details about missing version pin..."
+    assert result[0].labels == ("docs", "bug")
+    assert result[1].title == "CI badge broken"
+    assert result[1].labels == ("ci",)
+
+
+def test_extract_side_issues_skips_invalid_items() -> None:
+    from precision_squad.repair.adapter import _extract_side_issues
+
+    repair_json = {
+        "summary": "Fixed issue",
+        "side_issues": [
+            {
+                "title": "Valid issue",
+                "summary": "This is valid",
+                "body": "Body",
+            },
+            {
+                "title": "Missing summary field",
+                "body": "No summary",
+            },
+            {
+                "not_a_title": "Missing title",
+                "summary": "Has summary",
+                "body": "Body",
+            },
+        ],
+    }
+    result = _extract_side_issues(repair_json)
+    assert len(result) == 1
+    assert result[0].title == "Valid issue"
+
+
+def test_extract_side_issues_returns_empty_for_no_side_issues() -> None:
+    from precision_squad.repair.adapter import _extract_side_issues
+
+    repair_json = {"summary": "Fixed issue"}
+    result = _extract_side_issues(repair_json)
+    assert result == ()
+
+
+def test_extract_side_issues_returns_empty_for_non_list() -> None:
+    from precision_squad.repair.adapter import _extract_side_issues
+
+    repair_json = {"summary": "Fixed issue", "side_issues": "not a list"}
+    result = _extract_side_issues(repair_json)
+    assert result == ()
+
+
+def test_opencode_repair_adapter_prompt_includes_json_output_instruction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from precision_squad.repair.adapter import _build_repair_prompt
+
+    repo_workspace = tmp_path / "workspace" / "repo"
+    repo_workspace.mkdir(parents=True)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    _write_contract(contract_dir, ["python -m pip install -e .[dev]"], "python -m pytest tests/test_cli.py")
+
+    prompt = _build_repair_prompt(
+        intake=_intake(),
+        run_record=_record(run_dir),
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=repo_workspace,
+        qa_feedback=None,
+    )
+
+    assert "Output a single JSON object with at least a `summary` field" in prompt
+    assert "side_issues" in prompt
+    assert "title" in prompt
+    assert "summary" in prompt
+    assert "body" in prompt
+
+
+def test_opencode_repair_adapter_prompt_inlines_docs_fix_prompt_for_docs_remediation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from precision_squad.repair.adapter import _build_repair_prompt
+
+    repo_workspace = tmp_path / "workspace" / "repo"
+    repo_workspace.mkdir(parents=True)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "issue.md").write_text(
+        "# Issue\n\nFix docs only.\n",
+        encoding="utf-8",
+    )
+    contract_dir = run_dir / "execution-contract"
+    _write_contract(contract_dir, ["python -m pip install -e .[dev]"], "python -m pytest tests/test_cli.py")
+    docs_fix_content = "Add a setup command to README."
+    (contract_dir / "docs-fix-prompt.txt").write_text(docs_fix_content, encoding="utf-8")
+
+    docs_intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 16),
+            title="Docs blocker surfaced while repairing #9: clarify deterministic setup and QA",
+            body=(
+                "<!-- precision-squad:docs-remediation -->\n"
+                "<!-- precision-squad:target-findings:[{\"rule_id\":\"docs_setup_command_present\",\"section_key\":\"setup\",\"source_path\":\"readme.md\",\"subject_key\":\"setup-command\"}] -->\n\n"
+                "## Context"
+            ),
+            labels=(),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/16",
+        ),
+        summary="Fix docs",
+        problem_statement="Fix docs.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    prompt = _build_repair_prompt(
+        intake=docs_intake,
+        run_record=_record(run_dir),
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=repo_workspace,
+        qa_feedback=None,
+    )
+
+    assert docs_fix_content in prompt
+    assert str(contract_dir / "docs-fix-prompt.txt") not in prompt

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -11,7 +11,9 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    RepairResult,
     RunRecord,
+    SideIssue,
 )
 from precision_squad.publishing import build_publish_plan
 
@@ -189,5 +191,100 @@ def test_build_publish_plan_does_not_recurse_follow_up_issue_for_docs_remediatio
     )
 
     plan = build_publish_plan(intake, run_record, verdict)
+
+    assert plan.status == "issue_comment"
+
+
+def test_build_publish_plan_creates_follow_up_issue_for_side_issues() -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    run_record = RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=".precision-squad/runs/run-123",
+    )
+    verdict = GovernanceVerdict(
+        status="blocked",
+        summary="QA failed.",
+        reason_codes=("qa_failed",),
+    )
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed with side issues.",
+        detail_codes=("repair_stage_completed",),
+        side_issues=(
+            SideIssue(
+                title="Missing version pin",
+                summary="requirements.txt lacks version pin for pytest",
+                body="Full details here",
+                labels=("docs", "bug"),
+            ),
+            SideIssue(
+                title="CI badge broken",
+                summary="Travis CI badge returns 404",
+                body="The badge URL has changed",
+                labels=("ci",),
+            ),
+        ),
+    )
+
+    plan = build_publish_plan(intake, run_record, verdict, repair_result)
+
+    assert plan.status == "follow_up_issue"
+    assert "Side issues surfaced" in plan.title
+    assert "Missing version pin" in plan.body
+    assert "CI badge broken" in plan.body
+    assert "`docs`, `bug`" in plan.body
+    assert "`ci`" in plan.body
+    assert "requirements.txt lacks version pin" in plan.body
+
+
+def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    run_record = RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=".precision-squad/runs/run-123",
+    )
+    verdict = GovernanceVerdict(
+        status="blocked",
+        summary="QA failed.",
+        reason_codes=("qa_failed",),
+    )
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed.",
+        detail_codes=("repair_stage_completed",),
+        side_issues=(),
+    )
+
+    plan = build_publish_plan(intake, run_record, verdict, repair_result)
 
     assert plan.status == "issue_comment"


### PR DESCRIPTION
## Summary

- Add `jsonschema` dependency for proper JSON schema validation
- Create `SideIssue` dataclass and update `RepairResult` model
- Implement `_parse_repair_json` with jsonschema validation
- Implement `_extract_side_issues` for structured side issue parsing
- Update `_build_repair_prompt` with JSON output instructions and schema
- Update `build_publish_plan` to handle side issues as follow-up issues
- Add comprehensive test coverage (33 new tests in `test_adapter.py`)

## Changes

### 2.1 — JSON Schema (`data/repair-result-schema.json`)
- Schema file created with `summary` (required) and `side_issues` (optional array)
- Each side issue requires `title`, `summary`, `body`; optional `labels`

### 2.2 — `_build_repair_prompt`
- Docs-remediation: `docs-fix-prompt.txt` inlined in prompt
- Non-docs-remediation: recommends surfacing side issues via JSON output
- JSON instruction with schema added to both branches

### 2.3 — `OpenCodeRepairAdapter.repair`
- Parses JSON output with `jsonschema.validate()`
- Maps `summary` → `RepairResult.summary`
- Maps `side_issues` → `RepairResult.side_issues`
- Falls back to default summary on parse failure

### 2.4 — `build_publish_plan`
- When verdict is `blocked` and `side_issues` is non-empty, creates `follow_up_issue` PublishPlan

## Test Coverage

33 new tests covering:
- `_extract_json_events`: empty, non-JSON, non-dict, valid NDJSON
- `_parse_repair_json`: valid, empty, no events, non-dict, missing/wrong-type summary, side_issues validation
- `_extract_side_issues`: valid, missing keys, wrong types, labels handling, mixed valid/invalid
- `_build_repair_prompt`: non-docs, with docs-fix-prompt, docs-remediation, schema presence, QA feedback

Closes #3