### PR TITLE
Fix #23: Return workspace_path and stderr_path from OpenAIRepairAdapter

### DIFF
--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -28,7 +28,15 @@ _SYSTEM_PROMPT = (
 
 @dataclass(frozen=True, slots=True)
 class OpenAIRepairAdapter:
-    """Repair adapter that calls an OpenAI-compatible LLM API directly."""
+    """Repair adapter that calls an OpenAI-compatible LLM API directly.
+
+    This adapter generates a repair plan as JSON via the LLM but does **not**
+    modify files in the workspace.  The ``workspace_path`` in the returned
+    :class:`RepairResult` points to the cloned workspace prepared by
+    :class:`RepairStage` so that the QA loop can locate it, but the workspace
+    itself is unchanged.  Use :class:`OpenCodeRepairAdapter` when you need an
+    adapter that applies changes to the filesystem.
+    """
 
     model: str | None = None
     qa_feedback: str | None = None
@@ -47,6 +55,7 @@ class OpenAIRepairAdapter:
         repo_workspace: Path,
     ) -> RepairResult:
         stdout_path = run_dir / "repair.stdout.log"
+        stderr_path = run_dir / "repair.stderr.log"
 
         prompt = _build_repair_prompt(
             intake=intake,
@@ -75,10 +84,13 @@ class OpenAIRepairAdapter:
                 status="failed_infra",
                 summary=f"LLM API call failed: {exc}",
                 detail_codes=("llm_api_failed",),
+                workspace_path=str(repo_workspace.parent),
                 stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
             )
 
         stdout_path.write_text(raw_content, encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
 
         repair_json = _parse_llm_response(raw_content)
         side_issues: tuple[SideIssue, ...] = ()
@@ -90,14 +102,18 @@ class OpenAIRepairAdapter:
                 status="blocked",
                 summary="LLM response did not match the expected repair result schema.",
                 detail_codes=("llm_response_invalid",),
+                workspace_path=str(repo_workspace.parent),
                 stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
             )
 
         return RepairResult(
             status="completed",
             summary=repair_json.get("summary", "Repair agent completed."),
             detail_codes=("repair_stage_completed",),
+            workspace_path=str(repo_workspace.parent),
             stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
             side_issues=side_issues,
         )
 

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -147,6 +147,8 @@ def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
     assert result.status == "completed"
     assert result.summary == "Fixed the bug."
     assert result.stdout_path is not None
+    assert result.stderr_path is not None
+    assert result.workspace_path == str(repo_workspace.parent)
 
 
 def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
@@ -238,6 +240,8 @@ def test_repair_adapter_api_failure(tmp_path: Path) -> None:
 
     assert result.status == "failed_infra"
     assert "LLM API call failed" in result.summary
+    assert result.workspace_path == str(repo_workspace.parent)
+    assert result.stderr_path is not None
 
 
 def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
@@ -270,6 +274,8 @@ def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
 
     assert result.status == "blocked"
     assert "did not match" in result.summary
+    assert result.workspace_path == str(repo_workspace.parent)
+    assert result.stderr_path is not None
 
 
 def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Returns workspace_path and stderr_path in all RepairResult paths (completed, blocked, failed_infra)
- Documents that this is a plan-only adapter that does not modify files
- QA loop can now correctly locate the cloned workspace

## Changes

| File | Change |
|------|--------|
| src/precision_squad/repair/llm_adapter.py | Add workspace_path, stderr_path; update docstring |
| tests/test_llm_adapter.py | Add assertions for new fields |

## Acceptance Criteria

- [x] OpenAIRepairAdapter produces complete RepairResult with workspace_path and stderr_path
- [x] QA loop can locate the workspace
- [x] Existing tests pass
- [x] New assertions covering the adapter behavior

Closes #23