### PR TITLE
Fix #12: align config-file support with issue contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,65 @@ Primary repair command:
 python -m precision_squad.cli repair issue owner/repo#number --repo-path <local-repo>
 ```
 
+Optional project config:
+
+- locations, in search order: `./.precision-squad.toml` and `./.precision-squad/precision-squad.toml`
+- precedence: CLI flags override config values
+- boolean overrides: use `--publish` / `--no-publish` and `--force` / `--no-force`
+- schema: command-shaped TOML tables only; top-level scalar keys are invalid
+- discovery root:
+  - `repair issue`: `--repo-path` when provided, otherwise the current working directory
+  - `publish run`: the current working directory
+  - `install-skill`: `--project-root` when provided, otherwise the current working directory
+- relative path values from config are resolved relative to the config file that supplied them
+
+Example:
+
+```toml
+[repair.issue]
+repo_path = "."
+runs_dir = ".precision-squad/runs"
+repair_agent = "opencode"
+publish = false
+repair_model = "model-name"
+review_model = "model-name"
+approved_plan_path = "approved-plan.json"
+
+[publish.run]
+runs_dir = ".precision-squad/runs"
+review_model = "model-name"
+
+[install-skill]
+project_root = "."
+force = false
+```
+
+Supported keys for `repair issue`:
+
+- `repo_path`
+- `runs_dir`
+- `publish`
+- `repair_agent`
+- `repair_model`
+- `review_model`
+- `approved_plan_path`
+
+Supported keys for `publish run`:
+
+- `runs_dir`
+- `review_model`
+
+Supported keys for `install-skill`:
+
+- `project_root`
+- `force`
+
+CLI-only for this feature:
+
+- positional arguments such as `issue_ref` and `run_id`
+- command and subcommand names
+- `retry_from`, because run selection remains an explicit invocation-scoped operator choice
+
 Legacy alias still supported:
 
 ```bash

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -6,11 +6,17 @@ import argparse
 import importlib.resources
 import json
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
 from . import __version__
+from .config import (
+    format_config_search_locations,
+    load_command_config,
+    merge_config_into_args,
+)
 from .coordinator import PublishRunParams, RepairIssueParams, RunCoordinator
 from .env import load_local_env
 from .executor import DocsFirstExecutor
@@ -49,6 +55,8 @@ from .run_store import ApprovedPlanError, load_approved_plan_artifact
 # Keep a local alias so tests can monkeypatch the shared executor class through this module.
 _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
 
+_REPAIR_AGENT_CHOICES = ("none", "opencode", "vercel-ai")
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
@@ -77,38 +85,39 @@ def build_parser() -> argparse.ArgumentParser:
     )
     issue_parser.add_argument(
         "--runs-dir",
-        default=".precision-squad/runs",
+        default=argparse.SUPPRESS,
         help="Directory where run artifacts will be stored.",
     )
     issue_parser.add_argument(
         "--publish",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=argparse.SUPPRESS,
         help="Apply the publish plan to GitHub instead of only preparing it.",
     )
     issue_parser.add_argument(
         "--repo-path",
-        required=True,
+        default=argparse.SUPPRESS,
         help="Local filesystem path to the target repository checkout.",
     )
     issue_parser.add_argument(
         "--repair-agent",
-        default="opencode",
-        choices=("none", "opencode", "vercel-ai"),
+        choices=_REPAIR_AGENT_CHOICES,
+        default=argparse.SUPPRESS,
         help="Repair agent adapter to run after the documented execution contract is prepared.",
     )
     issue_parser.add_argument(
         "--repair-model",
-        default=None,
+        default=argparse.SUPPRESS,
         help="Optional model override for the repair agent runtime.",
     )
     issue_parser.add_argument(
         "--review-model",
-        default=None,
+        default=argparse.SUPPRESS,
         help="Optional model override for post-publish review agents.",
     )
     issue_parser.add_argument(
         "--retry-from",
-        default=None,
+        default=argparse.SUPPRESS,
         help="Existing run ID to retry from. Increments attempt counter.",
     )
     issue_parser.add_argument(
@@ -133,12 +142,12 @@ def build_parser() -> argparse.ArgumentParser:
     publish_run_parser.add_argument("run_id", help="Existing run ID to publish.")
     publish_run_parser.add_argument(
         "--runs-dir",
-        default=".precision-squad/runs",
+        default=argparse.SUPPRESS,
         help="Directory where run artifacts are stored.",
     )
     publish_run_parser.add_argument(
         "--review-model",
-        default=None,
+        default=argparse.SUPPRESS,
         help="Optional model override for post-publish review agents.",
     )
     publish_run_parser.set_defaults(handler=_publish_run)
@@ -149,12 +158,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     install_skill_parser.add_argument(
         "--project-root",
-        default=".",
+        default=argparse.SUPPRESS,
         help="Project root where SKILL.md should be written.",
     )
     install_skill_parser.add_argument(
         "--force",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=argparse.SUPPRESS,
         help="Overwrite an existing SKILL.md file.",
     )
     install_skill_parser.set_defaults(handler=_install_skill)
@@ -707,18 +717,206 @@ def _post_publish_review_is_stale(
     return head_sha != review_result.pull_head_sha
 
 
+@dataclass(frozen=True)
+class _CommandConfigSpec:
+    table: tuple[str, ...]
+    supported_keys: frozenset[str]
+    defaults: dict[str, Any]
+    validate: Callable[[dict[str, Any]], None]
+    discovery_root: Callable[[argparse.Namespace], Path]
+
+
+def _validate_repair_issue_args(args: dict[str, Any]) -> None:
+    _require_config_value(args, "repo_path")
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+    args["repo_path"] = _config_str(args.get("repo_path"), key="repo_path")
+    args["publish"] = _coerce_bool(args.get("publish"), key="publish")
+    args["repair_agent"] = _validate_repair_agent(args.get("repair_agent"))
+    _normalize_optional_path_arg(args, "approved_plan_path")
+    _normalize_optional_str_arg(args, "repair_model")
+    _normalize_optional_str_arg(args, "review_model")
+
+
+def _validate_publish_run_args(args: dict[str, Any]) -> None:
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+    _normalize_optional_str_arg(args, "review_model")
+
+
+def _validate_install_skill_args(args: dict[str, Any]) -> None:
+    args["project_root"] = _config_str(args.get("project_root"), key="project_root")
+    args["force"] = _coerce_bool(args.get("force"), key="force")
+
+
+def _repair_issue_config_root(args: argparse.Namespace) -> Path:
+    repo_path = getattr(args, "repo_path", argparse.SUPPRESS)
+    if repo_path is argparse.SUPPRESS:
+        return Path.cwd()
+    return Path(repo_path)
+
+
+def _publish_run_config_root(args: argparse.Namespace) -> Path:
+    del args
+    return Path.cwd()
+
+
+def _install_skill_config_root(args: argparse.Namespace) -> Path:
+    project_root = getattr(args, "project_root", argparse.SUPPRESS)
+    if project_root is argparse.SUPPRESS:
+        return Path.cwd()
+    return Path(project_root)
+
+
+_COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigSpec] = {
+    _repair_issue: _CommandConfigSpec(
+        table=("repair", "issue"),
+        supported_keys=frozenset(
+            {
+                "runs_dir",
+                "publish",
+                "repo_path",
+                "repair_agent",
+                "repair_model",
+                "review_model",
+                "approved_plan_path",
+            }
+        ),
+        defaults={
+            "runs_dir": ".precision-squad/runs",
+            "publish": False,
+            "repair_agent": "opencode",
+            "repair_model": None,
+            "review_model": None,
+            "retry_from": None,
+            "approved_plan_path": None,
+        },
+        validate=_validate_repair_issue_args,
+        discovery_root=_repair_issue_config_root,
+    ),
+    _publish_run: _CommandConfigSpec(
+        table=("publish", "run"),
+        supported_keys=frozenset({"runs_dir", "review_model"}),
+        defaults={"runs_dir": ".precision-squad/runs", "review_model": None},
+        validate=_validate_publish_run_args,
+        discovery_root=_publish_run_config_root,
+    ),
+    _install_skill: _CommandConfigSpec(
+        table=("install-skill",),
+        supported_keys=frozenset({"project_root", "force"}),
+        defaults={"project_root": ".", "force": False},
+        validate=_validate_install_skill_args,
+        discovery_root=_install_skill_config_root,
+    ),
+}
+
+
+def _resolve_cli_args(
+    parser: argparse.ArgumentParser, argv: Sequence[str] | None
+) -> argparse.Namespace:
+    parsed_args = parser.parse_args(list(argv) if argv is not None else None)
+    handler = getattr(parsed_args, "handler", None)
+    if handler is None:
+        return parsed_args
+
+    spec = _COMMAND_CONFIG_SPECS.get(handler)
+    if spec is None:
+        return parsed_args
+
+    args_dict = vars(parsed_args)
+    for key in spec.supported_keys:
+        args_dict.setdefault(key, argparse.SUPPRESS)
+    config = load_command_config(
+        start_dir=spec.discovery_root(parsed_args),
+        table=spec.table,
+        supported_tables={
+            command_spec.table: command_spec.supported_keys
+            for command_spec in _COMMAND_CONFIG_SPECS.values()
+        },
+    )
+    merged = merge_config_into_args(config, args_dict)
+    resolved = _apply_config_defaults(merged, spec)
+    _validate_resolved_args(resolved, spec)
+    return argparse.Namespace(**resolved)
+
+
+def _apply_config_defaults(args: dict[str, Any], spec: _CommandConfigSpec) -> dict[str, Any]:
+    resolved = dict(args)
+    for key, value in spec.defaults.items():
+        if resolved.get(key, argparse.SUPPRESS) is argparse.SUPPRESS:
+            resolved[key] = value
+    return resolved
+
+
+def _validate_resolved_args(args: dict[str, Any], spec: _CommandConfigSpec) -> None:
+    spec.validate(args)
+
+
+def _arg_reference(key: str) -> str:
+    return f"'{key}' (--{key.replace('_', '-')})"
+
+
+def _require_config_value(args: dict[str, Any], key: str) -> None:
+    value = args.get(key, argparse.SUPPRESS)
+    if value is argparse.SUPPRESS or value is None:
+        raise ValueError(
+            f"Missing required value for {_arg_reference(key)}. "
+            f"Provide --{key.replace('_', '-')} or set it in a precision-squad config file "
+            f"at {format_config_search_locations()} under the active command's discovery root."
+        )
+    if isinstance(value, str) and not value.strip():
+        raise ValueError(
+            f"Missing required value for {_arg_reference(key)}. "
+            f"Provide --{key.replace('_', '-')} or set it in a precision-squad config file "
+            f"at {format_config_search_locations()} under the active command's discovery root."
+        )
+
+
+def _normalize_optional_str_arg(args: dict[str, Any], key: str) -> None:
+    value = args.get(key)
+    if value is None:
+        return
+    args[key] = _config_str(value, key=key)
+
+
+def _normalize_optional_path_arg(args: dict[str, Any], key: str) -> None:
+    value = args.get(key)
+    if value is None:
+        return
+    args[key] = _config_str(value, key=key)
+
+
+def _config_str(value: Any, *, key: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Invalid value for {_arg_reference(key)}: expected a non-empty string")
+    return value
+
+
+def _validate_repair_agent(value: Any) -> str:
+    repair_agent = _config_str(value, key="repair_agent")
+    if repair_agent not in _REPAIR_AGENT_CHOICES:
+        expected = ", ".join(_REPAIR_AGENT_CHOICES)
+        raise ValueError(
+            f"Invalid value for {_arg_reference('repair_agent')}: "
+            f"{repair_agent!r}. Expected one of: {expected}"
+        )
+    return repair_agent
+
+
+def _coerce_bool(value: Any, *, key: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"Invalid value for {_arg_reference(key)}: expected a boolean")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI and return a process exit code."""
     load_local_env(Path(__file__).resolve().parent.parent.parent)
     parser = build_parser()
-    args = parser.parse_args(list(argv) if argv is not None else None)
-
-    handler = getattr(args, "handler", None)
-    if handler is None:
-        parser.print_help()
-        return 0
-
     try:
+        args = _resolve_cli_args(parser, argv)
+        handler = getattr(args, "handler", None)
+        if handler is None:
+            parser.print_help()
+            return 0
         return handler(args)
     except (GitHubClientError, NotImplementedError, ValueError) as exc:
         print(str(exc), file=sys.stderr)

--- a/src/precision_squad/config.py
+++ b/src/precision_squad/config.py
@@ -1,0 +1,229 @@
+"""Config file support for precision-squad CLI."""
+
+from __future__ import annotations
+
+import argparse
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+ConfigTable = tuple[str, ...]
+
+_CONFIG_CANDIDATES = (
+    Path(".precision-squad.toml"),
+    Path(".precision-squad") / "precision-squad.toml",
+)
+
+_PATH_LIKE_KEYS = frozenset({"approved_plan_path", "project_root", "repo_path", "runs_dir"})
+
+
+def config_search_locations(start_dir: Path | None = None) -> tuple[Path, ...]:
+    """Return supported config search locations relative to ``start_dir``."""
+    search_root = (start_dir or Path.cwd()).resolve()
+    return tuple(search_root / relative_path for relative_path in _CONFIG_CANDIDATES)
+
+
+def format_config_search_locations() -> str:
+    """Return supported config locations for user-facing messages."""
+    display_paths = tuple(f"./{path.as_posix()}" for path in _CONFIG_CANDIDATES)
+    return f"{display_paths[0]} or {display_paths[1]}"
+
+
+def load_config(start_dir: Path | None = None) -> dict[str, Any]:
+    """Return raw config file values, or an empty dict if no file is found."""
+    config_path = _find_config_path(start_dir)
+    if config_path is None:
+        return {}
+    return _parse_toml(config_path)
+
+
+def load_command_config(
+    *,
+    start_dir: Path | None = None,
+    table: ConfigTable,
+    supported_tables: Mapping[ConfigTable, frozenset[str]],
+) -> dict[str, Any]:
+    """Load, validate, and return one command table from the config file."""
+    config_path = _find_config_path(start_dir)
+    if config_path is None:
+        return {}
+
+    config = _parse_toml(config_path)
+    _validate_config_schema(config, path=config_path, supported_tables=supported_tables)
+
+    return _resolve_relative_paths(
+        _lookup_table(config, table),
+        base_dir=config_path.parent,
+    )
+
+
+def _find_config_path(start_dir: Path | None = None) -> Path | None:
+    for candidate in config_search_locations(start_dir):
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def _parse_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file and return the top-level table as a dict."""
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Invalid config file format in {path}: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"Unable to read config file {path}: {exc}") from exc
+
+
+def _validate_config_schema(
+    config: Mapping[str, Any],
+    *,
+    path: Path,
+    supported_tables: Mapping[ConfigTable, frozenset[str]],
+) -> None:
+    supported_sections = _format_supported_tables(supported_tables)
+
+    for key, value in config.items():
+        if not isinstance(value, Mapping):
+            raise ValueError(
+                f"Unsupported top-level config key {key!r} in {path}. "
+                f"Use command tables {supported_sections}."
+            )
+
+        prefix = (key,)
+        if not _has_matching_table(prefix, supported_tables):
+            raise ValueError(
+                f"Unknown config section {_format_table(prefix)} in {path}. "
+                f"Supported sections: {supported_sections}."
+            )
+
+        _validate_section(
+            value,
+            prefix=prefix,
+            path=path,
+            supported_tables=supported_tables,
+        )
+
+
+def _validate_section(
+    section: Mapping[str, Any],
+    *,
+    prefix: ConfigTable,
+    path: Path,
+    supported_tables: Mapping[ConfigTable, frozenset[str]],
+) -> None:
+    supported_sections = _format_supported_tables(supported_tables)
+    allowed_keys = supported_tables.get(prefix)
+
+    if allowed_keys is None:
+        if not section:
+            raise ValueError(
+                f"Unknown config section {_format_table(prefix)} in {path}. "
+                f"Supported sections: {supported_sections}."
+            )
+
+        expected_children = tuple(
+            sorted(
+                {
+                    table[len(prefix)]
+                    for table in supported_tables
+                    if len(table) > len(prefix) and table[: len(prefix)] == prefix
+                }
+            )
+        )
+        expected_tables = ", ".join(_format_table(prefix + (child,)) for child in expected_children)
+
+        for key, value in section.items():
+            child_prefix = prefix + (key,)
+            if not isinstance(value, Mapping):
+                raise ValueError(
+                    f"Unsupported config key {key!r} in section {_format_table(prefix)} in {path}. "
+                    f"Use nested command tables {expected_tables}."
+                )
+            if not _has_matching_table(child_prefix, supported_tables):
+                raise ValueError(
+                    f"Unknown config section {_format_table(child_prefix)} in {path}. "
+                    f"Supported sections: {supported_sections}."
+                )
+            _validate_section(
+                value,
+                prefix=child_prefix,
+                path=path,
+                supported_tables=supported_tables,
+            )
+        return
+
+    for key, value in section.items():
+        if isinstance(value, Mapping):
+            child_prefix = prefix + (key,)
+            raise ValueError(
+                f"Unknown config section {_format_table(child_prefix)} in {path}. "
+                f"Supported sections: {supported_sections}."
+            )
+        if key not in allowed_keys:
+            raise ValueError(
+                f"Unknown config key {key!r} in section {_format_table(prefix)} in {path}."
+            )
+
+
+def _has_matching_table(
+    prefix: ConfigTable,
+    supported_tables: Mapping[ConfigTable, frozenset[str]],
+) -> bool:
+    return any(table[: len(prefix)] == prefix for table in supported_tables)
+
+
+def _lookup_table(config: Mapping[str, Any], table: ConfigTable) -> dict[str, Any]:
+    node: Any = config
+    for segment in table:
+        if not isinstance(node, Mapping):
+            return {}
+        node = node.get(segment)
+        if node is None:
+            return {}
+
+    if not isinstance(node, Mapping):
+        return {}
+
+    return dict(node)
+
+
+def _resolve_relative_paths(section: dict[str, Any], *, base_dir: Path) -> dict[str, Any]:
+    resolved = dict(section)
+    for key in _PATH_LIKE_KEYS:
+        value = resolved.get(key)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        path = Path(value)
+        if path.is_absolute():
+            continue
+        resolved[key] = str((base_dir / path).resolve())
+    return resolved
+
+
+def _format_supported_tables(supported_tables: Mapping[ConfigTable, frozenset[str]]) -> str:
+    return ", ".join(_format_table(table) for table in supported_tables)
+
+
+def _format_table(table: ConfigTable) -> str:
+    return f"[{'.'.join(table)}]"
+
+
+def merge_config_into_args(
+    config: dict[str, Any],
+    args: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge config file values into CLI args.
+
+    CLI args take precedence. Values absent from the CLI namespace are filled
+    from the config file.
+    """
+    merged = dict(args)
+    for key, config_value in config.items():
+        if key not in merged:
+            continue
+        current = merged[key]
+        if current is argparse.SUPPRESS:
+            merged[key] = config_value
+    return merged

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,14 +10,20 @@ import pytest
 from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
 from precision_squad.cli import main
+from precision_squad.coordinator import RepairIssueReport
 from precision_squad.models import (
     ApprovedPlan,
+    EvaluationResult,
     ExecutionResult,
     GitHubIssue,
+    GovernanceVerdict,
     IssueAssessment,
     IssueIntake,
     IssueReference,
     PostPublishReviewResult,
+    PublishPlan,
+    PublishResult,
+    RunRecord,
 )
 
 
@@ -53,6 +59,29 @@ def test_install_skill_refuses_to_overwrite_without_force(tmp_path: Path) -> Non
     skill_path.write_text("existing\n", encoding="utf-8")
 
     status = main(["install-skill", "--project-root", str(tmp_path)])
+
+    assert status == 1
+    assert skill_path.read_text(encoding="utf-8") == "existing\n"
+
+
+def test_install_skill_no_force_overrides_true_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    skill_path = project_root / "SKILL.md"
+    skill_path.write_text("existing\n", encoding="utf-8")
+    (tmp_path / ".precision-squad.toml").write_text(
+        (
+            "[install-skill]\n"
+            f'project_root = "{project_root.as_posix()}"\n'
+            "force = true\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["install-skill", "--no-force"])
 
     assert status == 1
     assert skill_path.read_text(encoding="utf-8") == "existing\n"
@@ -1258,6 +1287,577 @@ def test_publish_run_retries_stale_rejected_post_publish_review(
     assert "Post-Publish Review: approved" in captured.out
     assert review_payload["status"] == "approved"
     assert review_payload["pull_head_sha"] == "new-sha"
+
+
+def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Config file values are used when CLI args are not provided."""
+    repo_path = tmp_path / "repo-from-config"
+    runs_dir = tmp_path / "runs-from-config"
+    config_file = tmp_path / ".precision-squad.toml"
+    config_file.write_text(
+        (
+            "[repair.issue]\n"
+            f'repo_path = "{repo_path.as_posix()}"\n'
+            f'runs_dir = "{runs_dir.as_posix()}"\n'
+            'repair_agent = "none"\n'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Example issue",
+            body="Example body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Example summary",
+        problem_statement="Example problem",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    captured_params: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured_params["repo_path"] = params.repo_path
+        captured_params["runs_dir"] = params.runs_dir
+        captured_params["repair_agent"] = params.repair_agent
+        return RepairIssueReport(
+            intake=intake,
+            run_record=RunRecord(
+                run_id="run-1",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs-from-config" / "run-1"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="Stub execution completed.",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(
+                status="success",
+                summary="Stub evaluation completed.",
+                detail_codes=(),
+            ),
+            governance_verdict=GovernanceVerdict(
+                status="approved",
+                summary="Approved",
+                reason_codes=(),
+            ),
+            publish_plan=PublishPlan(
+                status="draft_pr",
+                title="title",
+                body="body",
+                reason_codes=(),
+            ),
+            publish_result=PublishResult(
+                status="dry_run",
+                target="draft_pr",
+                summary="dry run",
+                url=None,
+            ),
+            repair_result=None,
+            qa_result=None,
+            post_publish_review_result=None,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(["repair", "issue", "owner/repo#1"])
+
+    assert status == 0
+    assert captured_params["repo_path"] == repo_path
+    assert captured_params["runs_dir"] == runs_dir
+    assert captured_params["repair_agent"] == "none"
+
+
+def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_file = tmp_path / ".precision-squad.toml"
+    config_file.write_text(
+        (
+            "[repair.issue]\n"
+            'repo_path = "/from/config"\n'
+            'runs_dir = "/config/runs"\n'
+            'repair_agent = "none"\n'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Example issue",
+            body="Example body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Example summary",
+        problem_statement="Example problem",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    captured_params: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured_params["repo_path"] = params.repo_path
+        captured_params["runs_dir"] = params.runs_dir
+        captured_params["repair_agent"] = params.repair_agent
+        return RepairIssueReport(
+            intake=intake,
+            run_record=RunRecord(
+                run_id="run-1",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs" / "run-1"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="Stub execution completed.",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(
+                status="success",
+                summary="Stub evaluation completed.",
+                detail_codes=(),
+            ),
+            governance_verdict=GovernanceVerdict(
+                status="approved",
+                summary="Approved",
+                reason_codes=(),
+            ),
+            publish_plan=PublishPlan(
+                status="draft_pr",
+                title="title",
+                body="body",
+                reason_codes=(),
+            ),
+            publish_result=PublishResult(
+                status="dry_run",
+                target="draft_pr",
+                summary="dry run",
+                url=None,
+            ),
+            repair_result=None,
+            qa_result=None,
+            post_publish_review_result=None,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo-from-cli"),
+            "--runs-dir",
+            str(tmp_path / "runs-from-cli"),
+            "--repair-agent",
+            "opencode",
+        ]
+    )
+
+    assert status == 0
+    assert captured_params["repo_path"] == tmp_path / "repo-from-cli"
+    assert captured_params["runs_dir"] == tmp_path / "runs-from-cli"
+    assert captured_params["repair_agent"] == "opencode"
+
+
+def test_invalid_config_file_format_returns_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    (tmp_path / ".precision-squad.toml").write_text("this is not valid toml [[[", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["repair", "issue", "owner/repo#1"])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Invalid config file format" in captured.err
+
+
+def test_empty_parent_namespace_config_returns_schema_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    (tmp_path / ".precision-squad.toml").write_text("[repair]\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["repair", "issue", "owner/repo#1"])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Unknown config section [repair]" in captured.err
+
+
+def test_invalid_config_repair_agent_returns_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        '[repair.issue]\nrepo_path = "/tmp/repo"\nrepair_agent = "openai"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["repair", "issue", "owner/repo#1"])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Invalid value for 'repair_agent' (--repair-agent)" in captured.err
+
+
+def test_invalid_cli_repair_agent_is_rejected_by_parser(capsys, tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "repair",
+                "issue",
+                "owner/repo#1",
+                "--repo-path",
+                str(tmp_path),
+                "--repair-agent",
+                "openai",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "invalid choice" in captured.err
+    assert "opencode" in captured.err
+    assert "vercel-ai" in captured.err
+
+
+def test_missing_repo_path_error_lists_supported_config_locations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["repair", "issue", "owner/repo#1"])
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "./.precision-squad.toml" in captured.err
+    assert "./.precision-squad/precision-squad.toml" in captured.err
+    assert "active command's discovery root" in captured.err
+
+
+def test_publish_run_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    runs_dir = tmp_path / "runs-from-config"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (tmp_path / ".precision-squad.toml").write_text(
+        f'[publish.run]\nruns_dir = "{runs_dir.as_posix()}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    (run_dir / "issue-intake.json").write_text(
+        json.dumps(
+            {
+                "issue": {
+                    "reference": {"owner": "owner", "repo": "repo", "number": 1},
+                    "title": "Issue",
+                    "body": "Body",
+                    "labels": [],
+                    "html_url": "https://github.com/owner/repo/issues/1",
+                },
+                "summary": "Summary",
+                "problem_statement": "Problem",
+                "assessment": {"status": "runnable", "reason_codes": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "publish-plan.json").write_text(
+        json.dumps({"status": "draft_pr", "title": "title", "body": "body", "reason_codes": []}),
+        encoding="utf-8",
+    )
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "publish-result.json").write_text(
+        json.dumps({"status": "dry_run", "target": "draft_pr", "summary": "dry run"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.cli.execute_publish_plan",
+        lambda intake, plan, publish, run_dir: PublishResult(
+            status="dry_run", target=plan.status, summary="dry run", url=None
+        ),
+    )
+    monkeypatch.setattr("precision_squad.cli._run_post_publish_review_if_needed", lambda **kwargs: None)
+
+    status = main(["publish", "run", "run-123"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Run ID: run-123" in captured.out
+
+
+def test_install_skill_uses_config_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (tmp_path / ".precision-squad.toml").write_text(
+        f'[install-skill]\nproject_root = "{project_root.as_posix()}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    status = main(["install-skill"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert (project_root / "SKILL.md").exists()
+    assert "Installed skill:" in captured.out
+
+
+def test_repair_issue_no_publish_cli_overrides_true_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo-from-config"
+    runs_dir = tmp_path / "runs-from-config"
+    (tmp_path / ".precision-squad.toml").write_text(
+        (
+            "[repair.issue]\n"
+            f'repo_path = "{repo_path.as_posix()}"\n'
+            f'runs_dir = "{runs_dir.as_posix()}"\n'
+            "publish = true\n"
+            'repair_agent = "none"\n'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Example issue",
+            body="Example body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Example summary",
+        problem_statement="Example problem",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    captured_params: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured_params["publish"] = params.publish
+        return RepairIssueReport(
+            intake=intake,
+            run_record=RunRecord(
+                run_id="run-1",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs-from-config" / "run-1"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="Stub execution completed.",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(
+                status="success",
+                summary="Stub evaluation completed.",
+                detail_codes=(),
+            ),
+            governance_verdict=GovernanceVerdict(
+                status="approved",
+                summary="Approved",
+                reason_codes=(),
+            ),
+            publish_plan=PublishPlan(
+                status="draft_pr",
+                title="title",
+                body="body",
+                reason_codes=(),
+            ),
+            publish_result=PublishResult(
+                status="dry_run",
+                target="draft_pr",
+                summary="dry run",
+                url=None,
+            ),
+            repair_result=None,
+            qa_result=None,
+            post_publish_review_result=None,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(["repair", "issue", "owner/repo#1", "--no-publish"])
+
+    assert status == 0
+    assert captured_params["publish"] is False
+
+
+def test_repair_issue_uses_explicit_repo_path_as_config_discovery_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_path = tmp_path / "target-repo"
+    repo_path.mkdir()
+    (workspace / ".precision-squad.toml").write_text(
+        (
+            "[repair.issue]\n"
+            f'runs_dir = "{(workspace / "runs-from-cwd").as_posix()}"\n'
+            'repair_agent = "vercel-ai"\n'
+        ),
+        encoding="utf-8",
+    )
+    (repo_path / ".precision-squad.toml").write_text(
+        (
+            "[repair.issue]\n"
+            f'runs_dir = "{(repo_path / "runs-from-repo").as_posix()}"\n'
+            'repair_agent = "none"\n'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Example issue",
+            body="Example body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Example summary",
+        problem_statement="Example problem",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    captured_params: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured_params["runs_dir"] = params.runs_dir
+        captured_params["repair_agent"] = params.repair_agent
+        return RepairIssueReport(
+            intake=intake,
+            run_record=RunRecord(
+                run_id="run-1",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(workspace / "runs-from-cwd" / "run-1"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="Stub execution completed.",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(
+                status="success",
+                summary="Stub evaluation completed.",
+                detail_codes=(),
+            ),
+            governance_verdict=GovernanceVerdict(
+                status="approved",
+                summary="Approved",
+                reason_codes=(),
+            ),
+            publish_plan=PublishPlan(
+                status="draft_pr",
+                title="title",
+                body="body",
+                reason_codes=(),
+            ),
+            publish_result=PublishResult(
+                status="dry_run",
+                target="draft_pr",
+                summary="dry run",
+                url=None,
+            ),
+            repair_result=None,
+            qa_result=None,
+            post_publish_review_result=None,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(repo_path),
+        ]
+    )
+
+    assert status == 0
+    assert captured_params["runs_dir"] == repo_path / "runs-from-repo"
+    assert captured_params["repair_agent"] == "none"
+
+
+def test_install_skill_uses_explicit_project_root_as_config_discovery_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    skill_path = project_root / "SKILL.md"
+    skill_path.write_text("existing\n", encoding="utf-8")
+
+    (project_root / ".precision-squad.toml").write_text(
+        "[install-skill]\nforce = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    status = main(["install-skill", "--project-root", str(project_root)])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert skill_path.exists()
+    assert "Installed skill:" in captured.out
 
 
 def test_run_issue_with_approved_plan_path_persists_approved_plan(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,292 @@
+"""Tests for config file support."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from precision_squad.config import (
+    config_search_locations,
+    format_config_search_locations,
+    load_command_config,
+    load_config,
+    merge_config_into_args,
+)
+
+
+SUPPORTED_TABLES = {
+    ("repair", "issue"): frozenset(
+        {
+            "runs_dir",
+            "publish",
+            "repo_path",
+            "repair_agent",
+            "repair_model",
+            "review_model",
+            "approved_plan_path",
+        }
+    ),
+    ("publish", "run"): frozenset({"runs_dir", "review_model"}),
+    ("install-skill",): frozenset({"project_root", "force"}),
+}
+
+
+def test_load_config_returns_empty_when_no_file(tmp_path: Path) -> None:
+    result = load_config(tmp_path)
+    assert result == {}
+
+
+def test_load_config_from_toml_file(tmp_path: Path) -> None:
+    config_file = tmp_path / ".precision-squad.toml"
+    config_file.write_text(
+        "[repair.issue]\nrepo_path = \"/tmp/repo\"\nrepair_agent = \"opencode\"\npublish = true\n",
+        encoding="utf-8",
+    )
+    result = load_config(tmp_path)
+    assert result == {
+        "repair": {
+            "issue": {
+                "repo_path": "/tmp/repo",
+                "repair_agent": "opencode",
+                "publish": True,
+            }
+        }
+    }
+
+
+def test_load_command_config_from_root_file(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair.issue]\nrepo_path = \"repo\"\nruns_dir = \"runs\"\n",
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("repair", "issue"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert result == {
+        "repo_path": str((tmp_path / "repo").resolve()),
+        "runs_dir": str((tmp_path / "runs").resolve()),
+    }
+
+
+def test_load_command_config_from_dot_precision_squad_directory(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".precision-squad"
+    config_dir.mkdir()
+    config_file = config_dir / "precision-squad.toml"
+    config_file.write_text(
+        "[publish.run]\nruns_dir = \"runs\"\n",
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("publish", "run"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert result["runs_dir"] == str((config_dir / "runs").resolve())
+
+
+def test_load_command_config_prefers_project_root_file(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair.issue]\nrepo_path = \"root-repo\"\n",
+        encoding="utf-8",
+    )
+    config_dir = tmp_path / ".precision-squad"
+    config_dir.mkdir()
+    (config_dir / "precision-squad.toml").write_text(
+        "[repair.issue]\nrepo_path = \"nested-repo\"\n",
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("repair", "issue"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert result["repo_path"] == str((tmp_path / "root-repo").resolve())
+
+
+def test_config_search_locations_match_documented_order(tmp_path: Path) -> None:
+    assert config_search_locations(tmp_path) == (
+        tmp_path.resolve() / ".precision-squad.toml",
+        tmp_path.resolve() / ".precision-squad" / "precision-squad.toml",
+    )
+
+
+def test_format_config_search_locations_lists_supported_paths() -> None:
+    assert format_config_search_locations() == (
+        "./.precision-squad.toml or ./.precision-squad/precision-squad.toml"
+    )
+
+
+def test_load_config_invalid_toml(tmp_path: Path) -> None:
+    config_file = tmp_path / ".precision-squad.toml"
+    config_file.write_text("this is not valid toml [[[", encoding="utf-8")
+    with pytest.raises(ValueError, match="Invalid config file format"):
+        load_config(tmp_path)
+
+
+def test_load_command_config_rejects_top_level_scalar_keys(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        'repo_path = "."\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported top-level config key"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
+def test_load_command_config_rejects_unknown_top_level_sections(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[unknown.section]\nvalue = true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown config section \[unknown\]"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
+def test_load_command_config_rejects_unknown_nested_sections(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair.unknown]\nrepo_path = \"repo\"\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown config section \[repair.unknown\]"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
+def test_load_command_config_rejects_empty_parent_namespace_sections(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown config section \[repair\]"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
+def test_load_command_config_rejects_unknown_keys(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair.issue]\nrepo_path = \"repo\"\nretry_from = \"run-123\"\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unknown config key 'retry_from'"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
+def test_load_command_config_returns_only_active_command_table(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        (
+            "[repair.issue]\nrepo_path = \"repo\"\n"
+            "[publish.run]\nruns_dir = \"runs\"\n"
+            "[install-skill]\nproject_root = \"project\"\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("publish", "run"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert result == {"runs_dir": str((tmp_path / "runs").resolve())}
+
+
+def test_load_command_config_preserves_absolute_paths(tmp_path: Path) -> None:
+    absolute_repo = (tmp_path / "external-repo").resolve()
+    (tmp_path / ".precision-squad.toml").write_text(
+        f'[repair.issue]\nrepo_path = "{absolute_repo.as_posix()}"\n',
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("repair", "issue"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert Path(result["repo_path"]) == absolute_repo
+
+
+def test_load_command_config_resolves_approved_plan_path_relative_to_config_file(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".precision-squad"
+    config_dir.mkdir()
+    (config_dir / "precision-squad.toml").write_text(
+        '[repair.issue]\napproved_plan_path = "plans/approved-plan.json"\n',
+        encoding="utf-8",
+    )
+
+    result = load_command_config(
+        start_dir=tmp_path,
+        table=("repair", "issue"),
+        supported_tables=SUPPORTED_TABLES,
+    )
+
+    assert result["approved_plan_path"] == str(
+        (config_dir / "plans" / "approved-plan.json").resolve()
+    )
+
+
+def test_merge_config_fills_suppressed_values() -> None:
+    config = {"repo_path": "/from/config", "repair_model": "gpt-4"}
+    args = {
+        "repo_path": argparse.SUPPRESS,
+        "repair_model": argparse.SUPPRESS,
+        "publish": False,
+    }
+    merged = merge_config_into_args(config, args)
+    assert merged["repo_path"] == "/from/config"
+    assert merged["repair_model"] == "gpt-4"
+
+
+def test_merge_config_does_not_override_cli_values() -> None:
+    config = {"repo_path": "/from/config"}
+    args = {"repo_path": "/from/cli"}
+    merged = merge_config_into_args(config, args)
+    assert merged["repo_path"] == "/from/cli"
+
+
+def test_merge_config_does_not_override_present_boolean_values() -> None:
+    config = {"publish": True}
+    args = {"publish": False}
+    merged = merge_config_into_args(config, args)
+    assert merged["publish"] is False
+
+
+def test_merge_config_ignores_unknown_keys() -> None:
+    config = {"unknown_key": "value"}
+    args = {"repo_path": "/cli"}
+    merged = merge_config_into_args(config, args)
+    assert merged == {"repo_path": "/cli"}


### PR DESCRIPTION
## Summary
- align issue #12 config discovery with the approved command-scoped contract
- enforce `CLI > config > built-in defaults` across `repair issue`, `publish run`, and `install-skill`
- validate command-shaped TOML config files and document the supported keys and locations

## Validation
- `python -m pytest tests/test_config.py tests/test_cli.py -k "config or install_skill_uses_config_defaults or publish_run_uses_config_defaults or invalid_cli_repair_agent or no_publish_cli_overrides_true_config or explicit_repo_path_as_config_discovery_root or explicit_project_root_as_config_discovery_root"`
- `python -m pyright src/precision_squad/config.py src/precision_squad/cli.py tests/test_config.py tests/test_cli.py`

## Notes
- This PR is stacked on #63 because the current local implementation depends on the approved-plan CLI seam added there.
- `retry_from` remains CLI-only for issue #12.

Closes #12