### PR TITLE
fix: enforce canonical approved-plan contract

### DIFF
--- a/.opencode/plans/issue-56.md
+++ b/.opencode/plans/issue-56.md
@@ -1,0 +1,199 @@
+# Issue 56 Plan: Canonical approved-plan ingress, persistence, retry carry-forward, and strict downstream validation
+
+## Problem Summary
+
+Issue 56 is the minimum enabling seam that turns the approved plan into a real contract artifact for `repair issue`. Today the repo splits approved-plan validation across multiple entry points: persisted artifact shape is validated in `run_store.py`, while CLI-only `issue_ref` checks live in `cli.py`, and downstream review still treats approved-plan presence largely as rendered-text availability. The fix for this issue is to designate one repo-local canonical approved-plan contract seam, require it at fresh-run ingress, persist the validated artifact at run start, reuse it for retry carry-forward, and force both developer and review stages to revalidate the persisted artifact instead of falling back to weaker checks.
+
+## Traceability
+
+- Issue #56 acceptance criteria require the approved plan to behave as one end-to-end contract artifact: validated at ingress, persisted for the run, carried forward on retry, and rejected downstream when structurally invalid.
+- Repo-local restatement of the required stage contract for this issue: downstream stages must consume the persisted approved-plan artifact by reloading and validating it at stage entry, and a missing or invalid artifact must stop that stage with an infrastructure failure before the stage runtime is invoked.
+- This repo-local restatement is the operative implementation authority for issue 56 in this worktree. Do not depend on unavailable ADR text to fill in missing requirements.
+- Scope remains the minimum enabling seam only: make the existing `ApprovedPlan` contract complete and enforceable without redesigning the broader planning workflow.
+
+## Scope Boundaries
+
+### In Scope
+
+- A single canonical validator/helper for approved-plan loading and invariant enforcement
+- Fresh-run `repair issue` ingress rules for `--approved-plan-path`
+- Early failure semantics that abort before coordinator run creation when a fresh-run plan is missing or invalid
+- Run-start persistence to `<run_dir>/approved-plan.json`
+- Retry carry-forward with the same precedence and revalidation rules
+- Strict developer-stage and review-stage revalidation of persisted approved plans
+- Minimal operator-facing discoverability updates for the fresh-run `--approved-plan-path` requirement (CLI help/usage text or equivalent narrow entrypoint docs)
+- Focused tests for ingress, retry, persistence, structured coordinator handoff, and downstream rejection paths
+
+### Out of Scope
+
+- New planning workflows, new stage commands, or alternate plan sources
+- Broader context-pack redesign beyond the approved-plan artifact already defined for downstream stages
+- Changes to issue review semantics, governance policy, publish behavior, or retry limits
+- Unrelated cleanup/refactors in repair, retry, coordinator, or review codepaths
+
+## Affected Areas
+
+- `src/precision_squad/cli.py`
+- `src/precision_squad/coordinator.py`
+- `src/precision_squad/run_store.py`
+- `src/precision_squad/repair/orchestration.py`
+- `src/precision_squad/repair/adapter.py`
+- `src/precision_squad/post_publish_review.py`
+- `tests/test_cli.py`
+- `tests/test_retry.py`
+- `tests/test_run_store.py`
+- `tests/test_adapter.py`
+- `tests/test_post_publish_review.py`
+
+## Canonical Approved-Plan Contract
+
+The plan artifact for this issue is the existing `ApprovedPlan` schema. For this issue, the canonical loader/validator must live in `src/precision_squad/run_store.py` as the repo-local approved-plan contract seam already shared by persistence and downstream consumers. CLI ingress, coordinator retry carry-forward, developer-stage loading, and review-stage loading must all call that seam instead of keeping separate partial checks. The source artifact must be a JSON object and every downstream-consumed field must be validated, not defaulted opportunistically by individual callers.
+
+- `issue_ref` must exist, must be a non-empty string, and must exactly match the current issue being processed.
+- `plan_summary` must exist and must be a non-empty string.
+- `implementation_steps` must exist, must be a list, and must contain at least one item.
+  - Each item must be a string.
+  - Whitespace-only strings are rejected.
+  - Non-string items are rejected; callers must not coerce numbers, booleans, objects, or nulls into strings.
+- `named_references` must exist and must be a list.
+  - `[]` is a canonical valid value; empty named references are allowed when a plan does not need explicit named references.
+  - Each item must be either:
+    - a non-empty string legacy shorthand, normalized to a `NamedReference` with default type `file`, or
+    - an object with a non-empty string `name`, optional `reference_type` constrained to the existing allowed values (`file`, `interface`, `symbol`, `example`), and optional string `description`.
+  - Non-list values, empty names, invalid `reference_type`, non-string `description`, or structurally invalid entries are rejected.
+  - Persistence must write normalized object form to `<run_dir>/approved-plan.json`; this issue should not preserve legacy string shorthand once the artifact has been loaded into the canonical `ApprovedPlan` model.
+- `retrieval_surface_summary` must exist and must be a string.
+  - `""` is a canonical valid value; an empty retrieval-surface summary is allowed and means there is no additional retrieval hint for this plan.
+  - `null`, objects, arrays, or other non-string values are rejected.
+- `approved` must exist as a boolean and must be `true`.
+
+Canonical validity for this issue therefore includes both structurally populated plans and intentionally minimal plans where `named_references` is empty and/or `retrieval_surface_summary` is an empty string. Missing those fields is not valid; explicit empty canonical values are valid.
+
+This helper must be the only supported seam for:
+
+- CLI ingress loading from `--approved-plan-path`
+- retry carry-forward from a previous run's `approved-plan.json`
+- persisted approved-plan loads from the run store
+- developer-stage loading for repair prompt/context construction
+- review-stage loading for post-publish review prompt/context construction
+
+Issue 56 should not leave separate partial validators in CLI and run-store codepaths. The implementation must expose a named public cross-module helper from `run_store.py`, and CLI/downstream call sites must stop importing or depending on the private `_read_approved_plan` seam directly.
+
+## Implementation Steps
+
+1. **Create/designate one canonical approved-plan validator/helper**
+   - Use `src/precision_squad/run_store.py` as the canonical approved-plan contract seam for this issue, exposing one named public shared loader/validator used by ingress, retry, persistence reloads, and downstream stage entry.
+   - Replace the current split behavior with one helper that loads an approved-plan artifact and validates all canonical invariants together.
+   - The helper must be used for both file-path ingress and persisted run-directory loads.
+   - The helper must take the current `issue_ref` as validation context so `issue_ref` matching is not left as a CLI-only check.
+   - The helper must reject artifacts that omit `named_references` or `retrieval_surface_summary`; callers must not silently backfill those downstream-consumed fields.
+   - The helper must reject top-level non-object JSON payloads everywhere it is used.
+   - CLI and downstream modules must stop using split/private readers or partial validators; the public canonical helper is the only supported cross-module API for approved-plan loading.
+   - The structured coordinator handoff boundary must be explicit: coordinator execution receives a fully validated `ApprovedPlan` object, not an unvalidated path or partially checked payload.
+
+2. **Make approved-plan input mandatory for fresh `repair issue` runs**
+   - A fresh run without `--approved-plan-path` must fail immediately.
+   - A fresh run with a malformed, mismatched, missing-field, malformed `named_references`, invalid `retrieval_surface_summary`, or `approved: false` artifact must fail immediately.
+   - This failure surface must be the command-input validation boundary, not a handled coordinator result: the command exits non-zero through the existing CLI command error path, emits an operator-facing approved-plan error message, and occurs before coordinator run creation so no new run record or run directory is created.
+   - This issue does not need to suppress issue intake/network lookup; it only requires that coordinator run artifacts are not created for invalid fresh-run ingress.
+
+3. **Define and enforce one precedence rule for fresh runs, retries, and persisted loads**
+   - Fresh run: the CLI-supplied approved plan is required and authoritative.
+   - Retry with explicit `--approved-plan-path`: the explicitly supplied artifact is authoritative after validation.
+   - Retry without explicit path: load the previous run's `approved-plan.json` through the same canonical validator/helper after the previous run record is located.
+   - All three paths must reuse the same validation rules and produce the same rejected cases.
+   - Retry carry-forward validation must happen before new run creation and before any retry execution continues; this issue does not require reordering issue intake/network lookup ahead of that point.
+
+4. **Persist the validated approved plan at run start**
+   - After coordinator run creation succeeds and before executor/repair/publish work begins, persist the selected validated plan to `<run_dir>/approved-plan.json`.
+   - Persist exactly the canonical approved-plan artifact for later stage reuse rather than a derived summary.
+   - Persistence must write the normalized canonical shape only; if the input used legacy `named_references` string shorthand, the persisted artifact must contain normalized `NamedReference` objects and downstream consumers must only read that normalized persisted shape.
+   - Do not add new sidecar artifacts for this issue.
+
+5. **Tighten retry carry-forward failure semantics**
+   - Retry without explicit replacement must fail before new run creation if the previous run is missing `approved-plan.json`.
+   - Retry without explicit replacement must also fail before new run creation if the persisted artifact is top-level non-object JSON, malformed, has mismatched `issue_ref`, has empty `plan_summary`, has empty/whitespace-only/non-string `implementation_steps`, has malformed `named_references`, has invalid `retrieval_surface_summary`, or has `approved: false`.
+   - Retry with explicit replacement must validate the replacement artifact with the same helper before new run creation.
+   - Retry operator messaging must distinguish the two failure classes explicitly: one message for missing prior `approved-plan.json`, and a different message for a prior artifact that exists but fails structural validation.
+
+6. **Require strict developer-stage revalidation and context loading**
+   - `RepairStage.execute` in `src/precision_squad/repair/orchestration.py` is the developer-stage enforcement seam for approved-plan loading and failure projection.
+   - That stage-entry seam must load and validate the current run's persisted `approved-plan.json` through the canonical run-store helper at the very start of `RepairStage.execute`, before workspace creation, clone, reset, checkout, cleanup, or any other repair-stage side effects.
+   - Developer-stage entry must reject the full canonical invalid matrix: missing artifact, top-level non-object JSON, malformed JSON, mismatched `issue_ref`, empty `plan_summary`, missing/empty/whitespace-only/non-string `implementation_steps`, missing/malformed `named_references`, missing/invalid `retrieval_surface_summary`, or `approved: false`, instead of silently proceeding from issue text alone.
+   - The observable failure contract here must be concrete: `RepairStage.execute` returns the existing repair-stage infrastructure failure result (`RepairResult.status == "failed_infra"`) with an approved-plan load/validation summary, and the short-circuit occurs before any repair-stage workspace mutation and before the repair adapter subprocess/API is invoked.
+   - `repair/adapter.py` remains the prompt-construction seam, but it must not become a second independent status-mapping gate for approved-plan validation failures.
+   - The developer context should render only the canonical approved-plan content needed by the existing context-pack rules: `plan_summary`, `implementation_steps`, `retrieval_surface_summary`, and named references from the approved artifact. It should not inject broader planning history, issue-thread planning discussion, or any noncanonical plan text.
+
+7. **Require strict review-stage revalidation and context loading**
+   - Post-publish review prompt construction must also load the current run's persisted `approved-plan.json` through the same canonical validator/helper.
+   - Review-stage entry must reject the exact same canonical invalid matrix used by ingress, retry, and developer-stage validation: missing artifact, top-level non-object JSON, malformed JSON, mismatched `issue_ref`, empty `plan_summary`, missing/empty/whitespace-only/non-string `implementation_steps`, missing/malformed `named_references`, missing/invalid `retrieval_surface_summary`, or `approved: false`.
+   - The observable failure contract here must be concrete: stage entry returns the existing review-stage infrastructure failure result (`ReviewAgentResult.status == "failed_infra"`) with an approved-plan load/validation summary, and the review agent runtime must not be invoked when plan loading fails.
+   - Review must stop relying on rendered-text presence as the effective validation seam; successful rendering is only allowed after structural and issue-match validation succeed.
+
+8. **Keep the operator boundary discoverable**
+   - Because this issue makes `--approved-plan-path` mandatory for fresh runs, the command help/usage surface must say so explicitly.
+   - At minimum, the narrow operator-facing seam for `repair issue` must cover both of these surfaces:
+    - `repair issue --help` / argparse help text for `--approved-plan-path`, explicitly stating that fresh runs require it and that retry carry-forward is the only no-path exception.
+    - the fresh-run missing-flag error surface, with wording that tells the operator the run requires `--approved-plan-path` rather than failing generically.
+     - the retry carry-forward rejection surface, with wording that distinguishes `missing prior approved-plan.json` from `prior approved-plan.json failed structural validation`.
+   - This issue does not require a broad docs rewrite.
+
+## Validation Plan
+
+- **Canonical validator/helper tests**
+  - one shared loader/validator enforces `issue_ref`, `plan_summary`, `implementation_steps`, `named_references`, `retrieval_surface_summary`, and `approved`
+  - file-path ingress loads and run-directory loads both exercise the same helper
+  - top-level non-object JSON payloads are rejected by the shared helper for both direct file loads and persisted run-directory loads
+  - mismatched `issue_ref` and `approved: false` are rejected by the shared helper, not by a one-off caller-only check
+   - missing `named_references`, missing `retrieval_surface_summary`, malformed `named_references`, and non-string `retrieval_surface_summary` are rejected by the shared helper
+   - empty `plan_summary` is rejected by the shared helper
+   - missing `implementation_steps`, empty `implementation_steps`, and `implementation_steps` entries that are whitespace-only or non-string are rejected by the shared helper
+   - explicit empty `named_references: []` and `retrieval_surface_summary: ""` are accepted as canonical valid cases
+   - legacy string shorthand for `named_references` loads successfully but persistence rewrites it in normalized object form
+   - downstream reloads from persisted run artifacts observe only the normalized object form, not legacy string shorthand
+
+- **Fresh-run CLI ingress tests**
+  - fresh run succeeds when a valid `--approved-plan-path` artifact is supplied
+  - fresh run without `--approved-plan-path` fails
+  - fresh run with top-level non-object JSON, malformed JSON, missing required fields, empty `plan_summary`, empty/whitespace-only/non-string `implementation_steps`, malformed `named_references`, invalid `retrieval_surface_summary`, mismatched `issue_ref`, or `approved: false` fails
+  - each of those failures occurs before coordinator run creation and leaves no new run directory artifacts
+  - the CLI help surface explicitly states the fresh-run requirement and the retry exception
+  - the missing-flag error path explicitly tells the operator to supply `--approved-plan-path`
+
+- **Retry precedence and carry-forward tests**
+   - retry without explicit replacement carries forward a valid previous `approved-plan.json`
+   - retry with explicit replacement uses the new validated artifact instead of the carried-forward one
+   - retry without explicit replacement fails before new run creation when the previous artifact is missing, top-level non-object JSON, malformed, mismatched, empty/whitespace-only/non-string in `implementation_steps`, malformed in `named_references`, invalid in `retrieval_surface_summary`, or `approved: false`
+   - retry failure messaging distinguishes `missing prior plan artifact` from `prior plan artifact structurally invalid`
+   - retry, fresh CLI ingress, and persisted run-store loads all use the same precedence and validation helper
+
+- **Structured coordinator handoff tests**
+  - coordinator persists only a validated `ApprovedPlan` selected before execution starts
+  - invalid ingress artifacts are rejected before coordinator creates run state
+
+- **Developer-stage tests**
+   - `RepairStage.execute` fails as a repair-stage infrastructure failure (`RepairResult.status == "failed_infra"`) when the persisted approved plan is missing
+   - `RepairStage.execute` fails with the same `failed_infra` contract when the persisted approved plan is top-level non-object JSON, malformed, has mismatched `issue_ref`, has empty `plan_summary`, has missing/empty/whitespace-only/non-string `implementation_steps`, has missing/malformed `named_references`, has missing/invalid `retrieval_surface_summary`, or has `approved: false`
+   - those failures happen before workspace creation, clone/reset, and before `RepairStage.execute` calls `self.adapter.repair(...)`, so no repair-stage side effects or repair agent subprocess/API invocation occurs
+   - when valid, the developer context includes the rendered canonical plan content only: summary, implementation steps, retrieval-surface summary, and named references from the approved artifact
+
+- **Review-stage tests**
+   - review prompt/context building fails as a review-stage infrastructure failure (`ReviewAgentResult.status == "failed_infra"`) when the persisted approved plan is missing
+   - review prompt/context building fails with the same `failed_infra` contract when the persisted approved plan is top-level non-object JSON, malformed, has mismatched `issue_ref`, has empty `plan_summary`, has missing/empty/whitespace-only/non-string `implementation_steps`, has missing/malformed `named_references`, has missing/invalid `retrieval_surface_summary`, or has `approved: false`
+   - those failures happen before the review agent runtime is invoked
+   - the happy path still works when the persisted artifact is valid and renderable
+
+## Risks And Mitigations
+
+- **Risk: validation drift between ingress, retry, run store, developer, and review paths.**
+  - Mitigation: require one canonical validator/helper and test every callsite against it.
+- **Risk: fresh-run failures still leave partial run artifacts behind.**
+  - Mitigation: make fresh-run validation happen before coordinator run creation and test for absence of new run directories.
+- **Risk: downstream stages silently widen scope by pulling broader planning context.**
+  - Mitigation: render only the canonical approved-plan artifact fields already allowed by the existing context-pack rules.
+- **Risk: operators miss the new mandatory fresh-run input boundary.**
+  - Mitigation: make the requirement explicit in CLI help/usage text and pin it in tests.
+
+## Minimum Enabling Seam
+
+This issue should land only the smallest coherent seam that makes approved-plan handling trustworthy end to end: complete canonical validation of the existing `ApprovedPlan` contract, required fresh-run ingress, run-start persistence, retry carry-forward, strict downstream revalidation, and the narrow discoverability updates needed for the new mandatory CLI boundary. Do not widen the change into general planning workflow redesign, schema redesign beyond the current contract, or unrelated context-pack work.

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -44,7 +44,7 @@ from .repair import (
     run_repair_qa_loop,
     synthesis_artifacts_ready,
 )
-from .run_store import _read_approved_plan as _read_persisted_approved_plan
+from .run_store import ApprovedPlanError, load_approved_plan_artifact
 
 # Keep a local alias so tests can monkeypatch the shared executor class through this module.
 _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
@@ -114,7 +114,10 @@ def build_parser() -> argparse.ArgumentParser:
     issue_parser.add_argument(
         "--approved-plan-path",
         default=None,
-        help="Path to an approved-plan.json file to pass to the coordinator.",
+        help=(
+            "Path to an approved-plan.json file. Required for fresh runs; retries may omit it "
+            "only to carry forward the prior run's approved-plan.json."
+        ),
     )
     issue_parser.set_defaults(handler=_repair_issue)
 
@@ -160,6 +163,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _repair_issue(args: argparse.Namespace) -> int:
+    if args.retry_from is None and not args.approved_plan_path:
+        raise ValueError(
+            "Fresh repair issue runs require --approved-plan-path; retries may omit it only "
+            "when carrying forward the prior approved-plan.json."
+        )
+
     intake = load_issue_intake(args.issue_ref)
     approved_plan: ApprovedPlan | None = None
     if args.approved_plan_path:
@@ -586,13 +595,10 @@ def _as_bool(value: Any) -> bool:
 
 def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
     """Load and validate an ApprovedPlan from a JSON file."""
-    plan = _read_persisted_approved_plan(path)
-    plan_issue_ref = plan.issue_ref
-    if plan_issue_ref != issue_ref:
-        raise ValueError(
-            f"Approved plan issue_ref '{plan_issue_ref}' does not match CLI issue_ref '{issue_ref}'"
-        )
-    return plan
+    try:
+        return load_approved_plan_artifact(path, issue_ref=issue_ref)
+    except ApprovedPlanError as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -17,11 +17,13 @@ from .executor import DocsFirstExecutor
 from .github_client import GitHubClientError, GitHubWriteClient
 from .intake import load_issue_intake
 from .models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    NamedReference,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -108,6 +110,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Existing run ID to retry from. Increments attempt counter.",
     )
+    issue_parser.add_argument(
+        "--approved-plan-path",
+        default=None,
+        help="Path to an approved-plan.json file to pass to the coordinator.",
+    )
     issue_parser.set_defaults(handler=_repair_issue)
 
     publish_parser = subparsers.add_parser(
@@ -153,6 +160,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _repair_issue(args: argparse.Namespace) -> int:
     intake = load_issue_intake(args.issue_ref)
+    approved_plan: ApprovedPlan | None = None
+    if args.approved_plan_path:
+        approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
     report = RunCoordinator().repair_issue(
         params=RepairIssueParams(
             issue_ref=args.issue_ref,
@@ -163,6 +173,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
             repair_model=args.repair_model,
             review_model=args.review_model,
             retry_from=args.retry_from,
+            approved_plan=approved_plan,
         ),
         intake=intake,
         dependencies=_CliRepairDependencies(),
@@ -477,7 +488,7 @@ def _read_publish_result(run_dir: Path) -> PublishResult | None:
         summary=_as_str(payload["summary"]),
         url=_as_optional_str(payload.get("url")),
         branch_name=_as_optional_str(payload.get("branch_name")),
-        pull_number=_as_optional_int(payload.get("pull_number")),
+        pull_number=_as_optional_int(payload.get("pull_number"]),
     )
 
 
@@ -570,6 +581,60 @@ def _as_bool(value: Any) -> bool:
     if not isinstance(value, bool):
         raise ValueError("Expected boolean value")
     return value
+
+
+def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
+    """Load and validate an ApprovedPlan from a JSON file."""
+    payload = _read_json(path)
+    if "issue_ref" not in payload:
+        raise ValueError("Approved plan is missing required field 'issue_ref'")
+    plan_issue_ref = _as_str(payload.get("issue_ref"))
+    if plan_issue_ref != issue_ref:
+        raise ValueError(
+            f"Approved plan issue_ref '{plan_issue_ref}' does not match CLI issue_ref '{issue_ref}'"
+        )
+    plan_summary = _as_str(payload.get("plan_summary"))
+    if not plan_summary.strip():
+        raise ValueError("Approved plan is missing a non-empty 'plan_summary'")
+    implementation_steps_raw = payload.get("implementation_steps", [])
+    if not isinstance(implementation_steps_raw, list):
+        raise ValueError("Expected 'implementation_steps' to be a list")
+    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
+    if not implementation_steps:
+        raise ValueError("Approved plan has no implementation steps")
+    named_references_raw = payload.get("named_references", [])
+    if not isinstance(named_references_raw, list):
+        raise ValueError("Expected 'named_references' to be a list")
+    named_refs: list[NamedReference] = []
+    allowed_types = {"file", "interface", "symbol", "example"}
+    for ref in named_references_raw:
+        if isinstance(ref, dict):
+            name = str(ref.get("name", ""))
+            if not name:
+                raise ValueError("Named reference has empty name")
+            ref_type = ref.get("reference_type", "file")
+            if ref_type not in allowed_types:
+                raise ValueError(
+                    "Named reference has invalid reference_type "
+                    f"'{ref_type}'; expected one of {allowed_types}"
+                )
+            named_refs.append(
+                NamedReference(
+                    name=name,
+                    reference_type=ref_type,
+                    description=str(ref.get("description", "")),
+                )
+            )
+        else:
+            named_refs.append(NamedReference(name=str(ref)))
+    return ApprovedPlan(
+        issue_ref=plan_issue_ref,
+        plan_summary=plan_summary,
+        implementation_steps=implementation_steps,
+        named_references=tuple(named_refs),
+        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
+        approved=bool(payload.get("approved", True)),
+    )
 
 
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -44,6 +44,7 @@ from .repair import (
     run_repair_qa_loop,
     synthesis_artifacts_ready,
 )
+from .run_store import _read_approved_plan as _read_persisted_approved_plan
 
 # Keep a local alias so tests can monkeypatch the shared executor class through this module.
 _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
@@ -585,56 +586,13 @@ def _as_bool(value: Any) -> bool:
 
 def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
     """Load and validate an ApprovedPlan from a JSON file."""
-    payload = _read_json(path)
-    if "issue_ref" not in payload:
-        raise ValueError("Approved plan is missing required field 'issue_ref'")
-    plan_issue_ref = _as_str(payload.get("issue_ref"))
+    plan = _read_persisted_approved_plan(path)
+    plan_issue_ref = plan.issue_ref
     if plan_issue_ref != issue_ref:
         raise ValueError(
             f"Approved plan issue_ref '{plan_issue_ref}' does not match CLI issue_ref '{issue_ref}'"
         )
-    plan_summary = _as_str(payload.get("plan_summary"))
-    if not plan_summary.strip():
-        raise ValueError("Approved plan is missing a non-empty 'plan_summary'")
-    implementation_steps_raw = payload.get("implementation_steps", [])
-    if not isinstance(implementation_steps_raw, list):
-        raise ValueError("Expected 'implementation_steps' to be a list")
-    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
-    if not implementation_steps:
-        raise ValueError("Approved plan has no implementation steps")
-    named_references_raw = payload.get("named_references", [])
-    if not isinstance(named_references_raw, list):
-        raise ValueError("Expected 'named_references' to be a list")
-    named_refs: list[NamedReference] = []
-    allowed_types = {"file", "interface", "symbol", "example"}
-    for ref in named_references_raw:
-        if isinstance(ref, dict):
-            name = str(ref.get("name", ""))
-            if not name:
-                raise ValueError("Named reference has empty name")
-            ref_type = ref.get("reference_type", "file")
-            if ref_type not in allowed_types:
-                raise ValueError(
-                    "Named reference has invalid reference_type "
-                    f"'{ref_type}'; expected one of {allowed_types}"
-                )
-            named_refs.append(
-                NamedReference(
-                    name=name,
-                    reference_type=ref_type,
-                    description=str(ref.get("description", "")),
-                )
-            )
-        else:
-            named_refs.append(NamedReference(name=str(ref)))
-    return ApprovedPlan(
-        issue_ref=plan_issue_ref,
-        plan_summary=plan_summary,
-        implementation_steps=implementation_steps,
-        named_references=tuple(named_refs),
-        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
-        approved=bool(payload.get("approved", True)),
-    )
+    return plan
 
 
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -488,7 +488,7 @@ def _read_publish_result(run_dir: Path) -> PublishResult | None:
         summary=_as_str(payload["summary"]),
         url=_as_optional_str(payload.get("url")),
         branch_name=_as_optional_str(payload.get("branch_name")),
-        pull_number=_as_optional_int(payload.get("pull_number"]),
+        pull_number=_as_optional_int(payload.get("pull_number")),
     )
 
 
@@ -741,6 +741,8 @@ def _post_publish_review_is_stale(
     if head_sha is None:
         return False
     return head_sha != review_result.pull_head_sha
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI and return a process exit code."""
     load_local_env(Path(__file__).resolve().parent.parent.parent)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -10,6 +10,7 @@ from .executor import DocsFirstExecutor
 from .governance import apply_governance, evaluate_run
 from .intake import IssueIntake, is_docs_remediation_issue
 from .models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
@@ -136,6 +137,7 @@ class RepairIssueParams:
     repair_model: str | None
     review_model: str | None
     retry_from: str | None = None
+    approved_plan: ApprovedPlan | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,10 +187,12 @@ class RunCoordinator:
 
         # Handle retry logic
         attempt = 1
+        previous_run_dir: Path | None = None
         if params.retry_from is not None:
             try:
                 previous_record = store.load_run(params.retry_from)
                 attempt = previous_record.attempt + 1
+                previous_run_dir = Path(previous_record.run_dir).resolve()
             except ValueError:
                 return RepairIssueReport(
                     intake=intake,
@@ -221,6 +225,14 @@ class RunCoordinator:
         if attempt > 1:
             record = record.with_attempt(attempt)
             store.write_run_record(record)
+
+        # Persist the approved plan early so later stages can load it.
+        # On retry, carry it forward from the previous run unless overridden.
+        effective_approved_plan = params.approved_plan
+        if effective_approved_plan is None and previous_run_dir is not None:
+            effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
+        if effective_approved_plan is not None:
+            store.write_approved_plan(run_dir, effective_approved_plan)
 
         if intake.assessment.status == "blocked":
             verdict = apply_governance(intake, execution_result=None, evaluation_result=None)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -24,7 +24,7 @@ from .models import (
 )
 from .publishing import build_publish_plan
 from .repair import RepairAdapter
-from .run_store import RunStore
+from .run_store import ApprovedPlanNotFoundError, ApprovedPlanValidationError, RunStore
 
 
 class RepairDependencies(Protocol):
@@ -210,7 +210,20 @@ class RunCoordinator:
         effective_approved_plan = params.approved_plan
         if effective_approved_plan is None and previous_run_dir is not None:
             try:
-                effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
+                effective_approved_plan = RunStore.load_approved_plan(
+                    previous_run_dir,
+                    issue_ref=params.issue_ref,
+                )
+            except ApprovedPlanNotFoundError:
+                raise ValueError(
+                    "Retry requires a prior approved-plan.json when --approved-plan-path is omitted; "
+                    f"missing prior approved-plan.json in {previous_run_dir}."
+                )
+            except ApprovedPlanValidationError as exc:
+                raise ValueError(
+                    "Retry carry-forward failed because the prior approved-plan.json failed "
+                    f"structural validation: {exc}"
+                ) from exc
             except ValueError:
                 return RepairIssueReport(
                     intake=intake,
@@ -232,6 +245,7 @@ class RunCoordinator:
                 request=request,
                 intake=intake,
                 attempt=attempt,
+                effective_approved_plan=effective_approved_plan,
                 dependencies=dependencies,
                 params=params,
             )
@@ -325,6 +339,7 @@ class RunCoordinator:
         request: RunRequest,
         intake: IssueIntake,
         attempt: int,
+        effective_approved_plan: ApprovedPlan | None,
         dependencies: RepairDependencies,
         params: RepairIssueParams,
     ) -> RepairIssueReport:
@@ -333,6 +348,8 @@ class RunCoordinator:
         run_dir = Path(record.run_dir).resolve()
         record = record.with_attempt(attempt)
         store.write_run_record(record)
+        if effective_approved_plan is not None:
+            store.write_approved_plan(run_dir, effective_approved_plan)
 
         escalated_result = RepairResult(
             status="escalated",

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -207,6 +207,24 @@ class RunCoordinator:
                     exit_code=3,
                 )
 
+        effective_approved_plan = params.approved_plan
+        if effective_approved_plan is None and previous_run_dir is not None:
+            try:
+                effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
+            except ValueError:
+                return RepairIssueReport(
+                    intake=intake,
+                    run_record=RunRecord(
+                        run_id="",
+                        issue_ref=params.issue_ref,
+                        status="blocked",
+                        created_at="",
+                        updated_at="",
+                        run_dir="",
+                    ),
+                    exit_code=3,
+                )
+
         # Check if escalated (max 3 attempts exceeded)
         if attempt > 3:
             return self._handle_escalation(
@@ -227,10 +245,6 @@ class RunCoordinator:
             store.write_run_record(record)
 
         # Persist the approved plan early so later stages can load it.
-        # On retry, carry it forward from the previous run unless overridden.
-        effective_approved_plan = params.approved_plan
-        if effective_approved_plan is None and previous_run_dir is not None:
-            effective_approved_plan = RunStore.load_approved_plan(previous_run_dir)
         if effective_approved_plan is not None:
             store.write_approved_plan(run_dir, effective_approved_plan)
 

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -208,6 +208,27 @@ class ReviewAgentResult:
 
 
 @dataclass(frozen=True, slots=True)
+class NamedReference:
+    """A named reference (file path, interface, symbol, or example) from the approved plan."""
+
+    name: str
+    reference_type: Literal["file", "interface", "symbol", "example"] = "file"
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovedPlan:
+    """Canonical approved-plan artifact for downstream stage consumption."""
+
+    issue_ref: str
+    plan_summary: str
+    implementation_steps: tuple[str, ...]
+    named_references: tuple[NamedReference, ...]
+    retrieval_surface_summary: str
+    approved: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class PostPublishReviewResult:
     """Combined result for post-publish PR review."""
 

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -230,9 +230,10 @@ def _build_review_prompt(
 ) -> str:
     approved_plan = RunStore.load_approved_plan_text(
         run_dir,
+        issue_ref=run_record.issue_ref,
         include_named_references=True,
     )
-    if not approved_plan or not approved_plan.strip():
+    if not approved_plan.strip():
         raise ValueError("Review context pack is missing required approved plan")
     pr_diff = _fetch_pr_diff(
         intake.issue.reference.owner,

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -13,6 +13,7 @@ from .github_client import GitHubWriteClient
 from .json_events import extract_json_events
 from .models import IssueIntake, PostPublishReviewResult, ReviewAgentResult, RunRecord
 from .opencode_model import resolve_opencode_model
+from .run_store import RunStore
 
 PULL_NUMBER_PATTERN = re.compile(r"/pull/(?P<number>[0-9]+)$")
 
@@ -49,13 +50,23 @@ class OpenCodePrReviewAgent:
         stdout_path = run_dir / f"{prefix}.stdout.log"
         stderr_path = run_dir / f"{prefix}.stderr.log"
         transcript_path = run_dir / f"{prefix}-transcript.json"
-        prompt = _build_review_prompt(
-            role=self.role,
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            pull_request_url=pull_request_url,
-        )
+        try:
+            prompt = _build_review_prompt(
+                role=self.role,
+                intake=intake,
+                run_record=run_record,
+                run_dir=run_dir,
+                pull_request_url=pull_request_url,
+            )
+        except ValueError as exc:
+            return ReviewAgentResult(
+                role=self.role,
+                status="failed_infra",
+                summary=str(exc),
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                transcript_path=str(transcript_path),
+            )
         command = [
             self.binary,
             "run",
@@ -217,18 +228,58 @@ def _build_review_prompt(
     run_dir: Path,
     pull_request_url: str,
 ) -> str:
+    approved_plan = RunStore.load_approved_plan_text(
+        run_dir,
+        include_named_references=True,
+    )
+    if not approved_plan or not approved_plan.strip():
+        raise ValueError("Review context pack is missing required approved plan")
+    pr_diff = _fetch_pr_diff(
+        intake.issue.reference.owner,
+        intake.issue.reference.repo,
+        pull_request_url,
+    )
+    if not pr_diff.strip():
+        raise ValueError("Review context pack is missing required PR diff")
     return "\n".join(
         [
             f"Review role: {role}",
             f"Run ID: {run_record.run_id}",
             f"Issue: {intake.issue.reference}",
             f"PR: {pull_request_url}",
+            "",
+            "## Approved Plan",
+            approved_plan,
+            "",
+            "## PR Diff",
+            pr_diff,
+            "",
             "Review the published PR and respond with exactly one JSON object.",
             'Use the shape: {"status":"approved|rejected","summary":"...","feedback":["..."]}',
             "If you reject, feedback must contain concrete required changes.",
             "Do not include markdown fences.",
         ]
     )
+
+
+def _fetch_pr_diff(owner: str, repo: str, pull_request_url: str) -> str:
+    match = PULL_NUMBER_PATTERN.search(pull_request_url.strip())
+    if match is None:
+        return ""
+    pull_number = int(match.group("number"))
+    payload = GitHubWriteClient.from_env().get_pull_request(owner, repo, pull_number)
+    diff_url = payload.get("diff_url")
+    if not isinstance(diff_url, str) or not diff_url:
+        return ""
+    completed = subprocess.run(
+        ["gh", "api", diff_url, "-H", "Accept: application/vnd.github.v3.diff"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout
 
 
 def _parse_review_output(events: list[dict]) -> dict[str, Any] | None:

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -13,7 +13,7 @@ from jsonschema import ValidationError, validate
 from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
 from ..json_events import extract_json_events
-from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
+from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
 
 
@@ -24,6 +24,7 @@ class RepairAdapter(Protocol):
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -94,6 +95,7 @@ class OpenCodeRepairAdapter:
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -106,6 +108,7 @@ class OpenCodeRepairAdapter:
         transcript_path = run_dir / "repair-transcript.json"
 
         prompt = _build_repair_prompt(
+            approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -192,7 +195,11 @@ class OpenCodeRepairAdapter:
 
         return RepairResult(
             status="completed",
-            summary=repair_json.get("summary") if repair_json else "Repair agent completed and produced source changes.",
+            summary=(
+                str(repair_json.get("summary"))
+                if repair_json is not None and isinstance(repair_json.get("summary"), str)
+                else "Repair agent completed and produced source changes."
+            ),
             detail_codes=("repair_stage_completed",),
             workspace_path=str(repo_workspace.parent),
             patch_path=str(patch_path),
@@ -247,6 +254,7 @@ def _extract_side_issues(repair_json: dict) -> tuple[SideIssue, ...]:
 
 def _build_repair_prompt(
     *,
+    approved_plan: ApprovedPlan | None = None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,
@@ -270,6 +278,7 @@ def _build_repair_prompt(
 
     if is_docs_remediation_issue(intake):
         lines = _build_docs_remediation_prompt(
+            approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -280,6 +289,7 @@ def _build_repair_prompt(
         )
     else:
         lines = _build_standard_repair_prompt(
+            approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -295,6 +305,7 @@ def _build_repair_prompt(
 
 def _build_docs_remediation_prompt(
     *,
+    approved_plan: ApprovedPlan | None = None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,
@@ -333,6 +344,7 @@ def _build_docs_remediation_prompt(
         f"Run ID: {run_record.run_id}",
         f"Issue: {intake.issue.reference}",
         f"Title: {intake.issue.title}",
+        *(_render_approved_plan_context(approved_plan)),
         "Requirements:",
         "- Update repository documentation in the current workspace to resolve the issue.",
         "- Treat this as a docs-remediation issue, not a product code change.",
@@ -369,6 +381,7 @@ def _build_docs_remediation_prompt(
 
 def _build_standard_repair_prompt(
     *,
+    approved_plan: ApprovedPlan | None = None,
     intake: IssueIntake,
     run_record: RunRecord,
     run_dir: Path,
@@ -383,6 +396,7 @@ def _build_standard_repair_prompt(
         f"Run ID: {run_record.run_id}",
         f"Issue: {intake.issue.reference}",
         f"Title: {intake.issue.title}",
+        *(_render_approved_plan_context(approved_plan)),
         "Requirements:",
         "- Modify code in the current workspace to resolve the issue.",
         "- Use the documented local setup/test contract as the source of truth.",
@@ -407,4 +421,24 @@ def _build_standard_repair_prompt(
             + f"\n{docs_fix_prompt_content}\n",
         )
     lines.insert(-1, json_instruction)
+    return lines
+
+
+def _render_approved_plan_context(approved_plan: ApprovedPlan | None) -> list[str]:
+    if approved_plan is None:
+        return []
+    lines = [
+        "Approved plan:",
+        f"- Summary: {approved_plan.plan_summary}",
+        "- Implementation steps:",
+        *[f"  - {step}" for step in approved_plan.implementation_steps],
+        f"- Retrieval surface summary: {approved_plan.retrieval_surface_summary or '(empty)'}",
+    ]
+    if approved_plan.named_references:
+        lines.append("- Named references:")
+        for ref in approved_plan.named_references:
+            suffix = f": {ref.description}" if ref.description else ""
+            lines.append(f"  - {ref.name} ({ref.reference_type}){suffix}")
+    else:
+        lines.append("- Named references: (none)")
     return lines

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import openai
 from jsonschema import ValidationError, validate
 
+from ..models import ApprovedPlan
 from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
 from .adapter import (
     REPAIR_RESULT_SCHEMA,
@@ -40,6 +41,7 @@ class VercelAIRepairAdapter:
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
@@ -49,6 +51,7 @@ class VercelAIRepairAdapter:
         stdout_path = run_dir / "repair.stdout.log"
 
         prompt = _build_repair_prompt(
+            approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import inspect
 import subprocess
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from ..docs_remediation import (
 from ..github_client import GitHubClientError, GitHubWriteClient
 from ..models import ExecutionResult, IssueIntake, QaResult, RepairResult, RunRecord
 from ..rerun_context import latest_rejected_pull_request
+from ..run_store import ApprovedPlanError, RunStore
 from .adapter import RepairAdapter
 from .qa import (
     WorkspaceQaVerifier,
@@ -51,6 +53,15 @@ class RepairStage:
     ) -> RepairResult:
         run_dir = run_dir.resolve()
         contract_artifact_dir = contract_artifact_dir.resolve()
+
+        try:
+            approved_plan = RunStore.load_approved_plan(run_dir, issue_ref=run_record.issue_ref)
+        except ApprovedPlanError as exc:
+            return RepairResult(
+                status="failed_infra",
+                summary=f"Repair stage could not load the persisted approved plan: {exc}",
+                detail_codes=("repair_approved_plan_invalid",),
+            )
 
         if self.adapter is None:
             return RepairResult(
@@ -134,13 +145,18 @@ class RepairStage:
                 workspace_path=str(workspace_path),
             )
 
-        return self.adapter.repair(
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
-            repo_workspace=repo_workspace,
-        )
+        repair_kwargs = {
+            "approved_plan": approved_plan,
+            "intake": intake,
+            "run_record": run_record,
+            "run_dir": run_dir,
+            "contract_artifact_dir": contract_artifact_dir,
+            "repo_workspace": repo_workspace,
+        }
+        parameters = inspect.signature(self.adapter.repair).parameters
+        if "approved_plan" not in parameters:
+            repair_kwargs.pop("approved_plan")
+        return self.adapter.repair(**repair_kwargs)
 
 
 def run_repair_qa_loop(

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from json import JSONDecodeError
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,21 @@ PersistedArtifact = (
     | RunRecord
     | RunRequest
 )
+
+APPROVED_PLAN_FILENAME = "approved-plan.json"
+_ALLOWED_NAMED_REFERENCE_TYPES = {"file", "interface", "symbol", "example"}
+
+
+class ApprovedPlanError(ValueError):
+    """Base error for approved-plan artifact loading failures."""
+
+
+class ApprovedPlanNotFoundError(ApprovedPlanError):
+    """Raised when an approved-plan artifact is missing."""
+
+
+class ApprovedPlanValidationError(ApprovedPlanError):
+    """Raised when an approved-plan artifact fails canonical validation."""
 
 
 class RunStore:
@@ -86,24 +102,21 @@ class RunStore:
         self._write_json(run_dir / "execution-result.json", result)
 
     def write_approved_plan(self, run_dir: Path, plan: ApprovedPlan) -> None:
-        self._write_json(run_dir / "approved-plan.json", plan)
+        self._write_json(run_dir / APPROVED_PLAN_FILENAME, plan)
 
     @staticmethod
-    def load_approved_plan(run_dir: Path) -> ApprovedPlan | None:
-        plan_path = run_dir / "approved-plan.json"
-        if not plan_path.exists():
-            return None
-        return _read_approved_plan(plan_path)
+    def load_approved_plan(run_dir: Path, *, issue_ref: str) -> ApprovedPlan:
+        return load_approved_plan_artifact(run_dir, issue_ref=issue_ref)
 
     @staticmethod
     def load_approved_plan_text(
         run_dir: Path,
+        *,
+        issue_ref: str,
         include_named_references: bool = False,
-    ) -> str | None:
-        """Load the approved plan and render it as markdown text, or None if not present."""
-        plan = RunStore.load_approved_plan(run_dir)
-        if plan is None:
-            return None
+    ) -> str:
+        """Load the approved plan and render it as markdown text."""
+        plan = RunStore.load_approved_plan(run_dir, issue_ref=issue_ref)
         return render_approved_plan_text(plan, include_named_references=include_named_references)
 
     def write_evaluation_result(self, run_dir: Path, result: EvaluationResult) -> None:
@@ -193,76 +206,165 @@ def _read_run_record(path: Path) -> RunRecord:
     )
 
 
-def _read_approved_plan(path: Path) -> ApprovedPlan:
-    """Read an approved plan from a JSON file."""
-    with path.open(encoding="utf-8") as f:
-        payload = json.load(f)
+def load_approved_plan_artifact(path: Path, *, issue_ref: str) -> ApprovedPlan:
+    """Load and validate an approved-plan artifact from a file path or run directory."""
+    plan_path = _resolve_approved_plan_path(path)
+    if not plan_path.exists():
+        raise ApprovedPlanNotFoundError(f"Approved plan artifact not found: {plan_path}")
+    try:
+        with plan_path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except JSONDecodeError as exc:
+        raise ApprovedPlanValidationError(
+            f"Approved plan artifact at {plan_path} is not valid JSON: {exc.msg}"
+        ) from exc
+    return _parse_approved_plan_payload(payload, path=plan_path, issue_ref=issue_ref)
+
+
+def _resolve_approved_plan_path(path: Path) -> Path:
+    if path.exists() and path.is_dir():
+        return path / APPROVED_PLAN_FILENAME
+    return path
+
+
+def _parse_approved_plan_payload(
+    payload: object,
+    *,
+    path: Path,
+    issue_ref: str,
+) -> ApprovedPlan:
     if not isinstance(payload, dict):
-        raise ValueError(f"Expected JSON object in {path}")
-    if "issue_ref" not in payload:
-        raise ValueError("Approved plan is missing required field 'issue_ref'")
-    plan_issue_ref = _require_non_empty_str(payload.get("issue_ref"), field_name="issue_ref")
-    plan_summary = _require_non_empty_str(payload.get("plan_summary"), field_name="plan_summary")
-    implementation_steps = _read_implementation_steps(payload)
-    approved = _read_approved_flag(payload)
-    named_references_raw = payload.get("named_references", [])
-    if not isinstance(named_references_raw, list):
-        raise ValueError("Expected 'named_references' to be a list")
-    named_refs: list[NamedReference] = []
-    allowed_types = {"file", "interface", "symbol", "example"}
-    for ref in named_references_raw:
-        if isinstance(ref, dict):
-            name = str(ref.get("name", ""))
-            if not name:
-                raise ValueError("Named reference has empty name")
-            ref_type = ref.get("reference_type", "file")
-            if ref_type not in allowed_types:
-                raise ValueError(
-                    f"Named reference has invalid reference_type '{ref_type}'; expected one of {allowed_types}"
-                )
-            named_refs.append(
-                NamedReference(
-                    name=name,
-                    reference_type=ref_type,
-                    description=str(ref.get("description", "")),
-                )
-            )
-        else:
-            named_refs.append(NamedReference(name=str(ref)))
+        raise ApprovedPlanValidationError(f"Expected JSON object in {path}")
+
+    plan_issue_ref = _require_non_empty_str_field(payload, field_name="issue_ref")
+    if plan_issue_ref != issue_ref:
+        raise ApprovedPlanValidationError(
+            f"Approved plan issue_ref '{plan_issue_ref}' does not match expected issue_ref '{issue_ref}'"
+        )
+
     return ApprovedPlan(
         issue_ref=plan_issue_ref,
-        plan_summary=plan_summary,
-        implementation_steps=implementation_steps,
-        named_references=tuple(named_refs),
-        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
-        approved=approved,
+        plan_summary=_require_non_empty_str_field(payload, field_name="plan_summary"),
+        implementation_steps=_read_implementation_steps(payload),
+        named_references=_read_named_references(payload),
+        retrieval_surface_summary=_require_string_field(
+            payload,
+            field_name="retrieval_surface_summary",
+        ),
+        approved=_read_approved_flag(payload),
     )
 
 
 def _require_non_empty_str(value: object, *, field_name: str) -> str:
     if not isinstance(value, str):
-        raise ValueError(f"Approved plan field '{field_name}' must be a string")
+        raise ApprovedPlanValidationError(f"Approved plan field '{field_name}' must be a string")
     if not value.strip():
-        raise ValueError(f"Approved plan is missing a non-empty '{field_name}'")
+        raise ApprovedPlanValidationError(f"Approved plan is missing a non-empty '{field_name}'")
+    return value
+
+
+def _require_non_empty_str_field(payload: dict[str, object], *, field_name: str) -> str:
+    if field_name not in payload:
+        raise ApprovedPlanValidationError(
+            f"Approved plan is missing required field '{field_name}'"
+        )
+    return _require_non_empty_str(payload[field_name], field_name=field_name)
+
+
+def _require_string_field(payload: dict[str, object], *, field_name: str) -> str:
+    if field_name not in payload:
+        raise ApprovedPlanValidationError(
+            f"Approved plan is missing required field '{field_name}'"
+        )
+    value = payload[field_name]
+    if not isinstance(value, str):
+        raise ApprovedPlanValidationError(f"Approved plan field '{field_name}' must be a string")
     return value
 
 
 def _read_implementation_steps(payload: dict[str, object]) -> tuple[str, ...]:
-    implementation_steps_raw = payload.get("implementation_steps", [])
+    if "implementation_steps" not in payload:
+        raise ApprovedPlanValidationError(
+            "Approved plan is missing required field 'implementation_steps'"
+        )
+    implementation_steps_raw = payload["implementation_steps"]
     if not isinstance(implementation_steps_raw, list):
-        raise ValueError("Expected 'implementation_steps' to be a list")
-    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
+        raise ApprovedPlanValidationError("Expected 'implementation_steps' to be a list")
+    implementation_steps: list[str] = []
+    for index, step in enumerate(implementation_steps_raw, start=1):
+        if not isinstance(step, str):
+            raise ApprovedPlanValidationError(
+                f"Approved plan implementation_steps[{index}] must be a string"
+            )
+        if not step.strip():
+            raise ApprovedPlanValidationError(
+                f"Approved plan implementation_steps[{index}] must be a non-empty string"
+            )
+        implementation_steps.append(step)
     if not implementation_steps:
-        raise ValueError("Approved plan has no implementation steps")
-    return implementation_steps
+        raise ApprovedPlanValidationError("Approved plan has no implementation steps")
+    return tuple(implementation_steps)
+
+
+def _read_named_references(payload: dict[str, object]) -> tuple[NamedReference, ...]:
+    if "named_references" not in payload:
+        raise ApprovedPlanValidationError(
+            "Approved plan is missing required field 'named_references'"
+        )
+    named_references_raw = payload["named_references"]
+    if not isinstance(named_references_raw, list):
+        raise ApprovedPlanValidationError("Expected 'named_references' to be a list")
+
+    named_refs: list[NamedReference] = []
+    for index, ref in enumerate(named_references_raw, start=1):
+        if isinstance(ref, str):
+            name = _require_non_empty_str(ref, field_name=f"named_references[{index}]")
+            named_refs.append(NamedReference(name=name))
+            continue
+        if not isinstance(ref, dict):
+            raise ApprovedPlanValidationError(
+                f"Approved plan named_references[{index}] must be a string or object"
+            )
+
+        if "name" not in ref:
+            raise ApprovedPlanValidationError(
+                f"Approved plan named_references[{index}] is missing required field 'name'"
+            )
+        name = _require_non_empty_str(ref["name"], field_name=f"named_references[{index}].name")
+
+        reference_type = ref.get("reference_type", "file")
+        if not isinstance(reference_type, str) or reference_type not in _ALLOWED_NAMED_REFERENCE_TYPES:
+            raise ApprovedPlanValidationError(
+                "Approved plan named_references[{}].reference_type must be one of {}".format(
+                    index,
+                    sorted(_ALLOWED_NAMED_REFERENCE_TYPES),
+                )
+            )
+
+        description = ref.get("description", "")
+        if not isinstance(description, str):
+            raise ApprovedPlanValidationError(
+                f"Approved plan named_references[{index}].description must be a string"
+            )
+
+        named_refs.append(
+            NamedReference(
+                name=name,
+                reference_type=cast(Literal["file", "interface", "symbol", "example"], reference_type),
+                description=description,
+            )
+        )
+    return tuple(named_refs)
 
 
 def _read_approved_flag(payload: dict[str, object]) -> bool:
-    approved_raw = payload.get("approved", True)
+    if "approved" not in payload:
+        raise ApprovedPlanValidationError("Approved plan is missing required field 'approved'")
+    approved_raw = payload["approved"]
     if not isinstance(approved_raw, bool):
-        raise ValueError("Approved plan field 'approved' must be a boolean")
+        raise ApprovedPlanValidationError("Approved plan field 'approved' must be a boolean")
     if not approved_raw:
-        raise ValueError("Approved plan must have 'approved': true")
+        raise ApprovedPlanValidationError("Approved plan must have 'approved': true")
     return approved_raw
 
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -95,6 +95,17 @@ class RunStore:
             return None
         return _read_approved_plan(plan_path)
 
+    @staticmethod
+    def load_approved_plan_text(
+        run_dir: Path,
+        include_named_references: bool = False,
+    ) -> str | None:
+        """Load the approved plan and render it as markdown text, or None if not present."""
+        plan = RunStore.load_approved_plan(run_dir)
+        if plan is None:
+            return None
+        return render_approved_plan_text(plan, include_named_references=include_named_references)
+
     def write_evaluation_result(self, run_dir: Path, result: EvaluationResult) -> None:
         self._write_json(run_dir / "evaluation-result.json", result)
 
@@ -186,9 +197,20 @@ def _read_approved_plan(path: Path) -> ApprovedPlan:
     """Read an approved plan from a JSON file."""
     with path.open(encoding="utf-8") as f:
         payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    if "issue_ref" not in payload:
+        raise ValueError("Approved plan is missing required field 'issue_ref'")
+    plan_issue_ref = _require_non_empty_str(payload.get("issue_ref"), field_name="issue_ref")
+    plan_summary = _require_non_empty_str(payload.get("plan_summary"), field_name="plan_summary")
+    implementation_steps = _read_implementation_steps(payload)
+    approved = _read_approved_flag(payload)
+    named_references_raw = payload.get("named_references", [])
+    if not isinstance(named_references_raw, list):
+        raise ValueError("Expected 'named_references' to be a list")
     named_refs: list[NamedReference] = []
     allowed_types = {"file", "interface", "symbol", "example"}
-    for ref in payload.get("named_references", []):
+    for ref in named_references_raw:
         if isinstance(ref, dict):
             name = str(ref.get("name", ""))
             if not name:
@@ -208,10 +230,63 @@ def _read_approved_plan(path: Path) -> ApprovedPlan:
         else:
             named_refs.append(NamedReference(name=str(ref)))
     return ApprovedPlan(
-        issue_ref=str(payload["issue_ref"]),
-        plan_summary=str(payload["plan_summary"]),
-        implementation_steps=tuple(str(step) for step in payload.get("implementation_steps", [])),
+        issue_ref=plan_issue_ref,
+        plan_summary=plan_summary,
+        implementation_steps=implementation_steps,
         named_references=tuple(named_refs),
         retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
-        approved=bool(payload.get("approved", True)),
+        approved=approved,
     )
+
+
+def _require_non_empty_str(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"Approved plan field '{field_name}' must be a string")
+    if not value.strip():
+        raise ValueError(f"Approved plan is missing a non-empty '{field_name}'")
+    return value
+
+
+def _read_implementation_steps(payload: dict[str, object]) -> tuple[str, ...]:
+    implementation_steps_raw = payload.get("implementation_steps", [])
+    if not isinstance(implementation_steps_raw, list):
+        raise ValueError("Expected 'implementation_steps' to be a list")
+    implementation_steps = tuple(str(step) for step in implementation_steps_raw)
+    if not implementation_steps:
+        raise ValueError("Approved plan has no implementation steps")
+    return implementation_steps
+
+
+def _read_approved_flag(payload: dict[str, object]) -> bool:
+    approved_raw = payload.get("approved", True)
+    if not isinstance(approved_raw, bool):
+        raise ValueError("Approved plan field 'approved' must be a boolean")
+    if not approved_raw:
+        raise ValueError("Approved plan must have 'approved': true")
+    return approved_raw
+
+
+def render_approved_plan_text(
+    plan: ApprovedPlan,
+    include_named_references: bool = False,
+) -> str:
+    """Render an ApprovedPlan to markdown text for context packs."""
+    approval_marker = "Approved Plan"
+    lines = [
+        f"# {approval_marker}: {plan.issue_ref}",
+        "",
+        plan.plan_summary,
+        "",
+        "## Implementation Steps",
+    ]
+    for step in plan.implementation_steps:
+        lines.append(f"- {step}")
+    if plan.retrieval_surface_summary:
+        lines.extend(["", f"**Retrieval Surface:** {plan.retrieval_surface_summary}"])
+    if include_named_references and plan.named_references:
+        lines.extend(["", "## Named References"])
+        for ref in plan.named_references:
+            ref_type_suffix = f" ({ref.reference_type})" if ref.reference_type != "file" else ""
+            desc_suffix = f": {ref.description}" if ref.description else ""
+            lines.append(f"- {ref.name}{ref_type_suffix}{desc_suffix}")
+    return "\n".join(lines)

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -10,10 +10,12 @@ from typing import Literal, cast
 from uuid import uuid4
 
 from .models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
     IssueIntake,
+    NamedReference,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -24,7 +26,8 @@ from .models import (
 )
 
 PersistedArtifact = (
-    EvaluationResult
+    ApprovedPlan
+    | EvaluationResult
     | ExecutionResult
     | GovernanceVerdict
     | IssueIntake
@@ -81,6 +84,16 @@ class RunStore:
 
     def write_execution_result(self, run_dir: Path, result: ExecutionResult) -> None:
         self._write_json(run_dir / "execution-result.json", result)
+
+    def write_approved_plan(self, run_dir: Path, plan: ApprovedPlan) -> None:
+        self._write_json(run_dir / "approved-plan.json", plan)
+
+    @staticmethod
+    def load_approved_plan(run_dir: Path) -> ApprovedPlan | None:
+        plan_path = run_dir / "approved-plan.json"
+        if not plan_path.exists():
+            return None
+        return _read_approved_plan(plan_path)
 
     def write_evaluation_result(self, run_dir: Path, result: EvaluationResult) -> None:
         self._write_json(run_dir / "evaluation-result.json", result)
@@ -166,4 +179,39 @@ def _read_run_record(path: Path) -> RunRecord:
         updated_at=str(payload["updated_at"]),
         run_dir=str(payload["run_dir"]),
         attempt=int(payload.get("attempt", 1)),
+    )
+
+
+def _read_approved_plan(path: Path) -> ApprovedPlan:
+    """Read an approved plan from a JSON file."""
+    with path.open(encoding="utf-8") as f:
+        payload = json.load(f)
+    named_refs: list[NamedReference] = []
+    allowed_types = {"file", "interface", "symbol", "example"}
+    for ref in payload.get("named_references", []):
+        if isinstance(ref, dict):
+            name = str(ref.get("name", ""))
+            if not name:
+                raise ValueError("Named reference has empty name")
+            ref_type = ref.get("reference_type", "file")
+            if ref_type not in allowed_types:
+                raise ValueError(
+                    f"Named reference has invalid reference_type '{ref_type}'; expected one of {allowed_types}"
+                )
+            named_refs.append(
+                NamedReference(
+                    name=name,
+                    reference_type=ref_type,
+                    description=str(ref.get("description", "")),
+                )
+            )
+        else:
+            named_refs.append(NamedReference(name=str(ref)))
+    return ApprovedPlan(
+        issue_ref=str(payload["issue_ref"]),
+        plan_summary=str(payload["plan_summary"]),
+        implementation_steps=tuple(str(step) for step in payload.get("implementation_steps", [])),
+        named_references=tuple(named_refs),
+        retrieval_surface_summary=str(payload.get("retrieval_surface_summary", "")),
+        approved=bool(payload.get("approved", True)),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
 from precision_squad.cli import main
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
@@ -1162,3 +1163,329 @@ def test_publish_run_retries_stale_rejected_post_publish_review(
     assert "Post-Publish Review: approved" in captured.out
     assert review_payload["status"] == "approved"
     assert review_payload["pull_head_sha"] == "new-sha"
+
+
+def test_run_issue_with_approved_plan_path_persists_approved_plan(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    monkeypatch.setattr(
+        "precision_squad.cli.DocsFirstExecutor.execute",
+        lambda self, intake, record, run_dir: ExecutionResult(
+            status="completed",
+            executor_name="docs",
+            summary="Stub execution completed.",
+            detail_codes=(),
+        ),
+    )
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add --version flag using click.",
+                "implementation_steps": ["Add click.option('--version')", "Bump __version__"],
+                "named_references": ["src/cli.py"],
+                "retrieval_surface_summary": "src/",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    run_dir_line = next(line for line in captured.out.splitlines() if line.startswith("Run Dir:"))
+    run_dir = Path(run_dir_line.removeprefix("Run Dir:").strip())
+
+    assert status == 0
+    assert (run_dir / "approved-plan.json").exists()
+    plan_payload = json.loads((run_dir / "approved-plan.json").read_text(encoding="utf-8"))
+    assert plan_payload["issue_ref"] == "cracklings3d/markdown-pdf-renderer#9"
+    assert plan_payload["plan_summary"] == "Add --version flag using click."
+    assert plan_payload["implementation_steps"] == [
+        "Add click.option('--version')",
+        "Bump __version__",
+    ]
+
+
+def test_run_issue_with_mismatched_approved_plan_issue_ref_raises(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#99",
+                "plan_summary": "Different issue plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "does not match CLI issue_ref" in captured.err
+
+
+def test_load_approved_plan_rejects_missing_plan_summary(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "non-empty" in captured.err.lower() or "plan_summary" in captured.err.lower()
+
+
+def test_load_approved_plan_rejects_missing_implementation_steps(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "A valid plan",
+                "implementation_steps": [],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "implementation steps" in captured.err.lower()
+
+
+class TestLoadApprovedPlanValidation:
+    def test_rejects_missing_issue_ref(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="issue_ref"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_wrong_issue_ref(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#99",
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="does not match"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_empty_plan_summary(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "   ",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="plan_summary"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_empty_implementation_steps(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": [],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="implementation steps"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_returns_approved_plan(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "Fix the bug",
+                    "implementation_steps": ["Step 1", "Step 2"],
+                    "named_references": ["src/main.py"],
+                    "retrieval_surface_summary": "src/",
+                    "approved": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        plan = _load_approved_plan(plan_path, "owner/repo#1")
+        assert isinstance(plan, ApprovedPlan)
+        assert plan.issue_ref == "owner/repo#1"
+        assert plan.plan_summary == "Fix the bug"
+        assert plan.implementation_steps == ("Step 1", "Step 2")
+        assert tuple(ref.name for ref in plan.named_references) == ("src/main.py",)
+        assert plan.retrieval_surface_summary == "src/"
+        assert plan.approved is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1464,6 +1464,26 @@ class TestLoadApprovedPlanValidation:
         with pytest.raises(ValueError, match="implementation steps"):
             _load_approved_plan(plan_path, "owner/repo#1")
 
+    def test_rejects_unapproved_plan(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                    "approved": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="approved.*true"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
     def test_returns_approved_plan(self, tmp_path: Path) -> None:
         plan_path = tmp_path / "approved-plan.json"
         plan_path.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,7 +102,7 @@ def test_run_issue_placeholder_returns_nonzero(
 
     captured = capsys.readouterr()
     assert status == 1
-    assert "github token" in captured.err.lower()
+    assert "approved-plan-path" in captured.err.lower()
 
 
 def test_run_issue_prints_runnable_intake(
@@ -122,6 +122,20 @@ def test_run_issue_prints_runnable_intake(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add version flag.",
+                "implementation_steps": ["Update CLI"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         "precision_squad.cli.DocsFirstExecutor.execute",
         lambda self, intake, record, run_dir: ExecutionResult(
@@ -141,6 +155,8 @@ def test_run_issue_prints_runnable_intake(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -169,6 +185,20 @@ def test_repair_issue_alias_prints_runnable_intake(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add version flag.",
+                "implementation_steps": ["Update CLI"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         "precision_squad.cli.DocsFirstExecutor.execute",
         lambda self, intake, record, run_dir: ExecutionResult(
@@ -188,6 +218,8 @@ def test_repair_issue_alias_prints_runnable_intake(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -217,6 +249,20 @@ def test_run_issue_prints_blocked_intake(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#1",
+                "plan_summary": "Plan artifact.",
+                "implementation_steps": ["Do thing"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     status = main(
         [
@@ -227,6 +273,8 @@ def test_run_issue_prints_blocked_intake(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -256,6 +304,20 @@ def test_run_issue_persists_run_artifacts(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add version flag.",
+                "implementation_steps": ["Update CLI"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         "precision_squad.cli.DocsFirstExecutor.execute",
         lambda self, intake, record, run_dir: ExecutionResult(
@@ -275,6 +337,8 @@ def test_run_issue_persists_run_artifacts(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -310,6 +374,20 @@ def test_run_issue_uses_executor_and_persists_execution_result(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Add version flag.",
+                "implementation_steps": ["Update CLI"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         "precision_squad.cli.DocsFirstExecutor.execute",
         lambda self, intake, record, run_dir: ExecutionResult(
@@ -329,6 +407,8 @@ def test_run_issue_uses_executor_and_persists_execution_result(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -364,6 +444,7 @@ def test_run_issue_does_not_enter_repair_loop_when_docs_are_missing(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="cracklings3d/markdown-pdf-renderer#9")
     monkeypatch.setattr(
         "precision_squad.cli.DocsFirstExecutor.execute",
         lambda self, intake, record, run_dir: ExecutionResult(
@@ -389,6 +470,8 @@ def test_run_issue_does_not_enter_repair_loop_when_docs_are_missing(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -421,6 +504,7 @@ def test_docs_remediation_issue_runs_repair_without_recursive_follow_up_issue(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="cracklings3d/markdown-pdf-renderer#16")
 
     workspace_root = tmp_path / "workspace"
     (workspace_root / "repo").mkdir(parents=True)
@@ -475,6 +559,8 @@ def test_docs_remediation_issue_runs_repair_without_recursive_follow_up_issue(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -502,6 +588,7 @@ def test_docs_remediation_issue_stays_blocked_when_revalidation_fails(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="cracklings3d/markdown-pdf-renderer#16")
 
     workspace_root = tmp_path / "workspace"
     (workspace_root / "repo").mkdir(parents=True)
@@ -563,6 +650,8 @@ def test_docs_remediation_issue_stays_blocked_when_revalidation_fails(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -590,6 +679,7 @@ def test_run_issue_persists_repair_result_when_synthesis_artifacts_exist(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="cracklings3d/markdown-pdf-renderer#9")
 
     def fake_execute(self, intake, record, run_dir):
         del self, intake
@@ -641,6 +731,8 @@ def test_run_issue_persists_repair_result_when_synthesis_artifacts_exist(
             str(tmp_path / "runs"),
             "--repair-agent",
             "none",
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -673,6 +765,7 @@ def test_run_issue_marks_baseline_tolerant_success_approved(
     )
 
     monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="cracklings3d/markdown-pdf-renderer#9")
 
     def fake_execute(self, intake, record, run_dir):
         del self, intake
@@ -723,6 +816,8 @@ def test_run_issue_marks_baseline_tolerant_success_approved(
             str(tmp_path / "repo"),
             "--runs-dir",
             str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -1201,6 +1296,7 @@ def test_run_issue_with_approved_plan_path_persists_approved_plan(
                 "implementation_steps": ["Add click.option('--version')", "Bump __version__"],
                 "named_references": ["src/cli.py"],
                 "retrieval_surface_summary": "src/",
+                "approved": True,
             }
         ),
         encoding="utf-8",
@@ -1233,6 +1329,9 @@ def test_run_issue_with_approved_plan_path_persists_approved_plan(
         "Add click.option('--version')",
         "Bump __version__",
     ]
+    assert plan_payload["named_references"] == [
+        {"name": "src/cli.py", "reference_type": "file", "description": ""}
+    ]
 
 
 def test_run_issue_with_mismatched_approved_plan_issue_ref_raises(
@@ -1262,6 +1361,7 @@ def test_run_issue_with_mismatched_approved_plan_issue_ref_raises(
                 "implementation_steps": ["Step 1"],
                 "named_references": [],
                 "retrieval_surface_summary": "",
+                "approved": True,
             }
         ),
         encoding="utf-8",
@@ -1283,7 +1383,132 @@ def test_run_issue_with_mismatched_approved_plan_issue_ref_raises(
 
     assert status == 1
     captured = capsys.readouterr()
-    assert "does not match CLI issue_ref" in captured.err
+    assert "does not match expected issue_ref" in captured.err
+
+
+def test_run_issue_requires_approved_plan_path_for_fresh_runs(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "require --approved-plan-path" in captured.err
+    assert not (tmp_path / "runs").exists()
+
+
+def test_repair_issue_help_mentions_fresh_run_approved_plan_requirement(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["repair", "issue", "--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "Required for fresh" in captured.out
+    assert "retries may omit it" in captured.out
+
+
+def test_load_approved_plan_rejects_missing_retrieval_surface_summary(
+    capsys, tmp_path: Path
+) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "A valid plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "retrieval_surface_summary" in captured.err
+    assert not (tmp_path / "runs").exists()
+
+
+def test_load_approved_plan_rejects_non_object_json_payload(capsys, tmp_path: Path) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text("[]\n", encoding="utf-8")
+
+    status = main(
+        [
+            "run",
+            "issue",
+            "cracklings3d/markdown-pdf-renderer#9",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Expected JSON object" in captured.err
+    assert not (tmp_path / "runs").exists()
+
+
+def _write_valid_plan(tmp_path: Path, *, issue_ref: str) -> Path:
+    plan_path = tmp_path / f"{issue_ref.split('#')[-1]}-approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": issue_ref,
+                "plan_summary": "Approved plan summary.",
+                "implementation_steps": ["Implement the change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return plan_path
 
 
 def test_load_approved_plan_rejects_missing_plan_summary(
@@ -1398,6 +1623,7 @@ class TestLoadApprovedPlanValidation:
                     "implementation_steps": ["Step 1"],
                     "named_references": [],
                     "retrieval_surface_summary": "",
+                    "approved": True,
                 }
             ),
             encoding="utf-8",
@@ -1417,6 +1643,7 @@ class TestLoadApprovedPlanValidation:
                     "implementation_steps": ["Step 1"],
                     "named_references": [],
                     "retrieval_surface_summary": "",
+                    "approved": True,
                 }
             ),
             encoding="utf-8",
@@ -1436,6 +1663,7 @@ class TestLoadApprovedPlanValidation:
                     "implementation_steps": ["Step 1"],
                     "named_references": [],
                     "retrieval_surface_summary": "",
+                    "approved": True,
                 }
             ),
             encoding="utf-8",
@@ -1455,6 +1683,7 @@ class TestLoadApprovedPlanValidation:
                     "implementation_steps": [],
                     "named_references": [],
                     "retrieval_surface_summary": "",
+                    "approved": True,
                 }
             ),
             encoding="utf-8",
@@ -1482,6 +1711,45 @@ class TestLoadApprovedPlanValidation:
         from precision_squad.cli import _load_approved_plan
 
         with pytest.raises(ValueError, match="approved.*true"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_missing_named_references(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": ["Step 1"],
+                    "retrieval_surface_summary": "",
+                    "approved": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="named_references"):
+            _load_approved_plan(plan_path, "owner/repo#1")
+
+    def test_rejects_non_string_implementation_step(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "approved-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "issue_ref": "owner/repo#1",
+                    "plan_summary": "A plan",
+                    "implementation_steps": [1],
+                    "named_references": [],
+                    "retrieval_surface_summary": "",
+                    "approved": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        from precision_squad.cli import _load_approved_plan
+
+        with pytest.raises(ValueError, match="implementation_steps\[1\]"):
             _load_approved_plan(plan_path, "owner/repo#1")
 
     def test_returns_approved_plan(self, tmp_path: Path) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -28,6 +28,7 @@ from precision_squad.repair import (
     merge_docs_remediation_execution_result,
     merge_execution_result,
 )
+from precision_squad.models import ApprovedPlan
 
 
 def _intake() -> IssueIntake:
@@ -352,6 +353,19 @@ def test_repair_stage_reports_not_configured_when_command_missing(tmp_path: Path
     run_dir.mkdir()
     contract_dir = run_dir / "execution-contract"
     contract_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     result = RepairStage(repo_path=repo_path, adapter=None).execute(
         _intake(),
@@ -364,6 +378,17 @@ def test_repair_stage_reports_not_configured_when_command_missing(tmp_path: Path
     assert "repair_stage_not_configured" in result.detail_codes
 
 
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        plan_summary="Repair the issue.",
+        implementation_steps=("Apply minimal change",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
+
+
 def test_repair_stage_clears_existing_workspace_before_clone(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -373,6 +398,19 @@ def test_repair_stage_clears_existing_workspace_before_clone(
     run_dir.mkdir()
     contract_dir = run_dir / "execution-contract"
     contract_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     stale_repo_workspace = run_dir / "repair-workspace" / "repo"
     stale_repo_workspace.mkdir(parents=True)
     (stale_repo_workspace / "stale.txt").write_text("stale", encoding="utf-8")
@@ -422,6 +460,130 @@ def test_repair_stage_clears_existing_workspace_before_clone(
     assert result.status == "completed"
 
 
+def test_repair_stage_fails_before_workspace_side_effects_when_approved_plan_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+
+    def fail_if_git_runs(*args, **kwargs):
+        raise AssertionError("git commands should not run before approved-plan validation")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            raise AssertionError("adapter should not run before approved-plan validation")
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fail_if_git_runs)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert "approved plan" in result.summary.lower()
+    assert "repair_approved_plan_invalid" in result.detail_codes
+
+
+def test_repair_stage_fails_before_workspace_side_effects_when_approved_plan_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": [1],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_if_git_runs(*args, **kwargs):
+        raise AssertionError("git commands should not run before approved-plan validation")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            raise AssertionError("adapter should not run before approved-plan validation")
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fail_if_git_runs)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert "approved plan" in result.summary.lower()
+    assert "repair_approved_plan_invalid" in result.detail_codes
+
+
+def test_repair_stage_with_no_adapter_still_fails_when_approved_plan_missing(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+
+    result = RepairStage(repo_path=repo_path, adapter=None).execute(
+        _intake(),
+        _record(run_dir),
+        run_dir,
+        contract_dir,
+    )
+
+    assert result.status == "failed_infra"
+    assert "approved plan" in result.summary.lower()
+    assert "repair_approved_plan_invalid" in result.detail_codes
+
+
+def test_repair_stage_with_no_adapter_still_fails_when_approved_plan_invalid(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": None,
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = RepairStage(repo_path=repo_path, adapter=None).execute(
+        _intake(),
+        _record(run_dir),
+        run_dir,
+        contract_dir,
+    )
+
+    assert result.status == "failed_infra"
+    assert "approved plan" in result.summary.lower()
+    assert "repair_approved_plan_invalid" in result.detail_codes
+
+
 def test_opencode_repair_adapter_reports_no_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -453,6 +615,7 @@ def test_opencode_repair_adapter_reports_no_changes(
     monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
 
     result = OpenCodeRepairAdapter().repair(
+        approved_plan=_approved_plan(),
         intake=_intake(),
         run_record=_record(run_dir),
         run_dir=run_dir,
@@ -500,6 +663,7 @@ def test_opencode_repair_adapter_prompt_references_issue_context_artifact(
     monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
 
     OpenCodeRepairAdapter().repair(
+        approved_plan=_approved_plan(),
         intake=_intake(),
         run_record=_record(run_dir),
         run_dir=run_dir,
@@ -541,6 +705,7 @@ def test_opencode_repair_adapter_resolves_custom_provider_model(
     monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
 
     OpenCodeRepairAdapter(model="custom-openai-model").repair(
+        approved_plan=_approved_plan(),
         intake=_intake(),
         run_record=_record(run_dir),
         run_dir=run_dir,
@@ -586,6 +751,7 @@ def test_opencode_repair_adapter_uses_env_default_model_when_unspecified(
     monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
 
     OpenCodeRepairAdapter().repair(
+        approved_plan=_approved_plan(),
         intake=_intake(),
         run_record=_record(run_dir),
         run_dir=run_dir,
@@ -636,6 +802,14 @@ def test_opencode_repair_adapter_uses_docs_remediation_prompt_for_docs_issue(
     monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
 
     OpenCodeRepairAdapter().repair(
+        approved_plan=ApprovedPlan(
+            issue_ref="cracklings3d/markdown-pdf-renderer#16",
+            plan_summary="Fix docs.",
+            implementation_steps=("Update README",),
+            named_references=(),
+            retrieval_surface_summary="docs/",
+            approved=True,
+        ),
         intake=IssueIntake(
             issue=GitHubIssue(
                 reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 16),
@@ -1233,6 +1407,7 @@ def test_opencode_repair_adapter_prompt_includes_json_output_instruction(
     _write_contract(contract_dir, ["python -m pip install -e .[dev]"], "python -m pytest tests/test_cli.py")
 
     prompt = _build_repair_prompt(
+        approved_plan=_approved_plan(),
         intake=_intake(),
         run_record=_record(run_dir),
         run_dir=run_dir,
@@ -1284,6 +1459,14 @@ def test_opencode_repair_adapter_prompt_inlines_docs_fix_prompt_for_docs_remedia
     )
 
     prompt = _build_repair_prompt(
+        approved_plan=ApprovedPlan(
+            issue_ref="cracklings3d/markdown-pdf-renderer#16",
+            plan_summary="Fix docs.",
+            implementation_steps=("Update docs",),
+            named_references=(),
+            retrieval_surface_summary="docs/",
+            approved=True,
+        ),
         intake=docs_intake,
         run_record=_record(run_dir),
         run_dir=run_dir,

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from precision_squad.models import (
+    ApprovedPlan,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
@@ -116,6 +117,17 @@ def _make_run_record() -> RunRecord:
     )
 
 
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Repair the issue.",
+        implementation_steps=("Apply minimal change",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
+
+
 def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
@@ -137,6 +149,7 @@ def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -170,6 +183,7 @@ def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -202,6 +216,7 @@ def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -229,6 +244,7 @@ def test_repair_adapter_api_failure(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -261,6 +277,7 @@ def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -304,6 +321,7 @@ def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
 
         adapter = VercelAIRepairAdapter(model="gpt-4o")
         result = adapter.repair(
+            approved_plan=_approved_plan(),
             intake=intake,
             run_record=run_record,
             run_dir=run_dir,
@@ -339,6 +357,7 @@ def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.Monke
 
         adapter = VercelAIRepairAdapter()
         adapter.repair(
+                approved_plan=_approved_plan(),
                 intake=intake,
                 run_record=run_record,
                 run_dir=run_dir,

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import cast
 
@@ -46,6 +47,22 @@ def _record(tmp_path: Path) -> RunRecord:
         created_at="2026-04-27T00:00:00Z",
         updated_at="2026-04-27T00:00:00Z",
         run_dir=str(tmp_path / "run-123"),
+    )
+
+
+def _write_approved_plan(run_dir: Path) -> None:
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Review the implementation against the approved plan.",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -176,6 +193,7 @@ def test_opencode_pr_review_agent_resolves_custom_provider_model(
 ) -> None:
     monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "MiniMax-M2.7-highspeed")
     commands: list[list[str]] = []
+    _write_approved_plan(tmp_path)
 
     def fake_run(command, cwd, capture_output, text):
         del cwd, capture_output, text
@@ -192,6 +210,10 @@ def test_opencode_pr_review_agent_resolves_custom_provider_model(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
         intake=_intake(),
@@ -209,6 +231,7 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
 ) -> None:
     monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "minimax-cn-coding-plan/MiniMax-M2.7-highspeed")
     commands: list[list[str]] = []
+    _write_approved_plan(tmp_path)
 
     def fake_run(command, cwd, capture_output, text):
         del cwd, capture_output, text
@@ -225,6 +248,10 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
         intake=_intake(),
@@ -240,6 +267,8 @@ def test_opencode_pr_review_agent_uses_full_configured_model_id(
 def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _write_approved_plan(tmp_path)
+
     def fake_run(command, cwd, capture_output, text):
         del command, cwd, capture_output, text
 
@@ -254,6 +283,10 @@ def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
         return _Completed()
 
     monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
 
     result = OpenCodePrReviewAgent(role="architect").review(
         intake=_intake(),
@@ -265,6 +298,38 @@ def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
     assert result.status == "rejected"
     assert result.summary == "needs follow-up"
     assert result.feedback == ("fix review handling",)
+
+
+def test_opencode_pr_review_agent_fails_when_persisted_plan_is_unapproved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+
+    result = OpenCodePrReviewAgent(role="reviewer").review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+    )
+
+    assert result.status == "failed_infra"
+    assert "approved" in result.summary.lower()
 
 
 def test_parse_review_output_accepts_prose_before_json() -> None:

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -19,6 +19,7 @@ from precision_squad.post_publish_review import (
     OpenCodePrReviewAgent,
     ReviewAgentResult,
     ReviewRunner,
+    _build_review_prompt,
     _parse_review_output,
     run_post_publish_review,
 )
@@ -64,6 +65,14 @@ def _write_approved_plan(run_dir: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _write_invalid_approved_plan(run_dir: Path, payload: dict[str, object]) -> None:
+    (run_dir / "approved-plan.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_raw_approved_plan(run_dir: Path, raw_payload: str) -> None:
+    (run_dir / "approved-plan.json").write_text(raw_payload, encoding="utf-8")
 
 
 def test_run_post_publish_review_reopens_issue_on_rejection(
@@ -330,6 +339,198 @@ def test_opencode_pr_review_agent_fails_when_persisted_plan_is_unapproved(
 
     assert result.status == "failed_infra"
     assert "approved" in result.summary.lower()
+
+
+def test_build_review_prompt_fails_when_persisted_plan_is_missing(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Approved plan artifact not found"):
+        _build_review_prompt(
+            role="reviewer",
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        )
+
+
+def test_build_review_prompt_fails_when_persisted_plan_has_invalid_structure(tmp_path: Path) -> None:
+    _write_invalid_approved_plan(
+        tmp_path,
+        {
+            "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+            "plan_summary": "Valid summary",
+            "implementation_steps": ["Inspect the diff"],
+            "named_references": [],
+            "approved": True,
+        },
+    )
+
+    with pytest.raises(ValueError, match="retrieval_surface_summary"):
+        _build_review_prompt(
+            role="reviewer",
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        )
+
+
+@pytest.mark.parametrize(
+    ("writer", "payload", "match"),
+    [
+        (_write_raw_approved_plan, "[]\n", "Expected JSON object"),
+        (_write_raw_approved_plan, "{", "not valid JSON"),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#999",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "does not match",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "   ",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "plan_summary",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "implementation_steps",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": [],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "implementation steps",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["   "],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "implementation_steps\\[1\\]",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": [1],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "implementation_steps\\[1\\]",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "named_references",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [42],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "named_references\\[1\\]",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "approved": True,
+            },
+            "retrieval_surface_summary",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": None,
+                "approved": True,
+            },
+            "retrieval_surface_summary",
+        ),
+        (
+            _write_invalid_approved_plan,
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Inspect the diff"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": False,
+            },
+            "approved.*true",
+        ),
+    ],
+)
+def test_build_review_prompt_rejects_canonical_invalid_approved_plan_cases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    writer,
+    payload,
+    match: str,
+) -> None:
+    def fail_if_diff_is_fetched(*args, **kwargs):
+        raise AssertionError("PR diff should not be fetched before approved-plan validation")
+
+    monkeypatch.setattr("precision_squad.post_publish_review._fetch_pr_diff", fail_if_diff_is_fetched)
+    writer(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        _build_review_prompt(
+            role="reviewer",
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        )
 
 
 def test_parse_review_output_accepts_prose_before_json() -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
@@ -71,6 +72,17 @@ def _create_previous_run(store: RunStore, attempt: int = 1) -> RunRecord:
     return updated
 
 
+def _approved_plan(issue_ref: str = "owner/repo#1") -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref=issue_ref,
+        plan_summary="Fix the bug with a minimal change.",
+        implementation_steps=("Update the implementation",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
+
+
 def test_retry_increments_attempt(tmp_path: Path) -> None:
     """Test that retry increments the attempt counter."""
     store = RunStore(tmp_path / "runs")
@@ -103,7 +115,7 @@ def test_retry_increments_attempt(tmp_path: Path) -> None:
     import precision_squad.coordinator as coord_module
     original_execute = coord_module.DocsFirstExecutor.execute
 
-    def mock_execute(self, intake, record, run_dir):
+    def mock_execute(self, intake, run_record, run_dir):
         return exec_result
 
     coord_module.DocsFirstExecutor.execute = mock_execute
@@ -228,7 +240,8 @@ def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
     )
 
     original_execute = coord_module.DocsFirstExecutor.execute
-    def mock_execute(self, intake, record, run_dir):
+
+    def mock_execute(self, intake, run_record, run_dir):
         return exec_result
     coord_module.DocsFirstExecutor.execute = mock_execute
 
@@ -244,6 +257,90 @@ def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
     # Verify the attempt was persisted
     loaded = store.load_run(report.run_record.run_id)
     assert loaded.attempt == 3
+
+
+def test_retry_carries_forward_approved_plan_into_new_run_directory(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+    previous_run_dir = Path(previous.run_dir)
+    store.write_approved_plan(previous_run_dir, _approved_plan())
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = False
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    coordinator = RunCoordinator()
+    params = _make_params(tmp_path, retry_from=previous.run_id)
+    intake = _make_intake()
+
+    import precision_squad.coordinator as coord_module
+
+    exec_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Test execution",
+        detail_codes=(),
+    )
+    original_execute = coord_module.DocsFirstExecutor.execute
+
+    def mock_execute(self, intake, run_record, run_dir):
+        return exec_result
+
+    coord_module.DocsFirstExecutor.execute = mock_execute
+    try:
+        report = coordinator.repair_issue(
+            params=params,
+            intake=intake,
+            dependencies=dependencies,
+        )
+    finally:
+        coord_module.DocsFirstExecutor.execute = original_execute
+
+    new_run_dir = Path(report.run_record.run_dir)
+    assert (new_run_dir / "approved-plan.json").exists()
+    carried_forward = RunStore.load_approved_plan(new_run_dir)
+    assert carried_forward is not None
+    assert carried_forward.issue_ref == "owner/repo#1"
+    assert carried_forward.plan_summary == "Fix the bug with a minimal change."
+    assert carried_forward.implementation_steps == ("Update the implementation",)
+
+
+def test_retry_with_unapproved_persisted_plan_fails_before_creating_new_run(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+    previous_run_dir = Path(previous.run_dir)
+    (previous_run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    coordinator = RunCoordinator()
+    report = coordinator.repair_issue(
+        params=_make_params(tmp_path, retry_from=previous.run_id),
+        intake=_make_intake(),
+        dependencies=MagicMock(),
+    )
+
+    assert report.exit_code == 3
+    run_ids = [path.name for path in store.root.iterdir() if path.is_dir()]
+    assert run_ids == [previous.run_id]
 
 
 def test_retry_escalated_uses_correct_attempt_count(tmp_path: Path) -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
     ApprovedPlan,
@@ -50,10 +52,16 @@ def _make_params(tmp_path: Path, *, retry_from: str | None = None) -> RepairIssu
         repair_model=None,
         review_model=None,
         retry_from=retry_from,
+        approved_plan=_approved_plan() if retry_from is None else None,
     )
 
 
-def _create_previous_run(store: RunStore, attempt: int = 1) -> RunRecord:
+def _create_previous_run(
+    store: RunStore,
+    attempt: int = 1,
+    *,
+    include_approved_plan: bool = True,
+) -> RunRecord:
     """Create a previous run record with the specified attempt number."""
     intake = _make_intake()
     request = RunRequest(issue_ref="owner/repo#1", runs_dir=str(store.root))
@@ -69,6 +77,8 @@ def _create_previous_run(store: RunStore, attempt: int = 1) -> RunRecord:
         attempt=attempt,
     )
     store.write_run_record(updated)
+    if include_approved_plan:
+        store.write_approved_plan(Path(updated.run_dir), _approved_plan(updated.issue_ref))
     return updated
 
 
@@ -305,8 +315,7 @@ def test_retry_carries_forward_approved_plan_into_new_run_directory(tmp_path: Pa
 
     new_run_dir = Path(report.run_record.run_dir)
     assert (new_run_dir / "approved-plan.json").exists()
-    carried_forward = RunStore.load_approved_plan(new_run_dir)
-    assert carried_forward is not None
+    carried_forward = RunStore.load_approved_plan(new_run_dir, issue_ref="owner/repo#1")
     assert carried_forward.issue_ref == "owner/repo#1"
     assert carried_forward.plan_summary == "Fix the bug with a minimal change."
     assert carried_forward.implementation_steps == ("Update the implementation",)
@@ -332,13 +341,61 @@ def test_retry_with_unapproved_persisted_plan_fails_before_creating_new_run(tmp_
     )
 
     coordinator = RunCoordinator()
-    report = coordinator.repair_issue(
-        params=_make_params(tmp_path, retry_from=previous.run_id),
-        intake=_make_intake(),
-        dependencies=MagicMock(),
+    with pytest.raises(ValueError, match="failed structural validation"):
+        coordinator.repair_issue(
+            params=_make_params(tmp_path, retry_from=previous.run_id),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+    run_ids = [path.name for path in store.root.iterdir() if path.is_dir()]
+    assert run_ids == [previous.run_id]
+
+
+def test_retry_without_prior_approved_plan_fails_with_missing_artifact_message(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1, include_approved_plan=False)
+
+    coordinator = RunCoordinator()
+    with pytest.raises(ValueError, match="missing prior approved-plan.json"):
+        coordinator.repair_issue(
+            params=_make_params(tmp_path, retry_from=previous.run_id),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+    run_ids = [path.name for path in store.root.iterdir() if path.is_dir()]
+    assert run_ids == [previous.run_id]
+
+
+def test_retry_with_invalid_prior_approved_plan_fails_with_validation_message(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=1)
+    previous_run_dir = Path(previous.run_dir)
+    (previous_run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Plan",
+                "implementation_steps": ["   "],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
     )
 
-    assert report.exit_code == 3
+    coordinator = RunCoordinator()
+    with pytest.raises(ValueError, match="failed structural validation"):
+        coordinator.repair_issue(
+            params=_make_params(tmp_path, retry_from=previous.run_id),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
     run_ids = [path.name for path in store.root.iterdir() if path.is_dir()]
     assert run_ids == [previous.run_id]
 
@@ -370,3 +427,30 @@ def test_retry_escalated_uses_correct_attempt_count(tmp_path: Path) -> None:
     assert report.repair_result is not None
     # Attempt 4 > 3, so should be escalated
     assert "4" in report.repair_result.summary or "3" in report.repair_result.summary
+
+
+def test_retry_escalation_persists_approved_plan_into_new_run_directory(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    previous = _create_previous_run(store, attempt=3)
+
+    dependencies = MagicMock()
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+
+    coordinator = RunCoordinator()
+    report = coordinator.repair_issue(
+        params=_make_params(tmp_path, retry_from=previous.run_id),
+        intake=_make_intake(),
+        dependencies=dependencies,
+    )
+
+    escalated_run_dir = Path(report.run_record.run_dir)
+    assert (escalated_run_dir / "approved-plan.json").exists()
+
+    persisted_plan = RunStore.load_approved_plan(escalated_run_dir, issue_ref="owner/repo#1")
+    assert persisted_plan == _approved_plan()

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -21,7 +21,12 @@ from precision_squad.models import (
     QaResult,
     RunRequest,
 )
-from precision_squad.run_store import RunStore
+from precision_squad.run_store import (
+    ApprovedPlanNotFoundError,
+    ApprovedPlanValidationError,
+    RunStore,
+    load_approved_plan_artifact,
+)
 
 
 def _approved_plan() -> ApprovedPlan:
@@ -177,8 +182,89 @@ def test_load_approved_plan_rejects_unapproved_artifact(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="approved.*true"):
-        RunStore.load_approved_plan(run_dir)
+    with pytest.raises(ApprovedPlanValidationError, match="approved.*true"):
+        RunStore.load_approved_plan(run_dir, issue_ref="owner/repo#1")
+
+
+def test_load_approved_plan_requires_named_references_and_retrieval_surface_summary(tmp_path: Path) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Step 1"],
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ApprovedPlanValidationError, match="named_references"):
+        load_approved_plan_artifact(plan_path, issue_ref="owner/repo#1")
+
+
+def test_load_approved_plan_rejects_non_object_payload(tmp_path: Path) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ApprovedPlanValidationError, match="Expected JSON object"):
+        load_approved_plan_artifact(plan_path, issue_ref="owner/repo#1")
+
+
+def test_load_approved_plan_accepts_explicit_empty_canonical_fields(tmp_path: Path) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = load_approved_plan_artifact(plan_path, issue_ref="owner/repo#1")
+
+    assert plan.named_references == ()
+    assert plan.retrieval_surface_summary == ""
+
+
+def test_write_approved_plan_normalizes_named_reference_objects(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    plan = load_approved_plan_artifact(
+        _write_plan(
+            tmp_path / "incoming-approved-plan.json",
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": ["src/main.py"],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+        ),
+        issue_ref="owner/repo#1",
+    )
+
+    store.write_approved_plan(run_dir, plan)
+
+    payload = json.loads((run_dir / "approved-plan.json").read_text(encoding="utf-8"))
+    assert payload["named_references"] == [
+        {"name": "src/main.py", "reference_type": "file", "description": ""}
+    ]
+
+
+def test_load_approved_plan_missing_artifact_raises_not_found(tmp_path: Path) -> None:
+    with pytest.raises(ApprovedPlanNotFoundError, match="Approved plan artifact not found"):
+        RunStore.load_approved_plan(tmp_path / "missing-run", issue_ref="owner/repo#1")
 
 
 def test_render_approved_plan_text(tmp_path: Path) -> None:
@@ -191,3 +277,8 @@ def test_render_approved_plan_text(tmp_path: Path) -> None:
     assert "Fix the bug with a minimal change." in text
     assert "Update the implementation" in text
     assert "Retrieval Surface" in text
+
+
+def _write_plan(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from precision_squad.models import (
+    ApprovedPlan,
     EvaluationResult,
     ExecutionResult,
     GitHubIssue,
@@ -19,6 +22,17 @@ from precision_squad.models import (
     RunRequest,
 )
 from precision_squad.run_store import RunStore
+
+
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Fix the bug with a minimal change.",
+        implementation_steps=("Update the implementation",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
 
 
 def test_create_run_writes_expected_artifacts(tmp_path: Path) -> None:
@@ -144,3 +158,36 @@ def test_write_qa_results_uses_phase_specific_filenames(tmp_path: Path) -> None:
 
     assert (run_dir / "qa-baseline-result.json").exists()
     assert (run_dir / "qa-result.json").exists()
+
+
+def test_load_approved_plan_rejects_unapproved_artifact(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Invalid plan",
+                "implementation_steps": ["Step 1"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="approved.*true"):
+        RunStore.load_approved_plan(run_dir)
+
+
+def test_render_approved_plan_text(tmp_path: Path) -> None:
+    del tmp_path
+    from precision_squad.run_store import render_approved_plan_text
+
+    text = render_approved_plan_text(_approved_plan(), include_named_references=False)
+
+    assert "Approved Plan" in text
+    assert "Fix the bug with a minimal change." in text
+    assert "Update the implementation" in text
+    assert "Retrieval Surface" in text


### PR DESCRIPTION
## Summary
- enforce one canonical approved-plan loader/validator across CLI ingress, retry carry-forward, and downstream repair/review stage entry
- persist normalized `approved-plan.json` at run start and on escalated retry runs so downstream stages consume the same canonical artifact
- add focused regression coverage for CLI ingress, run-store validation, retry semantics, repair-stage fail-fast behavior, review-stage validation, and LLM adapter handoff

## Plan
- Approved plan: `.opencode/plans/issue-56.md`

## Notable implementation decisions
- centralize approved-plan contract loading in `src/precision_squad/run_store.py` as the only supported cross-module API
- make `RepairStage.execute` enforce approved-plan validation before any workspace side effects or adapter invocation
- distinguish missing prior `approved-plan.json` from structurally invalid prior artifacts during retry carry-forward

## Validation
- `PYTHONPATH=src python -m pytest tests/test_run_store.py tests/test_retry.py tests/test_post_publish_review.py tests/test_executor.py tests/test_llm_adapter.py tests/test_cli.py`
- `PYTHONPATH=src python -m pytest tests/test_executor.py -k "not_configured_when_command_missing or no_adapter_still_fails_when_approved_plan or approved_plan_missing or approved_plan_invalid"`
- `PYTHONPATH=src python -m pytest tests/test_retry.py -k "approved_plan or escalat"`
- `PYTHONPATH=src python -m pytest tests/test_post_publish_review.py -k "persisted_plan or canonical_invalid_approved_plan_cases"`
- `PYTHONPATH=src python -m pytest tests/test_cli.py tests/test_run_store.py tests/test_llm_adapter.py`

Closes #56