### PR TITLE
Fix #56: pass approved-plan artifacts through the CLI

### DIFF
--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -17,11 +17,13 @@ from .executor import DocsFirstExecutor
 from .github_client import GitHubClientError, GitHubWriteClient
 from .intake import load_issue_intake
 from .models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    NamedReference,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -108,6 +110,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Existing run ID to retry from. Increments attempt counter.",
     )
+    issue_parser.add_argument(
+        "--approved-plan-path",
+        default=None,
+        help="Path to an approved-plan.json file to pass to the coordinator.",
+    )
     issue_parser.set_defaults(handler=_repair_issue)
 
     publish_parser = subparsers.add_parser(
@@ -153,6 +160,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _repair_issue(args: argparse.Namespace) -> int:
     intake = load_issue_intake(args.issue_ref)
+    approved_plan: ApprovedPlan | None = None
+    if args.approved_plan_path:
+        approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
     report = RunCoordinator().repair_issue(
         params=RepairIssueParams(
             issue_ref=args.issue_ref,
@@ -163,6 +173,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
             repair_model=args.repair_model,
             review_model=args.review_model,
             retry_from=args.retry_from,
+            approved_plan=approved_plan,
         ),
         intake=intake,
         dependencies=_CliRepairDependencies(),
@@ -477,7 +488,7 @@ def _read_publish_result(run_dir: Path) -> PublishResult | None:
         summary=_as_str(payload["summary"]),
         url=_as_optional_str(payload.get("url")),
         branch_name=_as_optional_str(payload.get("branch_name")),
-        pull_number=_as_optional_int(payload.get("pull_number")),
+        pull_number=_as_optional_int(payload.get("pull_number"]),
     )
 
 
@@ -570,6 +581,60 @@ def _as_bool(value: Any) -> bool:
     if not isinstance(value, bool):
         raise ValueError("Expected boolean value")
     return value
+
+
+def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
+    """Load and validate an ApprovedPlan from a JSON file."""
+    payload = _read_json(path)
+    if "issue_ref" not in payload:
+        raise ValueError("Approved plan is missing required field 'issue_ref'")
+    plan_issue_ref = _as_str(payload.get("issue_ref"))
+    if plan_issue_ref != issue_ref:
+        raise ValueError(
+            f"Approved plan issue_ref '{plan_issue_ref}' does not match CLI issue_ref '{issue_ref}'"
+        )
+    plan_summary = _as_str(payload.get("plan_summary"))
+    if not plan_summary.strip():
+        raise ValueError("Approved plan is missing a non-empty 'plan_summary'")
+    implementation_steps_raw = payload.get("implementation_steps", [])
+    if not isinstance(implementation_steps_raw, list):
+        raise ValueError("Expected 'implementation_steps' to be a list")
+    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
+    if not implementation_steps:
+        raise ValueError("Approved plan has no implementation steps")
+    named_references_raw = payload.get("named_references", [])
+    if not isinstance(named_references_raw, list):
+        raise ValueError("Expected 'named_references' to be a list")
+    named_refs: list[NamedReference] = []
+    allowed_types = {"file", "interface", "symbol", "example"}
+    for ref in named_references_raw:
+        if isinstance(ref, dict):
+            name = str(ref.get("name", ""))
+            if not name:
+                raise ValueError("Named reference has empty name")
+            ref_type = ref.get("reference_type", "file")
+            if ref_type not in allowed_types:
+                raise ValueError(
+                    "Named reference has invalid reference_type "
+                    f"'{ref_type}'; expected one of {allowed_types}"
+                )
+            named_refs.append(
+                NamedReference(
+                    name=name,
+                    reference_type=ref_type,
+                    description=str(ref.get("description", "")),
+                )
+            )
+        else:
+            named_refs.append(NamedReference(name=str(ref)))
+    return ApprovedPlan(
+        issue_ref=plan_issue_ref,
+        plan_summary=plan_summary,
+        implementation_steps=implementation_steps,
+        named_references=tuple(named_refs),
+        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
+        approved=bool(payload.get("approved", True)),
+    )
 
 
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -44,6 +44,7 @@ from .repair import (
     run_repair_qa_loop,
     synthesis_artifacts_ready,
 )
+from .run_store import _read_approved_plan as _read_persisted_approved_plan
 
 # Keep a local alias so tests can monkeypatch the shared executor class through this module.
 _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
@@ -585,56 +586,13 @@ def _as_bool(value: Any) -> bool:
 
 def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
     """Load and validate an ApprovedPlan from a JSON file."""
-    payload = _read_json(path)
-    if "issue_ref" not in payload:
-        raise ValueError("Approved plan is missing required field 'issue_ref'")
-    plan_issue_ref = _as_str(payload.get("issue_ref"))
+    plan = _read_persisted_approved_plan(path)
+    plan_issue_ref = plan.issue_ref
     if plan_issue_ref != issue_ref:
         raise ValueError(
             f"Approved plan issue_ref '{plan_issue_ref}' does not match CLI issue_ref '{issue_ref}'"
         )
-    plan_summary = _as_str(payload.get("plan_summary"))
-    if not plan_summary.strip():
-        raise ValueError("Approved plan is missing a non-empty 'plan_summary'")
-    implementation_steps_raw = payload.get("implementation_steps", [])
-    if not isinstance(implementation_steps_raw, list):
-        raise ValueError("Expected 'implementation_steps' to be a list")
-    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
-    if not implementation_steps:
-        raise ValueError("Approved plan has no implementation steps")
-    named_references_raw = payload.get("named_references", [])
-    if not isinstance(named_references_raw, list):
-        raise ValueError("Expected 'named_references' to be a list")
-    named_refs: list[NamedReference] = []
-    allowed_types = {"file", "interface", "symbol", "example"}
-    for ref in named_references_raw:
-        if isinstance(ref, dict):
-            name = str(ref.get("name", ""))
-            if not name:
-                raise ValueError("Named reference has empty name")
-            ref_type = ref.get("reference_type", "file")
-            if ref_type not in allowed_types:
-                raise ValueError(
-                    "Named reference has invalid reference_type "
-                    f"'{ref_type}'; expected one of {allowed_types}"
-                )
-            named_refs.append(
-                NamedReference(
-                    name=name,
-                    reference_type=ref_type,
-                    description=str(ref.get("description", "")),
-                )
-            )
-        else:
-            named_refs.append(NamedReference(name=str(ref)))
-    return ApprovedPlan(
-        issue_ref=plan_issue_ref,
-        plan_summary=plan_summary,
-        implementation_steps=implementation_steps,
-        named_references=tuple(named_refs),
-        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
-        approved=bool(payload.get("approved", True)),
-    )
+    return plan
 
 
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -488,7 +488,7 @@ def _read_publish_result(run_dir: Path) -> PublishResult | None:
         summary=_as_str(payload["summary"]),
         url=_as_optional_str(payload.get("url")),
         branch_name=_as_optional_str(payload.get("branch_name")),
-        pull_number=_as_optional_int(payload.get("pull_number"]),
+        pull_number=_as_optional_int(payload.get("pull_number")),
     )
 
 
@@ -741,6 +741,8 @@ def _post_publish_review_is_stale(
     if head_sha is None:
         return False
     return head_sha != review_result.pull_head_sha
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI and return a process exit code."""
     load_local_env(Path(__file__).resolve().parent.parent.parent)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -10,6 +10,7 @@ from .executor import DocsFirstExecutor
 from .governance import apply_governance, evaluate_run
 from .intake import IssueIntake, is_docs_remediation_issue
 from .models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
@@ -136,6 +137,7 @@ class RepairIssueParams:
     repair_model: str | None
     review_model: str | None
     retry_from: str | None = None
+    approved_plan: ApprovedPlan | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,10 +187,12 @@ class RunCoordinator:
 
         # Handle retry logic
         attempt = 1
+        previous_run_dir: Path | None = None
         if params.retry_from is not None:
             try:
                 previous_record = store.load_run(params.retry_from)
                 attempt = previous_record.attempt + 1
+                previous_run_dir = Path(previous_record.run_dir).resolve()
             except ValueError:
                 return RepairIssueReport(
                     intake=intake,
@@ -221,6 +225,14 @@ class RunCoordinator:
         if attempt > 1:
             record = record.with_attempt(attempt)
             store.write_run_record(record)
+
+        # Persist the approved plan early so later stages can load it.
+        # On retry, carry it forward from the previous run unless overridden.
+        effective_approved_plan = params.approved_plan
+        if effective_approved_plan is None and previous_run_dir is not None:
+            effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
+        if effective_approved_plan is not None:
+            store.write_approved_plan(run_dir, effective_approved_plan)
 
         if intake.assessment.status == "blocked":
             verdict = apply_governance(intake, execution_result=None, evaluation_result=None)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -207,6 +207,24 @@ class RunCoordinator:
                     exit_code=3,
                 )
 
+        effective_approved_plan = params.approved_plan
+        if effective_approved_plan is None and previous_run_dir is not None:
+            try:
+                effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
+            except ValueError:
+                return RepairIssueReport(
+                    intake=intake,
+                    run_record=RunRecord(
+                        run_id="",
+                        issue_ref=params.issue_ref,
+                        status="blocked",
+                        created_at="",
+                        updated_at="",
+                        run_dir="",
+                    ),
+                    exit_code=3,
+                )
+
         # Check if escalated (max 3 attempts exceeded)
         if attempt > 3:
             return self._handle_escalation(
@@ -227,10 +245,6 @@ class RunCoordinator:
             store.write_run_record(record)
 
         # Persist the approved plan early so later stages can load it.
-        # On retry, carry it forward from the previous run unless overridden.
-        effective_approved_plan = params.approved_plan
-        if effective_approved_plan is None and previous_run_dir is not None:
-            effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
         if effective_approved_plan is not None:
             store.write_approved_plan(run_dir, effective_approved_plan)
 

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -208,6 +208,27 @@ class ReviewAgentResult:
 
 
 @dataclass(frozen=True, slots=True)
+class NamedReference:
+    """A named reference (file path, interface, symbol, or example) from the approved plan."""
+
+    name: str
+    reference_type: Literal["file", "interface", "symbol", "example"] = "file"
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovedPlan:
+    """Canonical approved-plan artifact for downstream stage consumption."""
+
+    issue_ref: str
+    plan_summary: str
+    implementation_steps: tuple[str, ...]
+    named_references: tuple[NamedReference, ...]
+    retrieval_surface_summary: str
+    approved: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class PostPublishReviewResult:
     """Combined result for post-publish PR review."""
 

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -13,6 +13,7 @@ from .github_client import GitHubWriteClient
 from .json_events import extract_json_events
 from .models import IssueIntake, PostPublishReviewResult, ReviewAgentResult, RunRecord
 from .opencode_model import resolve_opencode_model
+from .run_store import RunStore
 
 PULL_NUMBER_PATTERN = re.compile(r"/pull/(?P<number>[0-9]+)$")
 
@@ -49,13 +50,23 @@ class OpenCodePrReviewAgent:
         stdout_path = run_dir / f"{prefix}.stdout.log"
         stderr_path = run_dir / f"{prefix}.stderr.log"
         transcript_path = run_dir / f"{prefix}-transcript.json"
-        prompt = _build_review_prompt(
-            role=self.role,
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            pull_request_url=pull_request_url,
-        )
+        try:
+            prompt = _build_review_prompt(
+                role=self.role,
+                intake=intake,
+                run_record=run_record,
+                run_dir=run_dir,
+                pull_request_url=pull_request_url,
+            )
+        except ValueError as exc:
+            return ReviewAgentResult(
+                role=self.role,
+                status="failed_infra",
+                summary=str(exc),
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                transcript_path=str(transcript_path),
+            )
         command = [
             self.binary,
             "run",
@@ -217,18 +228,58 @@ def _build_review_prompt(
     run_dir: Path,
     pull_request_url: str,
 ) -> str:
+    approved_plan = RunStore.load_approved_plan_text(
+        run_dir,
+        include_named_references=True,
+    )
+    if not approved_plan or not approved_plan.strip():
+        raise ValueError("Review context pack is missing required approved plan")
+    pr_diff = _fetch_pr_diff(
+        intake.issue.reference.owner,
+        intake.issue.reference.repo,
+        pull_request_url,
+    )
+    if not pr_diff.strip():
+        raise ValueError("Review context pack is missing required PR diff")
     return "\n".join(
         [
             f"Review role: {role}",
             f"Run ID: {run_record.run_id}",
             f"Issue: {intake.issue.reference}",
             f"PR: {pull_request_url}",
+            "",
+            "## Approved Plan",
+            approved_plan,
+            "",
+            "## PR Diff",
+            pr_diff,
+            "",
             "Review the published PR and respond with exactly one JSON object.",
             'Use the shape: {"status":"approved|rejected","summary":"...","feedback":["..."]}',
             "If you reject, feedback must contain concrete required changes.",
             "Do not include markdown fences.",
         ]
     )
+
+
+def _fetch_pr_diff(owner: str, repo: str, pull_request_url: str) -> str:
+    match = PULL_NUMBER_PATTERN.search(pull_request_url.strip())
+    if match is None:
+        return ""
+    pull_number = int(match.group("number"))
+    payload = GitHubWriteClient.from_env().get_pull_request(owner, repo, pull_number)
+    diff_url = payload.get("diff_url")
+    if not isinstance(diff_url, str) or not diff_url:
+        return ""
+    completed = subprocess.run(
+        ["gh", "api", diff_url, "-H", "Accept: application/vnd.github.v3.diff"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout
 
 
 def _parse_review_output(events: list[dict]) -> dict[str, Any] | None:

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -95,6 +95,17 @@ class RunStore:
             return None
         return _read_approved_plan(plan_path)
 
+    @staticmethod
+    def load_approved_plan_text(
+        run_dir: Path,
+        include_named_references: bool = False,
+    ) -> str | None:
+        """Load the approved plan and render it as markdown text, or None if not present."""
+        plan = RunStore.load_approved_plan(run_dir)
+        if plan is None:
+            return None
+        return render_approved_plan_text(plan, include_named_references=include_named_references)
+
     def write_evaluation_result(self, run_dir: Path, result: EvaluationResult) -> None:
         self._write_json(run_dir / "evaluation-result.json", result)
 
@@ -186,9 +197,20 @@ def _read_approved_plan(path: Path) -> ApprovedPlan:
     """Read an approved plan from a JSON file."""
     with path.open(encoding="utf-8") as f:
         payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    if "issue_ref" not in payload:
+        raise ValueError("Approved plan is missing required field 'issue_ref'")
+    plan_issue_ref = _require_non_empty_str(payload.get("issue_ref"), field_name="issue_ref")
+    plan_summary = _require_non_empty_str(payload.get("plan_summary"), field_name="plan_summary")
+    implementation_steps = _read_implementation_steps(payload)
+    approved = _read_approved_flag(payload)
+    named_references_raw = payload.get("named_references", [])
+    if not isinstance(named_references_raw, list):
+        raise ValueError("Expected 'named_references' to be a list")
     named_refs: list[NamedReference] = []
     allowed_types = {"file", "interface", "symbol", "example"}
-    for ref in payload.get("named_references", []):
+    for ref in named_references_raw:
         if isinstance(ref, dict):
             name = str(ref.get("name", ""))
             if not name:
@@ -208,10 +230,63 @@ def _read_approved_plan(path: Path) -> ApprovedPlan:
         else:
             named_refs.append(NamedReference(name=str(ref)))
     return ApprovedPlan(
-        issue_ref=str(payload["issue_ref"]),
-        plan_summary=str(payload["plan_summary"]),
-        implementation_steps=tuple(str(step) for step in payload.get("implementation_steps", [])),
+        issue_ref=plan_issue_ref,
+        plan_summary=plan_summary,
+        implementation_steps=implementation_steps,
         named_references=tuple(named_refs),
         retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
-        approved=bool(payload.get("approved", True)),
+        approved=approved,
     )
+
+
+def _require_non_empty_str(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"Approved plan field '{field_name}' must be a string")
+    if not value.strip():
+        raise ValueError(f"Approved plan is missing a non-empty '{field_name}'")
+    return value
+
+
+def _read_implementation_steps(payload: dict[str, object]) -> tuple[str, ...]:
+    implementation_steps_raw = payload.get("implementation_steps", [])
+    if not isinstance(implementation_steps_raw, list):
+        raise ValueError("Expected 'implementation_steps' to be a list")
+    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
+    if not implementation_steps:
+        raise ValueError("Approved plan has no implementation steps")
+    return implementation_steps
+
+
+def _read_approved_flag(payload: dict[str, object]) -> bool:
+    approved_raw = payload.get("approved", True)
+    if not isinstance(approved_raw, bool):
+        raise ValueError("Approved plan field 'approved' must be a boolean")
+    if not approved_raw:
+        raise ValueError("Approved plan must have 'approved': true")
+    return approved_raw
+
+
+def render_approved_plan_text(
+    plan: ApprovedPlan,
+    include_named_references: bool = False,
+) -> str:
+    """Render an ApprovedPlan to markdown text for context packs."""
+    approval_marker = "Approved Plan"
+    lines = [
+        f"# {approval_marker}: {plan.issue_ref}",
+        "",
+        plan.plan_summary,
+        "",
+        "## Implementation Steps",
+    ]
+    for step in plan.implementation_steps:
+        lines.append(f"- {step}")
+    if plan.retrieval_surface_summary:
+        lines.extend(["", f"**Retrieval Surface:** {plan.retrieval_surface_summary}"])
+    if include_named_references and plan.named_references:
+        lines.extend(["", "## Named References"])
+        for ref in plan.named_references:
+            ref_type_suffix = f" ({ref.reference_type})" if ref.reference_type != "file" else ""
+            desc_suffix = f": {ref.description}" if ref.description else ""
+            lines.append(f"- {ref.name}{ref_type_suffix}{desc_suffix}")
+    return "\n".join(lines)

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -10,10 +10,12 @@ from typing import Literal, cast
 from uuid import uuid4
 
 from .models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
     IssueIntake,
+    NamedReference,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -24,7 +26,8 @@ from .models import (
 )
 
 PersistedArtifact = (
-    EvaluationResult
+    ApprovedPlan
+    | EvaluationResult
     | ExecutionResult
     | GovernanceVerdict
     | IssueIntake
@@ -81,6 +84,16 @@ class RunStore:
 
     def write_execution_result(self, run_dir: Path, result: ExecutionResult) -> None:
         self._write_json(run_dir / "execution-result.json", result)
+
+    def write_approved_plan(self, run_dir: Path, plan: ApprovedPlan) -> None:
+        self._write_json(run_dir / "approved-plan.json", plan)
+
+    @staticmethod
+    def load_approved_plan(run_dir: Path) -> ApprovedPlan | None:
+        plan_path = run_dir / "approved-plan.json"
+        if not plan_path.exists():
+            return None
+        return _read_approved_plan(plan_path)
 
     def write_evaluation_result(self, run_dir: Path, result: EvaluationResult) -> None:
         self._write_json(run_dir / "evaluation-result.json", result)
@@ -166,4 +179,39 @@ def _read_run_record(path: Path) -> RunRecord:
         updated_at=str(payload["updated_at"]),
         run_dir=str(payload["run_dir"]),
         attempt=int(payload.get("attempt", 1)),
+    )
+
+
+def _read_approved_plan(path: Path) -> ApprovedPlan:
+    """Read an approved plan from a JSON file."""
+    with path.open(encoding="utf-8") as f:
+        payload = json.load(f)
+    named_refs: list[NamedReference] = []
+    allowed_types = {"file", "interface", "symbol", "example"}
+    for ref in payload.get("named_references", []):
+        if isinstance(ref, dict):
+            name = str(ref.get("name", ""))
+            if not name:
+                raise ValueError("Named reference has empty name")
+            ref_type = ref.get("reference_type", "file")
+            if ref_type not in allowed_types:
+                raise ValueError(
+                    f"Named reference has invalid reference_type '{ref_type}'; expected one of {allowed_types}"
+                )
+            named_refs.append(
+                NamedReference(
+                    name=name,
+                    reference_type=ref_type,
+                    description=str(ref.get("description", "")),
+                )
+            )
+        else:
+            named_refs.append(NamedReference(name=str(ref)))
+    return ApprovedPlan(
+        issue_ref=str(payload["issue_ref"]),
+        plan_summary=str(payload["plan_summary"]),
+        implementation_steps=tuple(str(step) for step in payload.get("implementation_steps", [])),
+        named_references=tuple(named_refs),
+        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
+        approved=bool(payload.get("approved", True)),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
 from precision_squad.cli import main
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
@@ -1162,3 +1163,329 @@ def test_publish_run_retries_stale_rejected_post_publish_review(
     assert "Post-Publish Review: approved" in captured.out
     assert review_payload["status"] == "approved"
     assert review_payload["pull_head_sha"] == "new-sha"
+
+
+def test_run_issue_with_approved_plan_path_persists_approved_plan(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    monkeypatch.setattr(
+        "precision_squad.cli.DocsFirstExecutor.execute",
+        lambda self, intake, record, run_dir: ExecutionResult(
+            status="completed",
+            executor_name="docs",
+            summary="Stub execution completed.",
+            detail_codes=(),
+        ),
+    )
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add --version flag using click.",
+                "implementation_steps": ["Add click.option('--version')", "Bump __version__"],
+                "named_references": ["src/cli.py"],
+                "retrieval_surface_summary": "src/",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    run_dir_line = next(line for line in captured.out.splitlines() if line.startswith("Run Dir:"))
+    run_dir = Path(run_dir_line.removeprefix("Run Dir:").strip())
+
+    assert status == 0
+    assert (run_dir / "approved-plan.json").exists()
+    plan_payload = json.loads((run_dir / "approved-plan.json").read_text(encoding="utf-8"))
+    assert plan_payload["issue_ref"] == "cracklings3d/markdown-pdf-renderer#9"
+    assert plan_payload["plan_summary"] == "Add --version flag using click."
+    assert plan_payload["implementation_steps"] == [
+        "Add click.option('--version')",
+        "Bump __version__",
+    ]
+
+
+def test_run_issue_with_mismatched_approved_plan_issue_ref_raises(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#99",
+                "plan_summary": "Different issue plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "does not match CLI issue_ref" in captured.err
+
+
+def test_load_approved_plan_rejects_missing_plan_summary(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "non-empty" in captured.err.lower() or "plan_summary" in captured.err.lower()
+
+
+def test_load_approved_plan_rejects_missing_implementation_steps(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "A valid plan",
+                "implementation_steps": [],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "implementation steps" in captured.err.lower()
+
+
+class TestLoadApprovedPlanValidation:
+    def test_rejects_missing_issue_ref(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="issue_ref"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_wrong_issue_ref(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#99",
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="does not match"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_empty_plan_summary(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "   ",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="plan_summary"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_empty_implementation_steps(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": [],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="implementation steps"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_returns_approved_plan(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "Fix the bug",
+                    "implementation_steps": ["Step 1", "Step 2"],
+                    "named_references": ["src/main.py"],
+                    "retrieval_surface_summary": "src/",
+                    "approved": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        plan = _load_approved_plan(plan_path, "owner/repo#1")
+        assert isinstance(plan, ApprovedPlan)
+        assert plan.issue_ref == "owner/repo#1"
+        assert plan.plan_summary == "Fix the bug"
+        assert plan.implementation_steps == ("Step 1", "Step 2")
+        assert tuple(ref.name for ref in plan.named_references) == ("src/main.py",)
+        assert plan.retrieval_surface_summary == "src/"
+        assert plan.approved is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1464,6 +1464,26 @@ class TestLoadApprovedPlanValidation:
         with pytest.raises(ValueError, match="implementation steps"):
             _load_approved_plan(plan_path, "owner/repo#1")
 
+    def test_rejects_unapproved_plan(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                    "approved": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="approved.*true"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
     def test_returns_approved_plan(self, tmp_path: Path) -> None:
         plan_path = tmp_path / "approved-plan.json"
         plan_path.write_text(

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import cast
 
@@ -46,6 +47,22 @@ def _record(tmp_path: Path) -> RunRecord:
         created_at="2026-04-27T00:00:00Z",
         updated_at="2026-04-27T00:00:00Z",
         run_dir=str(tmp_path / "run-123"),
+    )
+
+
+def _write_approved_plan(run_dir: Path) -> None:
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Review the implementation against the approved plan.",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -176,6 +193,7 @@ def test_opencode_pr_review_agent_resolves_custom_provider_model(
 ) -> None:
     monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "MiniMax-M2.7-highspeed")
     commands: list[list[str]] = []
+    _write_approved_plan(tmp_path)
 
     def fake_run(command, cwd, capture_output, text):
         del cwd, capture_output, text
@@ -192,6 +210,10 @@ def test_opencode_pr_review_agent_resolves_custom_provider_model(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
         intake=_intake(),
@@ -209,6 +231,7 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
 ) -> None:
     monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "minimax-cn-coding-plan/MiniMax-M2.7-highspeed")
     commands: list[list[str]] = []
+    _write_approved_plan(tmp_path)
 
     def fake_run(command, cwd, capture_output, text):
         del cwd, capture_output, text
@@ -225,6 +248,10 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
         intake=_intake(),
@@ -240,6 +267,8 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
 def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _write_approved_plan(tmp_path)
+
     def fake_run(command, cwd, capture_output, text):
         del command, cwd, capture_output, text
 
@@ -254,6 +283,10 @@ def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="architect").review(
         intake=_intake(),
@@ -265,6 +298,38 @@ def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
     assert result.status == "rejected"
     assert result.summary == "needs follow-up"
     assert result.feedback == ("fix review handling",)
+
+
+def test_opencode_pr_review_agent_fails_when_persisted_plan_is_unapproved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+
+    result = OpenCodePrReviewAgent(role="reviewer").review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+    )
+
+    assert result.status == "failed_infra"
+    assert "approved" in result.summary.lower()
 
 
 def test_parse_review_output_accepts_prose_before_json() -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
@@ -71,6 +72,17 @@ def _create_previous_run(store: RunStore, attempt: int = 1) -> RunRecord:
     return updated
 
 
+def _approved_plan(issue_ref: str = "owner/repo#1") -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref=issue_ref,
+        plan_summary="Fix the bug with a minimal change.",
+        implementation_steps=("Update the implementation",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
+
+
 def test_retry_increments_attempt(tmp_path: Path) -> None:
     """Test that retry increments the attempt counter."""
     store = RunStore(tmp_path / "runs")
@@ -103,7 +115,7 @@ def test_retry_increments_attempt(tmp_path: Path) -> None:
     import precision_squad.coordinator as coord_module
     original_execute = coord_module.DocsFirstExecutor.execute
 
-    def mock_execute(self, intake, record, run_dir):
+    def mock_execute(self, intake, run_record, run_dir):
         return exec_result
 
     coord_module.DocsFirstExecutor.execute = mock_execute
@@ -228,7 +240,8 @@ def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
     )
 
     original_execute = coord_module.DocsFirstExecutor.execute
-    def mock_execute(self, intake, record, run_dir):
+
+    def mock_execute(self, intake, run_record, run_dir):
         return exec_result
     coord_module.DocsFirstExecutor.execute = mock_execute
 
@@ -244,6 +257,90 @@ def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
     # Verify the attempt was persisted
     loaded = store.load_run(report.run_record.run_id)
     assert loaded.attempt == 3
+
+
+def test_retry_carries_forward_approved_plan_into_new_run_directory(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+    previous_run_dir = Path(previous.run_dir)
+    store.write_approved_plan(previous_run_dir, _approved_plan())
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = False
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    import precision_squad.coordinator as coord_module
+
+    exec_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Test execution",
+        detail_codes=(),
+    )
+    original_execute = coord_module.DocsFirstExecutor.execute
+
+    def mock_execute(self, intake, run_record, run_dir):
+        return exec_result
+
+    coord_module.DocsFirstExecutor.execute = mock_execute
+    try:
+        report = coordinator.repair_issue(
+            params=params,
+            intake=intake,
+            dependencies=dependencies,
+        )
+    finally:
+        coord_module.DocsFirstExecutor.execute = original_execute
+
+    new_run_dir = Path(report.run_record.run_dir)
+    assert (new_run_dir / "approved-plan.json").exists()
+    carried_forward = RunStore.load_approved_plan(new_run_dir)
+    assert carried_forward is not None
+    assert carried_forward.issue_ref == "owner/repo#1"
+    assert carried_forward.plan_summary == "Fix the bug with a minimal change."
+    assert carried_forward.implementation_steps == ("Update the implementation",)
+
+
+def test_retry_with_unapproved_persisted_plan_fails_before_creating_new_run(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+    previous_run_dir = Path(previous.run_dir)
+    (previous_run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    coordinator = RunCoordinator()
+    report = coordinator.repair_issue(
+        params=_make_params(tmp_path, retry_from=previous.run_id),
+        intake=_make_intake(),
+        dependencies=MagicMock(),
+    )
+
+    assert report.exit_code == 3
+    run_ids = [path.name for path in store.root.iterdir() if path.is_dir()]
+    assert run_ids == [previous.run_id]
 
 
 def test_retry_escalated_uses_correct_attempt_count(tmp_path: Path) -> None:

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from precision_squad.models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GitHubIssue,
@@ -19,6 +22,17 @@ from precision_squad.models import (
     RunRequest,
 )
 from precision_squad.run_store import RunStore
+
+
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Fix the bug with a minimal change.",
+        implementation_steps=("Update the implementation",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
 
 
 def test_create_run_writes_expected_artifacts(tmp_path: Path) -> None:
@@ -144,3 +158,36 @@ def test_write_qa_results_uses_phase_specific_filenames(tmp_path: Path) -> None:
 
     assert (run_dir / "qa-baseline-result.json").exists()
     assert (run_dir / "qa-result.json").exists()
+
+
+def test_load_approved_plan_rejects_unapproved_artifact(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="approved.*true"):
+        RunStore.load_approved_plan(run_dir)
+
+
+def test_render_approved_plan_text(tmp_path: Path) -> None:
+    del tmp_path
+    from precision_squad.run_store import render_approved_plan_text
+
+    text = render_approved_plan_text(_approved_plan(), include_named_references=False)
+
+    assert "Approved Plan" in text
+    assert "Fix the bug with a minimal change." in text
+    assert "Update the implementation" in text
+    assert "Retrieval Surface" in text


### PR DESCRIPTION
## Summary
- add `--approved-plan-path` support so the CLI can load and validate an approved plan before invoking the coordinator
- persist approved-plan artifacts into the run directory and carry them forward on retries so downstream context packs can load the canonical file
- add focused CLI loading and validation coverage, with follow-up still required for retry carry-forward proof and strict downstream invalid-artifact rejection

## Review Follow-Up
- reject `approved: false` artifacts during approved-plan ingestion and reload instead of treating non-empty plan text as sufficient
- add a retry regression test proving that a retry without a fresh `--approved-plan-path` carries the prior canonical `approved-plan.json` into the new run directory
- either add downstream invalid-artifact coverage or narrow the ADR-007 claim until strict downstream consumption is proven

## Scope Note
- review was evaluated against issue `#56` and ADR-007 minimum-seam language because no separate approved implementation plan artifact was available

Closes #56