### PR TITLE
fix: type governance_verdict as GovernanceVerdict instead of object

### DIFF
--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -181,11 +181,11 @@ def _repair_issue(args: argparse.Namespace) -> int:
             print(f"- {reason_code}")
 
     if report.execution_result is None:
-        verdict = cast(Any, report.governance_verdict)
+        verdict = report.governance_verdict
         publish_plan = cast(PublishPlan, report.publish_plan)
         publish_result = cast(PublishResult, report.publish_result)
-        print(f"Governance: {verdict.status}")
-        print(f"Governance Summary: {verdict.summary}")
+        print(f"Governance: {verdict.status if verdict else 'N/A'}")
+        print(f"Governance Summary: {verdict.summary if verdict else 'N/A'}")
         print(f"Publish Plan: {publish_plan.status}")
         print(f"Publish Result: {publish_result.status}")
         print(f"Publish Summary: {publish_result.summary}")
@@ -193,7 +193,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
 
     execution_result = report.execution_result
     evaluation_result = cast(Any, report.evaluation_result)
-    verdict = cast(Any, report.governance_verdict)
+    verdict = report.governance_verdict
     publish_plan = cast(PublishPlan, report.publish_plan)
     publish_result = cast(PublishResult, report.publish_result)
     repair_result = report.repair_result
@@ -212,7 +212,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
         print(f"QA Status: {qa_result.status}")
         print(f"QA Summary: {qa_result.summary}")
     print(f"Evaluation Status: {evaluation_result.status}")
-    print(f"Governance: {verdict.status}")
+    print(f"Governance: {verdict.status if verdict else 'N/A'}")
     print(f"Publish Plan: {publish_plan.status}")
     print(f"Publish Result: {publish_result.status}")
     print(f"Publish Summary: {publish_result.summary}")

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -151,7 +151,7 @@ class RepairIssueReport:
     run_record: RunRecord
     execution_result: ExecutionResult | None = None
     evaluation_result: EvaluationResult | None = None
-    governance_verdict: object | None = None
+    governance_verdict: GovernanceVerdict | None = None
     publish_plan: PublishPlan | None = None
     publish_result: PublishResult | None = None
     repair_result: RepairResult | None = None


### PR DESCRIPTION
## Summary

Change `governance_verdict` field type from `object | None` to `GovernanceVerdict | None` in `RepairIssueReport`.

## Problem

`governance_verdict` was typed as `object | None`, forcing `cli.py` to use `cast(Any, report.governance_verdict)` to access `.status` and `.summary`. This bypassed type checking entirely.

## Fix

1. Changed type annotation in `coordinator.py:154`
2. Removed `cast(Any, ...)` calls in `cli.py:184` and `cli.py:196`
3. Added proper None handling for `verdict.status` access

## Changes

| File | Change |
|---|---|
| `src/precision_squad/coordinator.py` | Changed `governance_verdict: object | None` to `governance_verdict: GovernanceVerdict | None` |
| `src/precision_squad/cli.py` | Removed `cast(Any, ...)` calls, added None handling |

Closes #19