### PR TITLE
refactor: extract duplicated _extract_json_events to shared module

### DIFF
--- a/src/precision_squad/json_events.py
+++ b/src/precision_squad/json_events.py
@@ -1,0 +1,32 @@
+"""JSON event extraction utilities."""
+
+from __future__ import annotations
+
+import json
+
+
+def extract_json_events(stdout: str) -> list[dict]:
+    """Extract JSON objects from NDJSON output.
+
+    Parses each line of stdout, looking for lines that start with '{'.
+    Lines that are valid JSON dicts are collected into the result list.
+    Non-JSON lines and malformed JSON lines are silently skipped.
+
+    Args:
+        stdout: Raw stdout text, typically from a subprocess or LLM response.
+
+    Returns:
+        List of parsed JSON dicts in order of appearance.
+    """
+    events: list[dict] = []
+    for line in stdout.splitlines():
+        text = line.strip()
+        if not text.startswith("{"):
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Literal, Protocol
 
 from .github_client import GitHubWriteClient
+from .json_events import extract_json_events
 from .models import IssueIntake, PostPublishReviewResult, ReviewAgentResult, RunRecord
 from .opencode_model import resolve_opencode_model
 
@@ -79,7 +80,7 @@ class OpenCodePrReviewAgent:
         )
         stdout_path.write_text(completed.stdout, encoding="utf-8", errors="ignore")
         stderr_path.write_text(completed.stderr, encoding="utf-8", errors="ignore")
-        events = _extract_json_events(completed.stdout)
+        events = extract_json_events(completed.stdout)
         transcript_path.write_text(json.dumps(events, indent=2) + "\n", encoding="utf-8")
         parsed = _parse_review_output(events)
 
@@ -228,21 +229,6 @@ def _build_review_prompt(
             "Do not include markdown fences.",
         ]
     )
-
-
-def _extract_json_events(stdout: str) -> list[dict]:
-    events: list[dict] = []
-    for line in stdout.splitlines():
-        text = line.strip()
-        if not text.startswith("{"):
-            continue
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            events.append(payload)
-    return events
 
 
 def _parse_review_output(events: list[dict]) -> dict[str, Any] | None:

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -12,6 +12,7 @@ from jsonschema import ValidationError, validate
 
 from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
+from ..json_events import extract_json_events
 from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
 
@@ -138,7 +139,7 @@ class OpenCodeRepairAdapter:
         stdout_path.write_text(command_result.stdout, encoding="utf-8", errors="ignore")
         stderr_path.write_text(command_result.stderr, encoding="utf-8", errors="ignore")
         transcript_path.write_text(
-            json.dumps(_extract_json_events(command_result.stdout), indent=2) + "\n",
+            json.dumps(extract_json_events(command_result.stdout), indent=2) + "\n",
             encoding="utf-8",
         )
 
@@ -203,7 +204,7 @@ class OpenCodeRepairAdapter:
 
 def _parse_repair_json(stdout: str) -> dict | None:
     """Parse and validate JSON output from the repair agent."""
-    events = _extract_json_events(stdout)
+    events = extract_json_events(stdout)
     if not events:
         return None
     last_event = events[-1]
@@ -362,18 +363,3 @@ def _build_repair_prompt(
     if qa_feedback:
         lines.extend(["QA feedback from the previous attempt:", qa_feedback])
     return "\n".join(lines)
-
-
-def _extract_json_events(stdout: str) -> list[dict]:
-    events: list[dict] = []
-    for line in stdout.splitlines():
-        text = line.strip()
-        if not text.startswith("{"):
-            continue
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            events.append(payload)
-    return events


### PR DESCRIPTION
## Summary

Extract duplicated `_extract_json_events` function to a shared module.

## Problem

The function was duplicated in two places:
- `adapter.py:367-379`
- `post_publish_review.py:233-245`

Any change to JSON event parsing logic must be applied in both places.

## Fix

1. Created `src/precision_squad/json_events.py` with `extract_json_events()` function
2. Updated `adapter.py` to import from shared module
3. Updated `post_publish_review.py` to import from shared module
4. Removed both local copies

## Changes

| File | Change |
|---|---|
| `src/precision_squad/json_events.py` | New shared module |
| `src/precision_squad/repair/adapter.py` | Import from shared, remove local copy |
| `src/precision_squad/post_publish_review.py` | Import from shared, remove local copy |

Closes #18