### PR TITLE
Fix #25: Rename VercelAIRepairAdapter to OpenAIRepairAdapter and clean __all__

### DIFF
--- a/docs/adr/adr-002-llm-abstraction.md
+++ b/docs/adr/adr-002-llm-abstraction.md
@@ -19,9 +19,9 @@ The implementation plan (Phase 3) proposed replacing this with a direct LLM API 
 Replace the `opencode` binary dependency with a direct LLM API call using the `openai` Python SDK. Introduce a `RepairAdapter` protocol that abstracts the repair mechanism, allowing multiple implementations:
 
 1. **`OpenCodeRepairAdapter`** — the original binary-based adapter (preserved for backward compatibility)
-2. **`VercelAIRepairAdapter`** — direct LLM API adapter using `openai` SDK
+2. **`OpenAIRepairAdapter`** — direct LLM API adapter using `openai` SDK
 
-The coordinator selects the adapter based on the `--repair-agent` CLI argument (`none`, `opencode`, `vercel-ai`).
+The coordinator selects the adapter based on the `--repair-agent` CLI argument (`none`, `opencode`, `openai`).
 
 ## Rationale
 
@@ -76,8 +76,7 @@ The coordinator selects the adapter based on the `--repair-agent` CLI argument (
 ## Consequences
 
 - `openai` is a required dependency in `pyproject.toml`.
-- `VercelAIRepairAdapter` uses the OpenAI SDK directly, not the Vercel AI SDK.
-- The adapter name `VercelAIRepairAdapter` is a historical artifact; the implementation uses OpenAI SDK. (See issue #25 for naming cleanup.)
+- `OpenAIRepairAdapter` uses the OpenAI SDK directly.
 - The `OpenCodeRepairAdapter` is preserved for backward compatibility but is not the default.
 - The `--repair-agent` CLI argument selects the adapter.
 - The `RepairAdapter` protocol defines the contract for all adapters.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -135,7 +135,7 @@ When verdict is `blocked` and `side_issues` is non-empty on the associated `Repa
 
 ### 3.1 — New `repair/llm_adapter.py`
 
-Create `VercelAIRepairAdapter` (or similar):
+Create `OpenAIRepairAdapter` (or similar):
 
 - Uses `openai` SDK directly (what Vercel AI SDK wraps) or the `@ai-sdk/openai` package.
 - Reads `OPENAI_API_KEY` (or `VERCEL_API_KEY`) from environment.
@@ -148,12 +148,12 @@ Create `VercelAIRepairAdapter` (or similar):
 
 ### 3.2 — `repair/__init__.py` (or `repair/adapter.py`)
 
-Export both `OpenCodeRepairAdapter` and `VercelAIRepairAdapter`.
+Export both `OpenCodeRepairAdapter` and `OpenAIRepairAdapter`.
 
 ### 3.3 — `coordinator.py` / `cli.py`
 
-- [ ] Update `RepairDependencies.create_repair_adapter` to return the new adapter when `repair_agent == "vercel-ai"` (new choice).
-- [ ] Add `--repair-agent` choice: `none`, `opencode`, `vercel-ai`.
+- [ ] Update `RepairDependencies.create_repair_adapter` to return the new adapter when `repair_agent == "openai"` (new choice).
+- [ ] Add `--repair-agent` choice: `none`, `opencode`, `openai`.
 - [ ] `OpenCodeRepairAdapter` remains functional for existing users.
 
 ### 3.4 — Dependency

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -32,9 +32,9 @@ from .models import (
 from .post_publish_review import OpenCodePrReviewAgent, run_post_publish_review
 from .publish_executor import execute_publish_plan
 from .repair import (
+    OpenAIRepairAdapter,
     OpenCodeRepairAdapter,
     RepairAdapter,
-    VercelAIRepairAdapter,
     evaluate_docs_remediation_validation,
     merge_docs_remediation_execution_result,
     merge_execution_result,
@@ -90,7 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     issue_parser.add_argument(
         "--repair-agent",
         default="opencode",
-        choices=("none", "opencode", "vercel-ai"),
+        choices=("none", "opencode", "openai"),
         help="Repair agent adapter to run after the documented execution contract is prepared.",
     )
     issue_parser.add_argument(
@@ -266,8 +266,8 @@ class _CliRepairDependencies:
     ) -> RepairAdapter | None:
         if repair_agent == "opencode":
             return OpenCodeRepairAdapter(model=repair_model)
-        if repair_agent == "vercel-ai":
-            return VercelAIRepairAdapter(model=repair_model)
+        if repair_agent == "openai":
+            return OpenAIRepairAdapter(model=repair_model)
         return None
 
     def run_repair_qa_loop(
@@ -676,6 +676,8 @@ def _post_publish_review_is_stale(
     if head_sha is None:
         return False
     return head_sha != review_result.pull_head_sha
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI and return a process exit code."""
     load_local_env(Path(__file__).resolve().parent.parent.parent)

--- a/src/precision_squad/repair/__init__.py
+++ b/src/precision_squad/repair/__init__.py
@@ -1,13 +1,12 @@
 """Agent-backed repair stage using a documented local execution contract."""
 
-import subprocess
+import subprocess  # noqa: F401 — re-exported for test monkeypatching
 
 from ..github_client import GitHubWriteClient
 from .adapter import OpenCodeRepairAdapter, RepairAdapter
-from .llm_adapter import VercelAIRepairAdapter
+from .llm_adapter import OpenAIRepairAdapter
 from .orchestration import (
     RepairStage,
-    _resolve_rerun_branch,
     evaluate_docs_remediation_validation,
     merge_docs_remediation_execution_result,
     merge_execution_result,
@@ -16,18 +15,15 @@ from .orchestration import (
     run_repair_qa_loop,
     synthesis_artifacts_ready,
 )
-from .qa import WorkspaceQaVerifier, _failure_signature, _finalize_qa_result, build_qa_feedback
+from .qa import WorkspaceQaVerifier, build_qa_feedback
 
 __all__ = [
+    "GitHubWriteClient",
+    "OpenAIRepairAdapter",
     "OpenCodeRepairAdapter",
     "RepairAdapter",
     "RepairStage",
-    "VercelAIRepairAdapter",
     "WorkspaceQaVerifier",
-    "GitHubWriteClient",
-    "_failure_signature",
-    "_finalize_qa_result",
-    "_resolve_rerun_branch",
     "build_qa_feedback",
     "evaluate_docs_remediation_validation",
     "merge_docs_remediation_execution_result",
@@ -35,6 +31,5 @@ __all__ = [
     "resolve_artifact_dir",
     "run_docs_remediation_repair",
     "run_repair_qa_loop",
-    "subprocess",
     "synthesis_artifacts_ready",
 ]

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -27,15 +27,15 @@ _SYSTEM_PROMPT = (
 
 
 @dataclass(frozen=True, slots=True)
-class VercelAIRepairAdapter:
+class OpenAIRepairAdapter:
     """Repair adapter that calls an OpenAI-compatible LLM API directly."""
 
     model: str | None = None
     qa_feedback: str | None = None
 
-    def with_qa_feedback(self, feedback: str) -> VercelAIRepairAdapter:
+    def with_qa_feedback(self, feedback: str) -> OpenAIRepairAdapter:
         """Return a copy of this adapter with the given QA feedback."""
-        return VercelAIRepairAdapter(model=self.model, qa_feedback=feedback)
+        return OpenAIRepairAdapter(model=self.model, qa_feedback=feedback)
 
     def repair(
         self,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -22,12 +22,11 @@ from precision_squad.repair import (
     OpenCodeRepairAdapter,
     RepairStage,
     WorkspaceQaVerifier,
-    _failure_signature,
-    _finalize_qa_result,
     evaluate_docs_remediation_validation,
     merge_docs_remediation_execution_result,
     merge_execution_result,
 )
+from precision_squad.repair.qa import _failure_signature, _finalize_qa_result
 
 
 def _intake() -> IssueIntake:

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -16,7 +16,7 @@ from precision_squad.models import (
     RunRecord,
 )
 from precision_squad.repair.llm_adapter import (
-    VercelAIRepairAdapter,
+    OpenAIRepairAdapter,
     _parse_llm_response,
 )
 
@@ -86,7 +86,7 @@ def test_parse_llm_response_pretty_printed_json() -> None:
 
 
 # ---------------------------------------------------------------------------
-# VercelAIRepairAdapter.repair
+# OpenAIRepairAdapter.repair
 # ---------------------------------------------------------------------------
 
 
@@ -135,7 +135,7 @@ def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -168,7 +168,7 @@ def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -200,7 +200,7 @@ def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -227,7 +227,7 @@ def test_repair_adapter_api_failure(tmp_path: Path) -> None:
         mock_client.chat.completions.create.side_effect = Exception("API error")
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -259,7 +259,7 @@ def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -302,7 +302,7 @@ def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        adapter = OpenAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
             intake=intake,
             run_record=run_record,
@@ -337,7 +337,7 @@ def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.Monke
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai.return_value = mock_client
 
-        adapter = VercelAIRepairAdapter()
+        adapter = OpenAIRepairAdapter()
         adapter.repair(
                 intake=intake,
                 run_record=run_record,
@@ -352,7 +352,7 @@ def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.Monke
 
 
 def test_repair_adapter_with_qa_feedback(tmp_path: Path) -> None:
-    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    adapter = OpenAIRepairAdapter(model="gpt-4o")
     new_adapter = adapter.with_qa_feedback("Tests failed: test_foo")
     assert new_adapter.qa_feedback == "Tests failed: test_foo"
     assert new_adapter.model == "gpt-4o"
@@ -360,8 +360,8 @@ def test_repair_adapter_with_qa_feedback(tmp_path: Path) -> None:
 
 
 def test_repair_adapter_protocol_compliance() -> None:
-    """Verify VercelAIRepairAdapter satisfies RepairAdapter protocol."""
+    """Verify OpenAIRepairAdapter satisfies RepairAdapter protocol."""
     from precision_squad.repair.adapter import RepairAdapter
 
-    adapter = VercelAIRepairAdapter()
+    adapter = OpenAIRepairAdapter()
     assert isinstance(adapter, RepairAdapter)

--- a/tests/test_repair_rerun.py
+++ b/tests/test_repair_rerun.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from precision_squad.models import GitHubIssue, IssueAssessment, IssueIntake, IssueReference
-from precision_squad.repair import _resolve_rerun_branch
+from precision_squad.repair.orchestration import _resolve_rerun_branch
 
 
 def test_resolve_rerun_branch_uses_latest_rejected_pull_request(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Renames VercelAIRepairAdapter to OpenAIRepairAdapter to match the actual SDK used (OpenAI, not Vercel AI)
- Changes CLI --repair-agent choice from vercel-ai to openai
- Cleans __all__ in repair/__init__.py: removes private symbols (_failure_signature, _finalize_qa_result, _resolve_rerun_branch) and subprocess from the public API
- Updates ADR-002 and implementation-plan.md to reflect new naming

## Acceptance Criteria

- [x] Adapter name accurately reflects its implementation
- [x] __all__ exports only public API symbols
- [x] No private symbols in package exports
- [x] Existing tests pass

Closes #25