### PR TITLE
docs: add ADRs and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to precision-squad
+
+`precision-squad` is a docs-first workflow control system. Contributing means working within the issue-first process described below, respecting the governance model, and maintaining the project's standards for code, tests, and documentation.
+
+---
+
+## Repository
+
+https://github.com/cracklings3d/precision-squad.git
+
+---
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/cracklings3d/precision-squad.git
+cd precision-squad
+
+# Install in dev mode (includes linting, type-checking, and test tooling)
+python -m pip install -e ".[dev]"
+```
+
+---
+
+## Running Local Checks
+
+Before opening a pull request, run all three check targets:
+
+```bash
+ruff check .       # Linting (E, F, I rules)
+pyright            # Static type analysis
+pytest             # Unit and integration tests
+```
+
+### Integration Tests
+
+Some tests are marked `integration` and require a `GITHUB_TOKEN` environment variable with a GitHub personal access token, plus network access to the GitHub API. These are skipped automatically when the token is absent.
+
+```bash
+GITHUB_TOKEN=ghp_... pytest -m integration
+```
+
+### Python Version
+
+The project requires **Python 3.14 or later**. If you are using an older version, the CI will fail.
+
+---
+
+## Issue-First Workflow
+
+This repository follows a strict **issue-first GitHub workflow**:
+
+1. **Open an issue** describing the problem or change before writing any code.
+2. **Link a PR** to that issue. PRs without a corresponding issue will be closed.
+3. **Scope the PR to the issue.** Avoid scope creep; one PR per issue.
+4. **Include a closing reference** in the PR description, e.g. `Closes #8`.
+
+### Issue Labels
+
+- `phase-X` — implementation phases tracked across the roadmap
+- `documentation` — docs-only work
+- `tests` — test additions or updates
+- `bug`, `enhancement`, `refactor` — standard categories
+
+---
+
+## Governance Model
+
+Every repair run produces a **governance verdict** that determines what happens next.
+
+### Verdict: Approved
+
+The run passed governance. A draft PR is created automatically. No further human action is required before the PR is reviewed.
+
+### Verdict: Blocked
+
+The run did not pass governance. A `requires_review` or `follow_up_issue` action is created. Human action is required before publishing.
+
+### Quality Tag
+
+Every `ExecutionResult` carries a **quality tag** that describes the relationship between the baseline and final QA outcomes:
+
+| Tag | Meaning |
+|---|---|
+| `green` | Baseline passed, or final matches baseline (no new failures) |
+| `improved` | Baseline failed; final has fewer failures |
+| `degraded` | New failures were introduced by the repair |
+
+Quality tags are informational. The **verdict (approved/blocked) is what gates publishing**.
+
+---
+
+## Side Issues
+
+During a repair, the agent may discover problems that are unrelated to the primary issue being worked. These are called **side issues**.
+
+Side issues are surfaced via a `side_issues` field on `RepairResult`. When a run is blocked, each side issue becomes a `follow_up_issue` action in the publish plan — a separate issue is opened on your behalf with the relevant details.
+
+This means: even a blocked run can leave you with clean, actionable follow-up work rather than one large ambiguous comment.
+
+---
+
+## Retry Policy
+
+If a repair does not produce an approved verdict, you can retry manually:
+
+```bash
+python -m precision_squad.cli repair issue owner/repo#number --retry-from <run-id>
+```
+
+- Up to **3 retry attempts** are allowed before the run is marked `escalated`.
+- Retries are always manual — there is no automatic retry loop.
+
+---
+
+## Docs-First Principle
+
+`precision-squad` treats repository documentation as the execution contract. This project practices what it preaches:
+
+- **Setup and QA commands** are extracted from the repository's own docs.
+- A `docs-fix-prompt.txt` file is generated when documentation quality issues are detected.
+- For **docs-remediation issues**, the `docs-fix-prompt.txt` content **is the fix specification itself**.
+- For **non-docs-remediation issues**, the presence of `docs-fix-prompt.txt` signals that side issues exist and should be surfaced as separate issues.
+
+---
+
+## What to Contribute
+
+### High-Value Contributions
+
+- **Phase issues** (issues labeled `phase-X`) represent the planned implementation roadmap.
+- **ADR documents** (`docs/adr/`) capture irreversible architectural decisions.
+- **Tests** for uncovered modules, especially edge cases in `executor.py`, `coordinator.py`, and `github_client.py`.
+- **Documentation improvements** that clarify the docs-first contract or operator workflow.
+
+### Not in Scope for V1
+
+Please do not open PRs for the following unless discussed in an issue first:
+
+- GitHub App authentication
+- MCP or remote runner support
+- Database-backed persistence
+- Multi-tenant or broad parallel execution
+- Deep repo-specific inference machinery
+
+These are listed as non-goals in the project scope and will be closed.
+
+---
+
+## PR Checklist
+
+Before requesting review:
+
+- [ ] `ruff check .` passes with no new violations
+- [ ] `pyright` reports 0 errors
+- [ ] `pytest` passes (integration tests skipped if no `GITHUB_TOKEN`)
+- [ ] New code has corresponding tests
+- [ ] PR description links to the issue it resolves and includes a closing reference
+- [ ] If changing behavior that affects the governance or publishing flow, the corresponding ADR (in `docs/adr/`) is updated or created
+
+---
+
+## Getting Help
+
+If you are unsure whether a contribution is in scope, open a discussion issue first. For questions about the repair workflow, governance model, or the docs-first principle, the `docs/operator-skill.md` provides a practical walkthrough.

--- a/docs/adr/adr-001-governance-two-verdicts.md
+++ b/docs/adr/adr-001-governance-two-verdicts.md
@@ -1,0 +1,88 @@
+# ADR-001: Governance Two-Verdict Model
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-01
+
+## Context
+
+The original governance model had three verdicts:
+
+- **approved** — QA passed, ready to publish
+- **provisional** — baseline was broken, repair improved it but did not fully fix it
+- **blocked** — something prevented a successful repair
+
+The `provisional` verdict occupied a middle ground: it meant "better than before, but not green." This created ambiguity about what a provisional verdict actually promised to an operator.
+
+## Decision
+
+Collapse governance to two verdicts: `approved` and `blocked`. Extract the "improved but not green" signal into a separate informational **quality tag** on `ExecutionResult`.
+
+### The Two Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| `approved` | Governance says yes. Creates `draft_pr` automatically. |
+| `blocked` | Governance says no. Creates `requires_review` or `follow_up_issue`. Requires human action before publishing. |
+
+### The Quality Tag
+
+| Tag | Meaning |
+|-----|---------|
+| `green` | Baseline passed, or final matches baseline (no new failures) |
+| `improved` | Baseline failed, final has fewer failures (baseline-tolerant repair) |
+| `degraded` | New failures introduced by repair |
+
+Quality tags are **informational only**. The verdict (approved/blocked) is what gates publishing.
+
+## Rationale
+
+### Why Remove Provisional
+
+1. **Ambiguous publish semantics.** Provisional verdicts could produce draft PRs, but the PR description had to explain that the fix was incomplete. Operators had to read the fine print to understand what they were approving.
+
+2. **Confused governance contract.** Three verdicts meant three code paths in publishing, three message templates, and three ways for operators to interpret the outcome. Two verdicts simplify the mental model: governance either says yes or no.
+
+3. **Quality is orthogonal to approval.** Whether a repair improved a broken baseline is a useful signal, but it is not a governance decision. A run that improved a broken baseline but introduced new failures is `degraded` and `blocked`. A run that improved a broken baseline without introducing new failures is `improved` and may be `approved` if the baseline was already failing.
+
+4. **Provisional conflated two concerns.** It tried to express both "the baseline was broken" and "the repair helped." These are now separate: the quality tag captures "the repair helped" and the verdict captures "is this ready to publish."
+
+### Why a Quality Tag Instead of a Verdict
+
+1. **Informational, not gating.** The quality tag does not control publishing. It provides context for the operator to understand what happened during the run.
+
+2. **Composable with verdicts.** Any quality tag can appear with either verdict. This is more expressive than a three-verdict model where provisional was a special case.
+
+3. **Simpler governance logic.** `apply_governance` returns `approved` or `blocked`. No special-case handling for "improved but not green."
+
+## Trade-offs
+
+### What We Lost
+
+- **Explicit provisional publish path.** The old model had a dedicated code path for provisional → draft PR with caveats. Now, an `improved` quality tag with `approved` verdict achieves the same outcome, but the publishing code does not distinguish it from a `green` + `approved` run. If we need provisional-specific publish behavior in the future, we will need to add it back.
+
+- **Quality-aware publish descriptions.** The publish plan body no longer has a dedicated "Provisional Summary" section. Operators must check the quality tag in the execution result to understand the baseline context.
+
+### What We Gained
+
+- **Simpler governance contract.** Two outcomes, clear semantics.
+- **Better separation of concerns.** Quality is a measurement; approval is a decision.
+- **Fewer code paths.** Publishing, CLI output, and integration tests all have one fewer branch to handle.
+- **Extensibility.** New quality tags (e.g., `unchanged`, `partially_improved`) can be added without changing the governance model.
+
+## Consequences
+
+- All references to `provisional` as a governance verdict must be removed from the codebase.
+- `ExecutionResult.quality` replaces the provisional signal.
+- Integration tests verify quality tags separately from verdicts.
+- The publish plan body uses the quality tag for context but does not gate on it.
+
+## References
+
+- [CONTEXT.md](../../CONTEXT.md) — Governance Verdicts, Quality Tag
+- [Implementation Plan](../implementation-plan.md) — Phase 1
+- [architecture.md](../architecture.md) — Governance section (updated)

--- a/docs/adr/adr-002-llm-abstraction.md
+++ b/docs/adr/adr-002-llm-abstraction.md
@@ -1,0 +1,119 @@
+# ADR-002: LLM Abstraction — Direct API Over Agent Binary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-01
+
+## Context
+
+The original repair stage used `OpenSWE` as the execution substrate. The system called an external agent binary (`opencode`) to perform code modifications. This created a hard dependency on a specific binary installation, version, and runtime environment.
+
+The implementation plan (Phase 3) proposed replacing this with a direct LLM API call via the Vercel AI SDK or equivalent.
+
+## Decision
+
+Replace the `opencode` binary dependency with a direct LLM API call using the `openai` Python SDK. Introduce a `RepairAdapter` protocol that abstracts the repair mechanism, allowing multiple implementations:
+
+1. **`OpenCodeRepairAdapter`** — the original binary-based adapter (preserved for backward compatibility)
+2. **`VercelAIRepairAdapter`** — direct LLM API adapter using `openai` SDK
+
+The coordinator selects the adapter based on the `--repair-agent` CLI argument (`none`, `opencode`, `vercel-ai`).
+
+## Rationale
+
+### Why Direct LLM API
+
+1. **No binary dependency.** The `openai` SDK is a pure Python package. No shell subprocess, no binary installation, no version pinning on an external tool.
+
+2. **Deterministic API contract.** The OpenAI API has a stable, documented contract. The adapter controls the prompt, the response format, and the error handling. No hidden prompt rewriting or side effects inside an agent binary.
+
+3. **Testability.** The adapter can be tested by mocking the API response. No need to install and configure a binary for unit tests.
+
+4. **Portability.** Works in any Python environment with network access. No platform-specific binary compilation or installation.
+
+5. **Composability.** The adapter can be extended with custom prompt construction, response parsing, and error handling without modifying an external tool.
+
+### Why a Protocol-Based Abstraction
+
+1. **Multiple implementations.** The `RepairAdapter` protocol allows both binary-based and API-based adapters to coexist. Operators can choose the adapter that fits their environment.
+
+2. **Test isolation.** Tests can use a mock adapter that returns controlled results without making API calls or running binaries.
+
+3. **Future extensibility.** New adapters (e.g., Anthropic, local models) can be added by implementing the protocol without changing the orchestration logic.
+
+4. **Clean separation.** The coordinator orchestrates; the adapter repairs. The protocol defines the contract between them.
+
+### Why OpenAI SDK Over Vercel AI SDK
+
+1. **Direct dependency.** The Vercel AI SDK wraps the OpenAI SDK. Using the wrapper adds a dependency without adding value for this use case.
+
+2. **Mature ecosystem.** The OpenAI SDK is well-documented, widely used, and stable.
+
+3. **Simpler dependency tree.** One SDK instead of two.
+
+## Trade-offs
+
+### What We Lost
+
+- **Agent binary capabilities.** The `opencode` binary may have had built-in prompt engineering, tool use, or multi-step reasoning that the direct API call does not replicate. The adapter must implement all prompt construction explicitly.
+
+- **Binary-level error recovery.** The binary may have had retry logic, rate limiting, or error handling that the adapter must now implement.
+
+- **Vercel AI SDK features.** If Vercel AI SDK adds features beyond OpenAI SDK (e.g., streaming, multi-provider routing), we will not automatically benefit from them.
+
+### What We Gained
+
+- **No binary installation.** Pure Python dependency.
+- **Full control over prompt and response.** No hidden transformations.
+- **Testable without binary.** Mock the API, test the logic.
+- **Portable.** Works in any Python environment.
+- **Composable.** Custom prompt construction, response parsing, error handling.
+
+## Consequences
+
+- `openai` is a required dependency in `pyproject.toml`.
+- `VercelAIRepairAdapter` uses the OpenAI SDK directly, not the Vercel AI SDK.
+- The adapter name `VercelAIRepairAdapter` is a historical artifact; the implementation uses OpenAI SDK. (See issue #25 for naming cleanup.)
+- The `OpenCodeRepairAdapter` is preserved for backward compatibility but is not the default.
+- The `--repair-agent` CLI argument selects the adapter.
+- The `RepairAdapter` protocol defines the contract for all adapters.
+
+## Design Notes
+
+### Adapter Protocol
+
+```python
+@runtime_checkable
+class RepairAdapter(Protocol):
+    def repair(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+    ) -> RepairResult: ...
+
+    def with_qa_feedback(self, feedback: str) -> RepairAdapter: ...
+```
+
+### Prompt Construction
+
+Both adapters use the same prompt construction logic (`_build_repair_prompt`). The prompt is adapter-agnostic; the adapter is responsible for sending it to the LLM and parsing the response.
+
+### Response Parsing
+
+The adapter parses the LLM response as JSON, validates it against the repair-result schema, and maps it to a `RepairResult`. If parsing fails, the result is `blocked` with appropriate error context.
+
+## References
+
+- [CONTEXT.md](../../CONTEXT.md) — Repair Agent
+- [Implementation Plan](../implementation-plan.md) — Phase 3
+- [architecture.md](../architecture.md) — Repair Stage section (updated)
+- [Issue #4](https://github.com/cracklings3d/precision-squad/issues/4) — LLM Adapter implementation
+- [Issue #25](https://github.com/cracklings3d/precision-squad/issues/25) — Naming cleanup

--- a/docs/project-status-report.md
+++ b/docs/project-status-report.md
@@ -60,7 +60,7 @@ Issue Intake → Run Store → Docs-First Executor → Repair Agent → QA
 |---|---|
 | Ruff linting | All checks passed |
 | Pyright type-checking | 0 errors, 0 warnings |
-| Pytest | 27 integration tests (23 passed, 4 skipped -- require GITHUB_TOKEN) |
+| Pytest | 28 integration tests (24 passed, 4 skipped -- require GITHUB_TOKEN) |
 | CI workflow | Configured (lint, typecheck, test) on push/PR |
 
 ## 5. Implemented Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Workflow control plane for OpenSWE-backed issue execution"
 readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "cracklings3d" }]
-dependencies = ["jsonschema>=4.26.0"]
+dependencies = ["jsonschema>=4.26.0", "openai>=1.76.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -103,6 +103,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional model override for post-publish review agents.",
     )
+    issue_parser.add_argument(
+        "--retry-from",
+        default=None,
+        help="Existing run ID to retry from. Increments attempt counter.",
+    )
     issue_parser.set_defaults(handler=_repair_issue)
 
     publish_parser = subparsers.add_parser(
@@ -157,6 +162,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
             repair_agent=args.repair_agent,
             repair_model=args.repair_model,
             review_model=args.review_model,
+            retry_from=args.retry_from,
         ),
         intake=intake,
         dependencies=_CliRepairDependencies(),

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -33,6 +33,8 @@ from .post_publish_review import OpenCodePrReviewAgent, run_post_publish_review
 from .publish_executor import execute_publish_plan
 from .repair import (
     OpenCodeRepairAdapter,
+    RepairAdapter,
+    VercelAIRepairAdapter,
     evaluate_docs_remediation_validation,
     merge_docs_remediation_execution_result,
     merge_execution_result,
@@ -88,7 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     issue_parser.add_argument(
         "--repair-agent",
         default="opencode",
-        choices=("none", "opencode"),
+        choices=("none", "opencode", "vercel-ai"),
         help="Repair agent adapter to run after the documented execution contract is prepared.",
     )
     issue_parser.add_argument(
@@ -255,16 +257,18 @@ def _publish_run(args: argparse.Namespace) -> int:
 class _CliRepairDependencies:
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ) -> OpenCodeRepairAdapter | None:
-        if repair_agent != "opencode":
-            return None
-        return OpenCodeRepairAdapter(model=repair_model)
+    ) -> RepairAdapter | None:
+        if repair_agent == "opencode":
+            return OpenCodeRepairAdapter(model=repair_model)
+        if repair_agent == "vercel-ai":
+            return VercelAIRepairAdapter(model=repair_model)
+        return None
 
     def run_repair_qa_loop(
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -283,7 +287,7 @@ class _CliRepairDependencies:
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -21,7 +21,7 @@ from .models import (
     RunRequest,
 )
 from .publishing import build_publish_plan
-from .repair import OpenCodeRepairAdapter
+from .repair import RepairAdapter
 from .run_store import RunStore
 
 
@@ -30,13 +30,13 @@ class RepairDependencies(Protocol):
 
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ) -> OpenCodeRepairAdapter | None: ...
+    ) -> RepairAdapter | None: ...
 
     def run_repair_qa_loop(
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -47,7 +47,7 @@ class RepairDependencies(Protocol):
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -12,6 +12,7 @@ from .intake import IssueIntake, is_docs_remediation_issue
 from .models import (
     EvaluationResult,
     ExecutionResult,
+    GovernanceVerdict,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -134,6 +135,7 @@ class RepairIssueParams:
     repair_agent: str
     repair_model: str | None
     review_model: str | None
+    retry_from: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,8 +182,88 @@ class RunCoordinator:
     ) -> RepairIssueReport:
         store = RunStore(params.runs_dir)
         request = RunRequest(issue_ref=params.issue_ref, runs_dir=str(params.runs_dir))
+
+        # Handle retry logic
+        attempt = 1
+        if params.retry_from is not None:
+            try:
+                previous_record = store.load_run(params.retry_from)
+                attempt = previous_record.attempt + 1
+            except ValueError:
+                return RepairIssueReport(
+                    intake=intake,
+                    run_record=RunRecord(
+                        run_id="",
+                        issue_ref=params.issue_ref,
+                        status="blocked",
+                        created_at="",
+                        updated_at="",
+                        run_dir="",
+                    ),
+                    exit_code=3,
+                )
+
+        # Check if escalated (max 3 attempts exceeded)
+        if attempt > 3:
+            record = store.create_run(request, intake)
+            run_dir = Path(record.run_dir).resolve()
+            record = RunRecord(
+                run_id=record.run_id,
+                issue_ref=record.issue_ref,
+                status=record.status,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                run_dir=record.run_dir,
+                attempt=attempt,
+            )
+            store.write_run_record(record)
+
+            escalated_result = RepairResult(
+                status="escalated",
+                summary=f"Repair escalated after {attempt - 1} failed attempts.",
+                detail_codes=("escalated_after_retries",),
+            )
+            store.write_repair_result(run_dir, escalated_result)
+
+            verdict = GovernanceVerdict(
+                status="blocked",
+                summary=f"Repair escalated after {attempt - 1} failed attempts.",
+                reason_codes=("escalated_after_retries",),
+            )
+            store.write_governance_verdict(run_dir, verdict)
+            publish_plan = build_publish_plan(intake, record, verdict)
+            store.write_publish_plan(run_dir, publish_plan)
+            publish_result = dependencies.execute_publish_plan(
+                intake,
+                publish_plan,
+                publish=params.publish,
+            )
+            store.write_publish_result(run_dir, publish_result)
+            return RepairIssueReport(
+                intake=intake,
+                run_record=record,
+                governance_verdict=verdict,
+                publish_plan=publish_plan,
+                publish_result=publish_result,
+                repair_result=escalated_result,
+                exit_code=4,
+            )
+
         record = store.create_run(request, intake)
         run_dir = Path(record.run_dir).resolve()
+
+        # Update attempt counter if retrying
+        if attempt > 1:
+            record = RunRecord(
+                run_id=record.run_id,
+                issue_ref=record.issue_ref,
+                status=record.status,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                run_dir=record.run_dir,
+                attempt=attempt,
+            )
+            store.write_run_record(record)
 
         if intake.assessment.status == "blocked":
             verdict = apply_governance(intake, execution_result=None, evaluation_result=None)

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -66,6 +66,7 @@ class RunRecord:
     created_at: str
     updated_at: str
     run_dir: str
+    attempt: int = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,7 +124,7 @@ class SideIssue:
 class RepairResult:
     """Normalized result for the post-synthesis repair stage."""
 
-    status: Literal["not_configured", "blocked", "failed_infra", "completed"]
+    status: Literal["not_configured", "blocked", "failed_infra", "completed", "escalated"]
     summary: str
     detail_codes: tuple[str, ...]
     workspace_path: str | None = None

--- a/src/precision_squad/repair/__init__.py
+++ b/src/precision_squad/repair/__init__.py
@@ -3,7 +3,8 @@
 import subprocess
 
 from ..github_client import GitHubWriteClient
-from .adapter import OpenCodeRepairAdapter
+from .adapter import OpenCodeRepairAdapter, RepairAdapter
+from .llm_adapter import VercelAIRepairAdapter
 from .orchestration import (
     RepairStage,
     _resolve_rerun_branch,
@@ -19,7 +20,9 @@ from .qa import WorkspaceQaVerifier, _failure_signature, _finalize_qa_result, bu
 
 __all__ = [
     "OpenCodeRepairAdapter",
+    "RepairAdapter",
     "RepairStage",
+    "VercelAIRepairAdapter",
     "WorkspaceQaVerifier",
     "GitHubWriteClient",
     "_failure_signature",

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from jsonschema import ValidationError, validate
 
@@ -13,6 +14,23 @@ from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
 from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
+
+
+@runtime_checkable
+class RepairAdapter(Protocol):
+    """Common interface for repair adapters."""
+
+    def repair(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+    ) -> RepairResult: ...
+
+    def with_qa_feedback(self, feedback: str) -> RepairAdapter: ...
 
 REPAIR_RESULT_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -62,6 +80,15 @@ class OpenCodeRepairAdapter:
     agent: str = "build"
     model: str | None = None
     qa_feedback: str | None = None
+
+    def with_qa_feedback(self, feedback: str) -> OpenCodeRepairAdapter:
+        """Return a copy of this adapter with the given QA feedback."""
+        return OpenCodeRepairAdapter(
+            binary=self.binary,
+            agent=self.agent,
+            model=self.model,
+            qa_feedback=feedback,
+        )
 
     def repair(
         self,

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -1,0 +1,117 @@
+"""Direct LLM repair adapter using the OpenAI SDK."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import openai
+from jsonschema import ValidationError, validate
+
+from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
+from .adapter import (
+    REPAIR_RESULT_SCHEMA,
+    _build_repair_prompt,
+    _extract_side_issues,
+)
+
+_SYSTEM_PROMPT = (
+    "You are a precise code repair assistant. "
+    "You will receive an issue description and context files. "
+    "Make the minimal source changes needed to resolve the issue. "
+    "Output a single JSON object matching the schema provided in the user prompt. "
+    "Do not output any text outside the JSON object."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VercelAIRepairAdapter:
+    """Repair adapter that calls an OpenAI-compatible LLM API directly."""
+
+    model: str | None = None
+    qa_feedback: str | None = None
+
+    def with_qa_feedback(self, feedback: str) -> VercelAIRepairAdapter:
+        """Return a copy of this adapter with the given QA feedback."""
+        return VercelAIRepairAdapter(model=self.model, qa_feedback=feedback)
+
+    def repair(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+    ) -> RepairResult:
+        stdout_path = run_dir / "repair.stdout.log"
+
+        prompt = _build_repair_prompt(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_artifact_dir,
+            repo_workspace=repo_workspace,
+            qa_feedback=self.qa_feedback,
+        )
+
+        resolved_model = self.model or os.environ.get("OPENAI_MODEL", "gpt-4o")
+
+        try:
+            client = openai.OpenAI()
+            response = client.chat.completions.create(
+                model=resolved_model,
+                response_format={"type": "json_object"},
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+            raw_content = response.choices[0].message.content or "{}"
+        except Exception as exc:
+            return RepairResult(
+                status="failed_infra",
+                summary=f"LLM API call failed: {exc}",
+                detail_codes=("llm_api_failed",),
+                stdout_path=str(stdout_path),
+            )
+
+        stdout_path.write_text(raw_content, encoding="utf-8")
+
+        repair_json = _parse_llm_response(raw_content)
+        side_issues: tuple[SideIssue, ...] = ()
+        if repair_json is not None:
+            side_issues = _extract_side_issues(repair_json)
+
+        if repair_json is None:
+            return RepairResult(
+                status="blocked",
+                summary="LLM response did not match the expected repair result schema.",
+                detail_codes=("llm_response_invalid",),
+                stdout_path=str(stdout_path),
+            )
+
+        return RepairResult(
+            status="completed",
+            summary=repair_json.get("summary", "Repair agent completed."),
+            detail_codes=("repair_stage_completed",),
+            stdout_path=str(stdout_path),
+            side_issues=side_issues,
+        )
+
+
+def _parse_llm_response(raw_content: str) -> dict | None:
+    """Parse and validate a single JSON response from an LLM."""
+    try:
+        payload = json.loads(raw_content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        validate(instance=payload, schema=REPAIR_RESULT_SCHEMA)
+    except ValidationError:
+        return None
+    return payload

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -14,7 +14,7 @@ from ..docs_remediation import (
 from ..github_client import GitHubClientError, GitHubWriteClient
 from ..models import ExecutionResult, IssueIntake, QaResult, RepairResult, RunRecord
 from ..rerun_context import latest_rejected_pull_request
-from .adapter import OpenCodeRepairAdapter
+from .adapter import RepairAdapter
 from .qa import (
     WorkspaceQaVerifier,
     _failure_signature,
@@ -31,7 +31,7 @@ class RepairStage:
         self,
         *,
         repo_path: Path,
-        adapter: OpenCodeRepairAdapter | None,
+        adapter: RepairAdapter | None,
         rerun_branch: str | None = None,
         rerun_remote_url: str | None = None,
     ) -> None:
@@ -144,7 +144,7 @@ class RepairStage:
 def run_repair_qa_loop(
     *,
     repo_path: Path,
-    adapter: OpenCodeRepairAdapter | None,
+    adapter: RepairAdapter | None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,
@@ -183,12 +183,7 @@ def run_repair_qa_loop(
     for iteration in range(1, max_iterations + 1):
         iteration_adapter = None
         if adapter is not None:
-            iteration_adapter = OpenCodeRepairAdapter(
-                binary=adapter.binary,
-                agent=adapter.agent,
-                model=adapter.model,
-                qa_feedback=qa_feedback,
-            )
+            iteration_adapter = adapter.with_qa_feedback(qa_feedback) if qa_feedback else adapter
         last_repair_result = RepairStage(
             repo_path=repo_path,
             adapter=iteration_adapter,
@@ -409,7 +404,7 @@ def merge_docs_remediation_execution_result(
 def run_docs_remediation_repair(
     *,
     repo_path: Path,
-    adapter: OpenCodeRepairAdapter | None,
+    adapter: RepairAdapter | None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal, cast
 from uuid import uuid4
 
 from .models import (
@@ -64,6 +65,19 @@ class RunStore:
         self._write_issue_context(run_dir / "issue.md", intake)
         self._write_json(run_dir / "run-record.json", record)
         return record
+
+    def load_run(self, run_id: str) -> RunRecord:
+        """Load an existing run record by run ID."""
+        run_dir = self.root / run_id
+        record_path = run_dir / "run-record.json"
+        if not record_path.exists():
+            raise ValueError(f"Run record not found: {record_path}")
+        return _read_run_record(record_path)
+
+    def write_run_record(self, record: RunRecord) -> None:
+        """Write an updated run record."""
+        run_dir = Path(record.run_dir).resolve()
+        self._write_json(run_dir / "run-record.json", record)
 
     def write_execution_result(self, run_dir: Path, result: ExecutionResult) -> None:
         self._write_json(run_dir / "execution-result.json", result)
@@ -134,3 +148,22 @@ def _build_run_id(created_at: str) -> str:
     stamp = created_at.replace(":", "").replace("-", "")
     stamp = stamp.replace("T", "-").replace("Z", "")
     return f"run-{stamp}-{uuid4().hex[:8]}"
+
+
+def _read_run_record(path: Path) -> RunRecord:
+    """Read a run record from a JSON file."""
+    with path.open(encoding="utf-8") as f:
+        payload = json.load(f)
+    status = cast(
+        Literal["intake_complete", "blocked", "runnable"],
+        str(payload["status"]),
+    )
+    return RunRecord(
+        run_id=str(payload["run_id"]),
+        issue_ref=str(payload["issue_ref"]),
+        status=status,
+        created_at=str(payload["created_at"]),
+        updated_at=str(payload["updated_at"]),
+        run_dir=str(payload["run_dir"]),
+        attempt=int(payload.get("attempt", 1)),
+    )

--- a/tests/integration/test_pipeline_approved.py
+++ b/tests/integration/test_pipeline_approved.py
@@ -78,6 +78,7 @@ def test_approved_happy_path(
     assert report.repair_result.status == "completed"
     assert report.qa_result is not None
     assert report.qa_result.status == "passed"
+    assert report.qa_result.quality == "green"
     assert report.baseline_qa_result is not None
     assert report.governance_verdict.status == "approved"
     assert report.publish_plan.status == "draft_pr"

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -272,6 +272,61 @@ def test_blocked_execution_result_blocks_pipeline(
 
 
 # ---------------------------------------------------------------------------
+# QA failed: repair completes but QA fails -> blocked verdict, quality=degraded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_qa_failed_blocks_pipeline(
+    make_clean_repo,
+    tmp_path: Path,
+) -> None:
+    """When repair completes but QA fails, governance blocks with quality=degraded."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+
+    params = RepairIssueParams(
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        runs_dir=runs_dir,
+        repo_path=make_clean_repo,
+        publish=False,
+        repair_agent="opencode",
+        repair_model=None,
+        review_model=None,
+    )
+
+    from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
+
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    deps = _QaFailedTestDependencies()
+
+    report = RunCoordinator().repair_issue(
+        params=params,
+        intake=intake,
+        dependencies=deps,
+    )
+
+    assert report.repair_result is not None
+    assert report.repair_result.status == "completed"
+    assert report.qa_result is not None
+    assert report.qa_result.status == "failed"
+    assert report.qa_result.quality == "degraded"
+    assert report.governance_verdict.status == "blocked"
+    assert report.exit_code == 4
+
+
+# ---------------------------------------------------------------------------
 # Test dependencies (blocks executor + all external calls)
 # ---------------------------------------------------------------------------
 
@@ -317,3 +372,101 @@ class _BlockedTestDependencies:
 
     def run_post_publish_review_if_needed(self, **kwargs):
         return None
+
+
+class _QaFailedTestDependencies:
+    """Dependencies that simulate a QA failure after successful repair."""
+
+    def __init__(self) -> None:
+        self._adapter = _StubRepairAdapter()
+
+    def create_repair_adapter(
+        self, *, repair_agent: str, repair_model: str | None
+    ):
+        if repair_agent == "none":
+            return None
+        return self._adapter
+
+    def run_repair_qa_loop(self, *, repo_path, adapter, intake, run_record, run_dir, contract_artifact_dir):
+        from precision_squad.models import QaResult, RepairResult
+
+        repair_result = RepairResult(
+            status="completed",
+            summary="Stub repair completed.",
+            detail_codes=("repair_stage_completed",),
+            workspace_path=str(repo_path.parent),
+        )
+        baseline_result = QaResult(
+            status="passed",
+            summary="Baseline QA passed.",
+            detail_codes=(),
+            phase="baseline",
+            quality="green",
+        )
+        qa_result = QaResult(
+            status="failed",
+            summary="QA failed: test_new_feature FAILED",
+            detail_codes=("qa_failed",),
+            phase="final",
+            quality="degraded",
+        )
+        return repair_result, baseline_result, qa_result
+
+    def run_docs_remediation_repair(self, **kwargs):
+        raise AssertionError("docs remediation should not run")
+
+    def evaluate_docs_remediation_validation(self, **kwargs):
+        raise AssertionError("validation should not run")
+
+    def merge_docs_remediation_execution_result(self, *args, **kwargs):
+        raise AssertionError("docs remediation merge should not run")
+
+    def merge_execution_result(self, synthesis_result, repair_result, qa_result=None):
+        from precision_squad.models import ExecutionResult
+
+        if qa_result and qa_result.status == "failed":
+            return ExecutionResult(
+                status="blocked",
+                executor_name="docs+repair",
+                summary=f"QA failed: {qa_result.summary}",
+                detail_codes=("qa_failed",),
+                quality="degraded",
+            )
+        return synthesis_result
+
+    def synthesis_artifacts_ready(self, execution_result):
+        return True
+
+    def execute_publish_plan(self, intake, plan, *, publish, run_dir=None):
+        return PublishResult(
+            status="dry_run",
+            target=plan.status,
+            summary="dry_run (test)",
+            url=None,
+        )
+
+    def run_post_publish_review_if_needed(self, **kwargs):
+        return None
+
+
+class _StubRepairAdapter:
+    """Trivial repair adapter that makes a minor change."""
+
+    def __init__(self) -> None:
+        self.binary: str | None = None
+        self.agent: str | None = None
+        self.model: str | None = None
+        self.qa_feedback: str | None = None
+
+    def repair(self, *, intake, run_record, run_dir, contract_artifact_dir, repo_workspace):
+        from precision_squad.models import RepairResult
+
+        return RepairResult(
+            status="completed",
+            summary="Stub repair completed.",
+            detail_codes=("repair_stage_completed",),
+            workspace_path=str(repo_workspace.parent),
+        )
+
+    def with_qa_feedback(self, feedback: str):
+        return self

--- a/tests/integration/test_pipeline_quality_tag.py
+++ b/tests/integration/test_pipeline_quality_tag.py
@@ -1,8 +1,8 @@
-"""Integration tests: provisional (baseline-tolerant) pipeline path.
+"""Integration tests: quality tag (baseline-tolerant) pipeline path.
 
 Exercises the baseline-tolerance logic: when the baseline QA fails but the
 repair improves the failure set without introducing new failures, governance
-marks the run as provisional.
+marks the run as approved with quality=improved.
 """
 
 from __future__ import annotations
@@ -49,6 +49,12 @@ class _RepairAdapterThatFixesFailingTest:
         self.agent: str | None = None
         self.model: str | None = None
         self.qa_feedback: str | None = None
+
+    def with_qa_feedback(self, feedback: str) -> _RepairAdapterThatFixesFailingTest:
+        """Return a copy of this adapter with the given QA feedback."""
+        new = _RepairAdapterThatFixesFailingTest()
+        new.qa_feedback = feedback
+        return new
 
     def repair(
         self,

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,367 @@
+"""Tests for the LLM repair adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precision_squad.models import (
+    GitHubIssue,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    RunRecord,
+)
+from precision_squad.repair.llm_adapter import (
+    VercelAIRepairAdapter,
+    _parse_llm_response,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_llm_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_llm_response_valid_summary_only() -> None:
+    payload = json.dumps({"summary": "Fixed the bug."})
+    result = _parse_llm_response(payload)
+    assert result is not None
+    assert result["summary"] == "Fixed the bug."
+
+
+def test_parse_llm_response_valid_with_side_issues() -> None:
+    payload = {
+        "summary": "Fixed the bug.",
+        "side_issues": [
+            {
+                "title": "Other bug",
+                "summary": "Found another bug",
+                "body": "Details here",
+                "labels": ["bug"],
+            }
+        ],
+    }
+    result = _parse_llm_response(json.dumps(payload))
+    assert result is not None
+    assert len(result["side_issues"]) == 1
+
+
+def test_parse_llm_response_empty_string() -> None:
+    assert _parse_llm_response("") is None
+
+
+def test_parse_llm_response_not_json() -> None:
+    assert _parse_llm_response("not json") is None
+
+
+def test_parse_llm_response_not_dict() -> None:
+    assert _parse_llm_response('"just a string"') is None
+
+
+def test_parse_llm_response_missing_summary() -> None:
+    assert _parse_llm_response(json.dumps({"side_issues": []})) is None
+
+
+def test_parse_llm_response_summary_wrong_type() -> None:
+    assert _parse_llm_response(json.dumps({"summary": 123})) is None
+
+
+def test_parse_llm_response_side_issues_wrong_type() -> None:
+    assert _parse_llm_response(json.dumps({"summary": "done", "side_issues": "bad"})) is None
+
+
+def test_parse_llm_response_side_issue_missing_required() -> None:
+    payload = json.dumps({"summary": "done", "side_issues": [{"title": "Only title"}]})
+    assert _parse_llm_response(payload) is None
+
+
+def test_parse_llm_response_pretty_printed_json() -> None:
+    payload = json.dumps({"summary": "Fixed the bug."}, indent=2)
+    result = _parse_llm_response(payload)
+    assert result is not None
+    assert result["summary"] == "Fixed the bug."
+
+
+# ---------------------------------------------------------------------------
+# VercelAIRepairAdapter.repair
+# ---------------------------------------------------------------------------
+
+
+def _make_intake() -> IssueIntake:
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Test issue",
+            body="Fix the bug.",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Test issue",
+        problem_statement="Fix the bug.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+
+def _make_run_record() -> RunRecord:
+    return RunRecord(
+        run_id="run-test",
+        issue_ref="owner/repo#1",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=".precision-squad/runs/run-test",
+    )
+
+
+def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert result.summary == "Fixed the bug."
+    assert result.stdout_path is not None
+
+
+def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert result.summary == "Fixed the bug."
+
+
+def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+
+
+def test_repair_adapter_api_failure(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("API error")
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "failed_infra"
+    assert "LLM API call failed" in result.summary
+
+
+def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"not_summary": "bad"}'
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "blocked"
+    assert "did not match" in result.summary
+
+
+def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    payload = {
+        "summary": "Fixed the bug.",
+        "side_issues": [
+            {
+                "title": "Other bug",
+                "summary": "Found another bug",
+                "body": "Details here",
+                "labels": ["bug"],
+            }
+        ],
+    }
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(payload)
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert len(result.side_issues) == 1
+    assert result.side_issues[0].title == "Other bug"
+
+
+def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4-turbo")
+
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps({"summary": "done"})
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter()
+        adapter.repair(
+                intake=intake,
+                run_record=run_record,
+                run_dir=run_dir,
+                contract_artifact_dir=contract_dir,
+                repo_workspace=repo_workspace,
+            )
+
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    assert call_args.kwargs["model"] == "gpt-4-turbo"
+
+
+def test_repair_adapter_with_qa_feedback(tmp_path: Path) -> None:
+    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    new_adapter = adapter.with_qa_feedback("Tests failed: test_foo")
+    assert new_adapter.qa_feedback == "Tests failed: test_foo"
+    assert new_adapter.model == "gpt-4o"
+    assert adapter.qa_feedback is None
+
+
+def test_repair_adapter_protocol_compliance() -> None:
+    """Verify VercelAIRepairAdapter satisfies RepairAdapter protocol."""
+    from precision_squad.repair.adapter import RepairAdapter
+
+    adapter = VercelAIRepairAdapter()
+    assert isinstance(adapter, RepairAdapter)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,275 @@
+"""Tests for the retry mechanism in RunCoordinator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from precision_squad.coordinator import RepairIssueParams, RunCoordinator
+from precision_squad.models import (
+    ExecutionResult,
+    GitHubIssue,
+    GovernanceVerdict,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    PublishPlan,
+    PublishResult,
+    RepairResult,
+    RunRecord,
+    RunRequest,
+)
+from precision_squad.run_store import RunStore
+
+
+def _make_intake(*, blocked: bool = False) -> IssueIntake:
+    status = "blocked" if blocked else "runnable"
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Test issue",
+            body="Fix the bug.",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Test issue",
+        problem_statement="Fix the bug.",
+        assessment=IssueAssessment(status=status, reason_codes=()),
+    )
+
+
+def _make_params(tmp_path: Path, *, retry_from: str | None = None) -> RepairIssueParams:
+    return RepairIssueParams(
+        issue_ref="owner/repo#1",
+        runs_dir=tmp_path / "runs",
+        repo_path=tmp_path / "repo",
+        publish=False,
+        repair_agent="none",
+        repair_model=None,
+        review_model=None,
+        retry_from=retry_from,
+    )
+
+
+def _create_previous_run(store: RunStore, attempt: int = 1) -> RunRecord:
+    """Create a previous run record with the specified attempt number."""
+    intake = _make_intake()
+    request = RunRequest(issue_ref="owner/repo#1", runs_dir=str(store.root))
+    record = store.create_run(request, intake)
+    # Update the record with the attempt number
+    updated = RunRecord(
+        run_id=record.run_id,
+        issue_ref=record.issue_ref,
+        status=record.status,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        run_dir=record.run_dir,
+        attempt=attempt,
+    )
+    store.write_run_record(updated)
+    return updated
+
+
+def test_retry_increments_attempt(tmp_path: Path) -> None:
+    """Test that retry increments the attempt counter."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = False
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+
+    # Create a minimal execution result for the mock
+    exec_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Test execution",
+        detail_codes=(),
+    )
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+
+    intake = _make_intake()
+    # Mock the executor to return a completed result
+    import precision_squad.coordinator as coord_module
+    original_execute = coord_module.DocsFirstExecutor.execute
+
+    def mock_execute(self, intake, record, run_dir):
+        return exec_result
+
+    coord_module.DocsFirstExecutor.execute = mock_execute
+    try:
+        report = coordinator.repair_issue(
+            params=params,
+            intake=intake,
+            dependencies=dependencies,
+        )
+    finally:
+        coord_module.DocsFirstExecutor.execute = original_execute
+
+    assert report.run_record.attempt == 2
+
+
+def test_retry_escalated_after_3_attempts(tmp_path: Path) -> None:
+    """Test that repair is escalated after 3 failed attempts."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=3)
+
+    dependencies = MagicMock()
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    report = coordinator.repair_issue(
+        params=params,
+        intake=intake,
+        dependencies=dependencies,
+    )
+
+    assert report.repair_result is not None
+    assert report.repair_result.status == "escalated"
+    assert "escalated" in report.repair_result.summary
+    assert report.exit_code == 4
+
+
+def test_retry_governance_blocked_after_escalation(tmp_path: Path) -> None:
+    """Test that governance returns blocked with escalated reason code."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=3)
+
+    dependencies = MagicMock()
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    report = coordinator.repair_issue(
+        params=params,
+        intake=intake,
+        dependencies=dependencies,
+    )
+
+    assert report.governance_verdict is not None
+    verdict = report.governance_verdict
+    assert isinstance(verdict, GovernanceVerdict)
+    assert verdict.status == "blocked"
+    assert "escalated_after_retries" in verdict.reason_codes
+
+
+def test_retry_from_nonexistent_run(tmp_path: Path) -> None:
+    """Test that retry from non-existent run returns error."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+
+    dependencies = MagicMock()
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from="nonexistent-run-id")
+    intake = _make_intake()
+
+    report = coordinator.repair_issue(
+        params=params,
+        intake=intake,
+        dependencies=dependencies,
+    )
+
+    assert report.exit_code == 3
+
+
+def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
+    """Test that attempt number is persisted in run record."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=2)
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = False
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    import precision_squad.coordinator as coord_module
+    exec_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Test execution",
+        detail_codes=(),
+    )
+
+    original_execute = coord_module.DocsFirstExecutor.execute
+    def mock_execute(self, intake, record, run_dir):
+        return exec_result
+    coord_module.DocsFirstExecutor.execute = mock_execute
+
+    try:
+        report = coordinator.repair_issue(
+            params=params,
+            intake=intake,
+            dependencies=dependencies,
+        )
+    finally:
+        coord_module.DocsFirstExecutor.execute = original_execute
+
+    # Verify the attempt was persisted
+    loaded = store.load_run(report.run_record.run_id)
+    assert loaded.attempt == 3
+
+
+def test_retry_escalated_uses_correct_attempt_count(tmp_path: Path) -> None:
+    """Test that escalated result uses the correct attempt count."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=3)
+
+    dependencies = MagicMock()
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    report = coordinator.repair_issue(
+        params=params,
+        intake=intake,
+        dependencies=dependencies,
+    )
+
+    assert report.repair_result is not None
+    # Attempt 4 > 3, so should be escalated
+    assert "4" in report.repair_result.summary or "3" in report.repair_result.summary


### PR DESCRIPTION
## Summary

- Add `docs/adr/adr-001-governance-two-verdicts.md` — documents why `provisional` was removed and quality tags introduced
- Add `docs/adr/adr-002-llm-abstraction.md` — documents why direct API over agent binary
- Add `CONTRIBUTING.md` — issue-first workflow, governance model, retry policy, PR checklist

## ADR-001: Governance Two-Verdicts

Documents the decision to collapse governance from three verdicts (approved/provisional/blocked) to two (approved/blocked), with quality tags as informational metadata.

Key trade-offs:
- Lost: explicit provisional publish path
- Gained: simpler governance contract, better separation of concerns

## ADR-002: LLM Abstraction

Documents the decision to use direct OpenAI SDK over agent binary dependency.

Key trade-offs:
- Lost: agent binary capabilities (built-in prompt engineering, multi-step reasoning)
- Gained: no binary dependency, full control, testability, portability

## CONTRIBUTING.md

Covers:
- Development setup
- Issue-first workflow
- Governance model (verdicts + quality tags)
- Side issues
- Retry policy
- Docs-first principle
- PR checklist

Closes #7
Closes #8