### PR TITLE
refactor: add RunRecord.with_attempt() helper

### DIFF
--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -207,15 +207,7 @@ class RunCoordinator:
         if attempt > 3:
             record = store.create_run(request, intake)
             run_dir = Path(record.run_dir).resolve()
-            record = RunRecord(
-                run_id=record.run_id,
-                issue_ref=record.issue_ref,
-                status=record.status,
-                created_at=record.created_at,
-                updated_at=record.updated_at,
-                run_dir=record.run_dir,
-                attempt=attempt,
-            )
+            record = record.with_attempt(attempt)
             store.write_run_record(record)
 
             escalated_result = RepairResult(
@@ -254,15 +246,7 @@ class RunCoordinator:
 
         # Update attempt counter if retrying
         if attempt > 1:
-            record = RunRecord(
-                run_id=record.run_id,
-                issue_ref=record.issue_ref,
-                status=record.status,
-                created_at=record.created_at,
-                updated_at=record.updated_at,
-                run_dir=record.run_dir,
-                attempt=attempt,
-            )
+            record = record.with_attempt(attempt)
             store.write_run_record(record)
 
         if intake.assessment.status == "blocked":

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -68,6 +68,18 @@ class RunRecord:
     run_dir: str
     attempt: int = 1
 
+    def with_attempt(self, attempt: int) -> RunRecord:
+        """Return a copy with a different attempt number."""
+        return RunRecord(
+            run_id=self.run_id,
+            issue_ref=self.issue_ref,
+            status=self.status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            run_dir=self.run_dir,
+            attempt=attempt,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class ExecutionResult:


### PR DESCRIPTION
## Summary

Add `with_attempt()` method to `RunRecord` dataclass to reduce reconstruction boilerplate in `coordinator.py`.

## Problem

The code reconstructed the entire frozen `RunRecord` just to change the `attempt` field in two places:

```python
# coordinator.py:210-218 and 257-265
record = RunRecord(
    run_id=record.run_id,
    issue_ref=record.issue_ref,
    status=record.status,
    created_at=record.created_at,
    updated_at=record.updated_at,
    run_dir=record.run_dir,
    attempt=attempt,
)
```

## Fix

Added `with_attempt()` method to `RunRecord`:

```python
def with_attempt(self, attempt: int) -> RunRecord:
    """Return a copy with a different attempt number."""
    return RunRecord(
        run_id=self.run_id,
        issue_ref=self.issue_ref,
        status=self.status,
        created_at=self.created_at,
        updated_at=self.updated_at,
        run_dir=self.run_dir,
        attempt=attempt,
    )
```

Both reconstruction sites now use the helper:
```python
record = record.with_attempt(attempt)
```

## Changes

| File | Change |
|---|---|
| `src/precision_squad/models.py` | Added `with_attempt()` method |
| `src/precision_squad/coordinator.py` | Updated both reconstruction sites |

Closes #26