### PR TITLE
feat: add LLM adapter for direct API calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Workflow control plane for OpenSWE-backed issue execution"
 readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "cracklings3d" }]
-dependencies = ["jsonschema>=4.26.0"]
+dependencies = ["jsonschema>=4.26.0", "openai>=1.76.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -33,6 +33,8 @@ from .post_publish_review import OpenCodePrReviewAgent, run_post_publish_review
 from .publish_executor import execute_publish_plan
 from .repair import (
     OpenCodeRepairAdapter,
+    RepairAdapter,
+    VercelAIRepairAdapter,
     evaluate_docs_remediation_validation,
     merge_docs_remediation_execution_result,
     merge_execution_result,
@@ -88,7 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     issue_parser.add_argument(
         "--repair-agent",
         default="opencode",
-        choices=("none", "opencode"),
+        choices=("none", "opencode", "vercel-ai"),
         help="Repair agent adapter to run after the documented execution contract is prepared.",
     )
     issue_parser.add_argument(
@@ -255,16 +257,18 @@ def _publish_run(args: argparse.Namespace) -> int:
 class _CliRepairDependencies:
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ) -> OpenCodeRepairAdapter | None:
-        if repair_agent != "opencode":
-            return None
-        return OpenCodeRepairAdapter(model=repair_model)
+    ) -> RepairAdapter | None:
+        if repair_agent == "opencode":
+            return OpenCodeRepairAdapter(model=repair_model)
+        if repair_agent == "vercel-ai":
+            return VercelAIRepairAdapter(model=repair_model)
+        return None
 
     def run_repair_qa_loop(
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -283,7 +287,7 @@ class _CliRepairDependencies:
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -21,7 +21,7 @@ from .models import (
     RunRequest,
 )
 from .publishing import build_publish_plan
-from .repair import OpenCodeRepairAdapter
+from .repair import RepairAdapter
 from .run_store import RunStore
 
 
@@ -30,13 +30,13 @@ class RepairDependencies(Protocol):
 
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ) -> OpenCodeRepairAdapter | None: ...
+    ) -> RepairAdapter | None: ...
 
     def run_repair_qa_loop(
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -47,7 +47,7 @@ class RepairDependencies(Protocol):
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,

--- a/src/precision_squad/repair/__init__.py
+++ b/src/precision_squad/repair/__init__.py
@@ -3,7 +3,8 @@
 import subprocess
 
 from ..github_client import GitHubWriteClient
-from .adapter import OpenCodeRepairAdapter
+from .adapter import OpenCodeRepairAdapter, RepairAdapter
+from .llm_adapter import VercelAIRepairAdapter
 from .orchestration import (
     RepairStage,
     _resolve_rerun_branch,
@@ -19,7 +20,9 @@ from .qa import WorkspaceQaVerifier, _failure_signature, _finalize_qa_result, bu
 
 __all__ = [
     "OpenCodeRepairAdapter",
+    "RepairAdapter",
     "RepairStage",
+    "VercelAIRepairAdapter",
     "WorkspaceQaVerifier",
     "GitHubWriteClient",
     "_failure_signature",

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from jsonschema import ValidationError, validate
 
@@ -13,6 +14,23 @@ from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
 from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
+
+
+@runtime_checkable
+class RepairAdapter(Protocol):
+    """Common interface for repair adapters."""
+
+    def repair(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+    ) -> RepairResult: ...
+
+    def with_qa_feedback(self, feedback: str) -> RepairAdapter: ...
 
 REPAIR_RESULT_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -62,6 +80,15 @@ class OpenCodeRepairAdapter:
     agent: str = "build"
     model: str | None = None
     qa_feedback: str | None = None
+
+    def with_qa_feedback(self, feedback: str) -> OpenCodeRepairAdapter:
+        """Return a copy of this adapter with the given QA feedback."""
+        return OpenCodeRepairAdapter(
+            binary=self.binary,
+            agent=self.agent,
+            model=self.model,
+            qa_feedback=feedback,
+        )
 
     def repair(
         self,

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -1,0 +1,117 @@
+"""Direct LLM repair adapter using the OpenAI SDK."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import openai
+from jsonschema import ValidationError, validate
+
+from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
+from .adapter import (
+    REPAIR_RESULT_SCHEMA,
+    _build_repair_prompt,
+    _extract_side_issues,
+)
+
+_SYSTEM_PROMPT = (
+    "You are a precise code repair assistant. "
+    "You will receive an issue description and context files. "
+    "Make the minimal source changes needed to resolve the issue. "
+    "Output a single JSON object matching the schema provided in the user prompt. "
+    "Do not output any text outside the JSON object."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VercelAIRepairAdapter:
+    """Repair adapter that calls an OpenAI-compatible LLM API directly."""
+
+    model: str | None = None
+    qa_feedback: str | None = None
+
+    def with_qa_feedback(self, feedback: str) -> VercelAIRepairAdapter:
+        """Return a copy of this adapter with the given QA feedback."""
+        return VercelAIRepairAdapter(model=self.model, qa_feedback=feedback)
+
+    def repair(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+    ) -> RepairResult:
+        stdout_path = run_dir / "repair.stdout.log"
+
+        prompt = _build_repair_prompt(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_artifact_dir,
+            repo_workspace=repo_workspace,
+            qa_feedback=self.qa_feedback,
+        )
+
+        resolved_model = self.model or os.environ.get("OPENAI_MODEL", "gpt-4o")
+
+        try:
+            client = openai.OpenAI()
+            response = client.chat.completions.create(
+                model=resolved_model,
+                response_format={"type": "json_object"},
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+            raw_content = response.choices[0].message.content or "{}"
+        except Exception as exc:
+            return RepairResult(
+                status="failed_infra",
+                summary=f"LLM API call failed: {exc}",
+                detail_codes=("llm_api_failed",),
+                stdout_path=str(stdout_path),
+            )
+
+        stdout_path.write_text(raw_content, encoding="utf-8")
+
+        repair_json = _parse_llm_response(raw_content)
+        side_issues: tuple[SideIssue, ...] = ()
+        if repair_json is not None:
+            side_issues = _extract_side_issues(repair_json)
+
+        if repair_json is None:
+            return RepairResult(
+                status="blocked",
+                summary="LLM response did not match the expected repair result schema.",
+                detail_codes=("llm_response_invalid",),
+                stdout_path=str(stdout_path),
+            )
+
+        return RepairResult(
+            status="completed",
+            summary=repair_json.get("summary", "Repair agent completed."),
+            detail_codes=("repair_stage_completed",),
+            stdout_path=str(stdout_path),
+            side_issues=side_issues,
+        )
+
+
+def _parse_llm_response(raw_content: str) -> dict | None:
+    """Parse and validate a single JSON response from an LLM."""
+    try:
+        payload = json.loads(raw_content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        validate(instance=payload, schema=REPAIR_RESULT_SCHEMA)
+    except ValidationError:
+        return None
+    return payload

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -14,7 +14,7 @@ from ..docs_remediation import (
 from ..github_client import GitHubClientError, GitHubWriteClient
 from ..models import ExecutionResult, IssueIntake, QaResult, RepairResult, RunRecord
 from ..rerun_context import latest_rejected_pull_request
-from .adapter import OpenCodeRepairAdapter
+from .adapter import RepairAdapter
 from .qa import (
     WorkspaceQaVerifier,
     _failure_signature,
@@ -31,7 +31,7 @@ class RepairStage:
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         rerun_branch: str | None = None,
         rerun_remote_url: str | None = None,
     ) -> None:
@@ -144,7 +144,7 @@ class RepairStage:
 def run_repair_qa_loop(
     *,
     repo_path: Path,
-    adapter: OpenCodeRepairAdapter | None,
+    adapter: RepairAdapter | None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,
@@ -183,12 +183,7 @@ def run_repair_qa_loop(
     for iteration in range(1, max_iterations + 1):
         iteration_adapter = None
         if adapter is not None:
-            iteration_adapter = OpenCodeRepairAdapter(
-                binary=adapter.binary,
-                agent=adapter.agent,
-                model=adapter.model,
-                qa_feedback=qa_feedback,
-            )
+            iteration_adapter = adapter.with_qa_feedback(qa_feedback) if qa_feedback else adapter
         last_repair_result = RepairStage(
             repo_path=repo_path,
             adapter=iteration_adapter,
@@ -409,7 +404,7 @@ def merge_docs_remediation_execution_result(
 def run_docs_remediation_repair(
     *,
     repo_path: Path,
-    adapter: OpenCodeRepairAdapter | None,
+    adapter: RepairAdapter | None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,367 @@
+"""Tests for the LLM repair adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precision_squad.models import (
+    GitHubIssue,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    RunRecord,
+)
+from precision_squad.repair.llm_adapter import (
+    VercelAIRepairAdapter,
+    _parse_llm_response,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_llm_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_llm_response_valid_summary_only() -> None:
+    payload = json.dumps({"summary": "Fixed the bug."})
+    result = _parse_llm_response(payload)
+    assert result is not None
+    assert result["summary"] == "Fixed the bug."
+
+
+def test_parse_llm_response_valid_with_side_issues() -> None:
+    payload = {
+        "summary": "Fixed the bug.",
+        "side_issues": [
+            {
+                "title": "Other bug",
+                "summary": "Found another bug",
+                "body": "Details here",
+                "labels": ["bug"],
+            }
+        ],
+    }
+    result = _parse_llm_response(json.dumps(payload))
+    assert result is not None
+    assert len(result["side_issues"]) == 1
+
+
+def test_parse_llm_response_empty_string() -> None:
+    assert _parse_llm_response("") is None
+
+
+def test_parse_llm_response_not_json() -> None:
+    assert _parse_llm_response("not json") is None
+
+
+def test_parse_llm_response_not_dict() -> None:
+    assert _parse_llm_response('"just a string"') is None
+
+
+def test_parse_llm_response_missing_summary() -> None:
+    assert _parse_llm_response(json.dumps({"side_issues": []})) is None
+
+
+def test_parse_llm_response_summary_wrong_type() -> None:
+    assert _parse_llm_response(json.dumps({"summary": 123})) is None
+
+
+def test_parse_llm_response_side_issues_wrong_type() -> None:
+    assert _parse_llm_response(json.dumps({"summary": "done", "side_issues": "bad"})) is None
+
+
+def test_parse_llm_response_side_issue_missing_required() -> None:
+    payload = json.dumps({"summary": "done", "side_issues": [{"title": "Only title"}]})
+    assert _parse_llm_response(payload) is None
+
+
+def test_parse_llm_response_pretty_printed_json() -> None:
+    payload = json.dumps({"summary": "Fixed the bug."}, indent=2)
+    result = _parse_llm_response(payload)
+    assert result is not None
+    assert result["summary"] == "Fixed the bug."
+
+
+# ---------------------------------------------------------------------------
+# VercelAIRepairAdapter.repair
+# ---------------------------------------------------------------------------
+
+
+def _make_intake() -> IssueIntake:
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Test issue",
+            body="Fix the bug.",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Test issue",
+        problem_statement="Fix the bug.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+
+def _make_run_record() -> RunRecord:
+    return RunRecord(
+        run_id="run-test",
+        issue_ref="owner/repo#1",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=".precision-squad/runs/run-test",
+    )
+
+
+def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert result.summary == "Fixed the bug."
+    assert result.stdout_path is not None
+
+
+def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert result.summary == "Fixed the bug."
+
+
+def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+
+
+def test_repair_adapter_api_failure(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("API error")
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "failed_infra"
+    assert "LLM API call failed" in result.summary
+
+
+def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"not_summary": "bad"}'
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "blocked"
+    assert "did not match" in result.summary
+
+
+def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    payload = {
+        "summary": "Fixed the bug.",
+        "side_issues": [
+            {
+                "title": "Other bug",
+                "summary": "Found another bug",
+                "body": "Details here",
+                "labels": ["bug"],
+            }
+        ],
+    }
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(payload)
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert len(result.side_issues) == 1
+    assert result.side_issues[0].title == "Other bug"
+
+
+def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4-turbo")
+
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "done"})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter()
+        adapter.repair(
+                intake=intake,
+                run_record=run_record,
+                run_dir=run_dir,
+                contract_artifact_dir=contract_dir,
+                repo_workspace=repo_workspace,
+            )
+
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args.kwargs["model"] == "gpt-4-turbo"
+
+
+def test_repair_adapter_with_qa_feedback(tmp_path: Path) -> None:
+    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    new_adapter = adapter.with_qa_feedback("Tests failed: test_foo")
+    assert new_adapter.qa_feedback == "Tests failed: test_foo"
+    assert new_adapter.model == "gpt-4o"
+    assert adapter.qa_feedback is None
+
+
+def test_repair_adapter_protocol_compliance() -> None:
+    """Verify VercelAIRepairAdapter satisfies RepairAdapter protocol."""
+    from precision_squad.repair.adapter import RepairAdapter
+
+    adapter = VercelAIRepairAdapter()
+    assert isinstance(adapter, RepairAdapter)


### PR DESCRIPTION
## Summary
- Extract `RepairAdapter` protocol from `adapter.py`
- Create `VercelAIRepairAdapter` using `openai` SDK
- Add `vercel-ai` choice to `--repair-agent` CLI argument
- Update `coordinator.py` and `cli.py` to use `RepairAdapter` protocol
- Add `openai` dependency to `pyproject.toml`
- Add 19 tests for new adapter

## Changes

| File | Action | Purpose |
|---|---|---|
| `src/precision_squad/repair/adapter.py` | Modified | Extracted `RepairAdapter` protocol with `repair()` and `with_qa_feedback()` methods |
| `src/precision_squad/repair/llm_adapter.py` | Created | `VercelAIRepairAdapter` using `openai` SDK with fixed system prompt and JSON schema validation |
| `src/precision_squad/repair/__init__.py` | Modified | Exports `RepairAdapter` and `VercelAIRepairAdapter` |
| `src/precision_squad/coordinator.py` | Modified | Updated `RepairDependencies` protocol to use `RepairAdapter` |
| `src/precision_squad/cli.py` | Modified | Added `vercel-ai` choice, updated factory to create `VercelAIRepairAdapter` |
| `pyproject.toml` | Modified | Added `openai>=1.76.0` dependency |
| `tests/test_llm_adapter.py` | Created | 19 tests covering parsing, API calls, error handling, and protocol compliance |

## Usage
```bash
# Use OpenAI-compatible LLM API
precision-squad repair issue owner/repo#42 --repo-path /path/to/repo --repair-agent vercel-ai

# With custom model
precision-squad repair issue owner/repo#42 --repo-path /path/to/repo --repair-agent vercel-ai --repair-model gpt-4-turbo
```

Closes #4