### PR TITLE
Docs #61: Clarify issue-scoped PR workflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,13 @@ Attached to `ExecutionResult`. Values:
 
 Quality tag is informational — governance verdict (approved/blocked) is what gates publishing.
 
+## Issue-Driven Workflow
+
+- Work is defined and tracked through GitHub issues.
+- Each implementation PR should stay scoped to one issue.
+- A PR branch should contain only the commits and file changes needed for that issue.
+- Unrelated fixes, refactors, or follow-on improvements belong in separate issues and separate PRs.
+
 ## Side Issues
 
 When a repair discovers issues unrelated to the primary issue being worked, the repair agent recommends opening separate issues. Structured as a `side_issues` field on `RepairResult`. These are included in the blocked run's publish plan as `follow_up_issue` actions.


### PR DESCRIPTION
## Summary
- make the issue-driven workflow rule explicit in `CONTEXT.md`
- state that each implementation PR should stay scoped to one issue and contain only issue-specific commits and file changes
- document that unrelated fixes and follow-on work belong in separate issues and PRs

Closes #61