### PR TITLE
fix: add GitHub transport selector seam

### DIFF
--- a/src/precision_squad/env.py
+++ b/src/precision_squad/env.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Literal, Mapping, cast
 
 ENV_ALIASES: dict[str, tuple[str, ...]] = {
     "GITHUB_TOKEN": ("OpenCode_Github_Token",),
 }
+GitHubTransportMode = Literal["auto", "mcp", "cli"]
 
 
 def load_local_env(start_dir: Path | None = None) -> Path | None:
@@ -49,3 +51,19 @@ def _apply_aliases() -> None:
             if value:
                 os.environ[target] = value
                 break
+
+
+def get_github_transport_mode(env: Mapping[str, str] | None = None) -> GitHubTransportMode:
+    """Return the normalized GitHub transport mode from the environment."""
+
+    source = env if env is not None else os.environ
+    raw_value = source.get("GITHUB_TRANSPORT")
+    if raw_value is None or not raw_value.strip():
+        return "auto"
+
+    normalized = raw_value.strip().lower()
+    if normalized not in {"auto", "mcp", "cli"}:
+        raise ValueError(
+            f"Invalid GITHUB_TRANSPORT value {raw_value!r}. Expected one of: auto, mcp, cli."
+        )
+    return cast(GitHubTransportMode, normalized)

--- a/src/precision_squad/github_client.py
+++ b/src/precision_squad/github_client.py
@@ -14,6 +14,7 @@ from .docs_remediation import (
     extract_docs_blocker_fingerprint,
     normalize_docs_findings,
 )
+from .github_transport import GitHubTransportResolution, resolve_github_transport
 from .models import GitHubIssue, IssueReference
 
 
@@ -24,8 +25,14 @@ class GitHubClientError(RuntimeError):
 class GitHubIssueClient:
     """Fetch issue data from the GitHub REST API."""
 
-    def __init__(self, token: str) -> None:
+    def __init__(
+        self,
+        token: str,
+        *,
+        transport_resolution: GitHubTransportResolution | None = None,
+    ) -> None:
         self._token = token
+        self.transport_resolution = transport_resolution
 
     @classmethod
     def from_env(cls, token_env: str = "GITHUB_TOKEN") -> "GitHubIssueClient":
@@ -34,7 +41,7 @@ class GitHubIssueClient:
             raise GitHubClientError(
                 f"Missing GitHub token. Set the {token_env} environment variable."
             )
-        return cls(token)
+        return cls(token, transport_resolution=resolve_github_transport())
 
     def fetch_issue(self, reference: IssueReference) -> GitHubIssue:
         payload = self._fetch_issue_via_gh(reference)
@@ -181,8 +188,14 @@ class GitHubIssueClient:
 class GitHubWriteClient:
     """Minimal PAT-backed GitHub write client."""
 
-    def __init__(self, token: str) -> None:
+    def __init__(
+        self,
+        token: str,
+        *,
+        transport_resolution: GitHubTransportResolution | None = None,
+    ) -> None:
         self._token = token
+        self.transport_resolution = transport_resolution
 
     @classmethod
     def from_env(cls, token_env: str = "GITHUB_TOKEN") -> "GitHubWriteClient":
@@ -191,7 +204,7 @@ class GitHubWriteClient:
             raise GitHubClientError(
                 f"Missing GitHub token. Set the {token_env} environment variable."
             )
-        return cls(token)
+        return cls(token, transport_resolution=resolve_github_transport())
 
     def create_issue_comment(self, reference: IssueReference, body: str) -> str:
         gh_url = self._create_issue_comment_via_gh(reference, body)

--- a/src/precision_squad/github_transport.py
+++ b/src/precision_squad/github_transport.py
@@ -1,0 +1,208 @@
+"""GitHub transport selection seam for per-run resolution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib.util import find_spec
+from typing import Literal, cast
+
+GitHubTransportMode = Literal["auto", "mcp", "cli"]
+GitHubTransportName = Literal["mcp", "cli"]
+GitHubTransportDecisionReason = Literal[
+    "auto_selected_mcp",
+    "auto_selected_cli",
+    "auto_no_transport_available",
+    "mcp_required_available",
+    "mcp_required_unavailable",
+    "cli_required_available",
+    "cli_required_unavailable",
+    "invalid_requested_mode",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubTransportResolution:
+    """Resolved GitHub transport metadata for the current run."""
+
+    requested_mode: GitHubTransportMode
+    selected_transport: GitHubTransportName
+    mcp_available: bool | None
+    gh_cli_available: bool | None
+    decision_reason: GitHubTransportDecisionReason
+
+
+class GitHubTransportSelectionError(RuntimeError):
+    """Raised when GitHub transport selection cannot succeed."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        requested_mode: str,
+        summary: str,
+        decision_reason: GitHubTransportDecisionReason,
+    ) -> None:
+        super().__init__(summary)
+        self.code = code
+        self.requested_mode = requested_mode
+        self.summary = summary
+        self.decision_reason = decision_reason
+
+
+_cached_resolutions: dict[GitHubTransportMode, GitHubTransportResolution] = {}
+_cached_errors: dict[GitHubTransportMode, GitHubTransportSelectionError] = {}
+
+
+def resolve_github_transport(
+    requested_mode: GitHubTransportMode | str | None = None,
+    *,
+    probe_mcp_available: Callable[[], bool] | None = None,
+    probe_gh_cli_available: Callable[[], bool] | None = None,
+) -> GitHubTransportResolution:
+    """Resolve and cache the GitHub transport for the current run."""
+
+    mode = _normalize_requested_mode(requested_mode)
+
+    cached_resolution = _cached_resolutions.get(mode)
+    if cached_resolution is not None:
+        return cached_resolution
+
+    cached_error = _cached_errors.get(mode)
+    if cached_error is not None:
+        raise cached_error
+
+    mcp_probe = probe_mcp_available or _probe_mcp_available
+    gh_cli_probe = probe_gh_cli_available or _probe_gh_cli_available
+
+    try:
+        resolution = _resolve_uncached(
+            mode,
+            mcp_probe=mcp_probe,
+            gh_cli_probe=gh_cli_probe,
+        )
+    except GitHubTransportSelectionError as exc:
+        _cached_errors[mode] = exc
+        raise
+
+    _cached_resolutions[mode] = resolution
+    return resolution
+
+
+def _resolve_uncached(
+    requested_mode: GitHubTransportMode,
+    *,
+    mcp_probe: Callable[[], bool],
+    gh_cli_probe: Callable[[], bool],
+) -> GitHubTransportResolution:
+    if requested_mode == "auto":
+        mcp_available = mcp_probe()
+        if mcp_available:
+            return GitHubTransportResolution(
+                requested_mode="auto",
+                selected_transport="mcp",
+                mcp_available=True,
+                gh_cli_available=None,
+                decision_reason="auto_selected_mcp",
+            )
+
+        gh_cli_available = gh_cli_probe()
+        if gh_cli_available:
+            return GitHubTransportResolution(
+                requested_mode="auto",
+                selected_transport="cli",
+                mcp_available=False,
+                gh_cli_available=True,
+                decision_reason="auto_selected_cli",
+            )
+
+        raise GitHubTransportSelectionError(
+            code="github_transport_unavailable",
+            requested_mode="auto",
+            summary="GitHub transport selection failed: neither MCP nor gh CLI is available.",
+            decision_reason="auto_no_transport_available",
+        )
+
+    if requested_mode == "mcp":
+        mcp_available = mcp_probe()
+        if mcp_available:
+            return GitHubTransportResolution(
+                requested_mode="mcp",
+                selected_transport="mcp",
+                mcp_available=True,
+                gh_cli_available=None,
+                decision_reason="mcp_required_available",
+            )
+
+        raise GitHubTransportSelectionError(
+            code="github_transport_mcp_unavailable",
+            requested_mode="mcp",
+            summary=(
+                "GitHub transport selection failed: MCP transport was required "
+                "but is unavailable."
+            ),
+            decision_reason="mcp_required_unavailable",
+        )
+
+    gh_cli_available = gh_cli_probe()
+    if gh_cli_available:
+        return GitHubTransportResolution(
+            requested_mode="cli",
+            selected_transport="cli",
+            mcp_available=None,
+            gh_cli_available=True,
+            decision_reason="cli_required_available",
+        )
+
+    raise GitHubTransportSelectionError(
+        code="github_transport_cli_unavailable",
+        requested_mode="cli",
+        summary=(
+            "GitHub transport selection failed: gh CLI transport was required "
+            "but is unavailable."
+        ),
+        decision_reason="cli_required_unavailable",
+    )
+
+
+def _normalize_requested_mode(
+    requested_mode: GitHubTransportMode | str | None,
+) -> GitHubTransportMode:
+    if requested_mode is None:
+        requested_mode = os.getenv("GITHUB_TRANSPORT")
+        if requested_mode is None or not requested_mode.strip():
+            return "auto"
+
+    normalized = requested_mode.strip().lower()
+    if normalized not in {"auto", "mcp", "cli"}:
+        raise GitHubTransportSelectionError(
+            code="github_transport_invalid_mode",
+            requested_mode=requested_mode,
+            summary=(
+                "Invalid GITHUB_TRANSPORT value "
+                f"{requested_mode!r}. Expected one of: auto, mcp, cli."
+            ),
+            decision_reason="invalid_requested_mode",
+        )
+    return cast(GitHubTransportMode, normalized)
+
+
+def _probe_mcp_available() -> bool:
+    """Return whether an MCP GitHub transport is currently available."""
+
+    return find_spec("mcp") is not None
+
+
+def _probe_gh_cli_available() -> bool:
+    """Return whether gh CLI is currently available on PATH."""
+
+    return shutil.which("gh") is not None
+
+
+def reset_github_transport_resolution_cache() -> None:
+    """Reset cached GitHub transport state for tests."""
+
+    _cached_resolutions.clear()
+    _cached_errors.clear()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from precision_squad.env import load_local_env
+from precision_squad.env import get_github_transport_mode, load_local_env
 
 
 def test_load_local_env_reads_repo_root_env_file(
@@ -41,3 +41,19 @@ def test_load_local_env_applies_github_alias(
     load_local_env(tmp_path)
 
     assert __import__("os").environ["GITHUB_TOKEN"] == "alias-token"
+
+
+def test_get_github_transport_mode_defaults_to_auto() -> None:
+    assert get_github_transport_mode({}) == "auto"
+
+
+@pytest.mark.parametrize("value", ["auto", "mcp", "cli", " AUTO "])
+def test_get_github_transport_mode_accepts_supported_values(value: str) -> None:
+    expected = value.strip().lower()
+
+    assert get_github_transport_mode({"GITHUB_TRANSPORT": value}) == expected
+
+
+def test_get_github_transport_mode_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="Invalid GITHUB_TRANSPORT value"):
+        get_github_transport_mode({"GITHUB_TRANSPORT": "http"})

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from precision_squad.github_client import GitHubClientError, GitHubIssueClient, GitHubWriteClient
+from precision_squad.github_transport import GitHubTransportSelectionError
 from precision_squad.models import IssueReference
 
 
@@ -31,6 +32,54 @@ def test_from_env_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
         GitHubIssueClient.from_env()
 
     assert "GITHUB_TOKEN" in str(exc_info.value)
+
+
+def test_issue_client_from_env_exposes_transport_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        "precision_squad.github_client.resolve_github_transport",
+        lambda: object(),
+    )
+
+    client = GitHubIssueClient.from_env()
+
+    assert client.transport_resolution is not None
+
+
+def test_write_client_from_env_exposes_transport_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    resolution = object()
+    monkeypatch.setattr(
+        "precision_squad.github_client.resolve_github_transport",
+        lambda: resolution,
+    )
+
+    client = GitHubWriteClient.from_env()
+
+    assert client.transport_resolution is resolution
+
+
+def test_from_env_propagates_transport_selection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fail() -> object:
+        raise GitHubTransportSelectionError(
+            code="github_transport_cli_unavailable",
+            requested_mode="cli",
+            summary="gh CLI unavailable",
+            decision_reason="cli_required_unavailable",
+        )
+
+    monkeypatch.setattr("precision_squad.github_client.resolve_github_transport", fail)
+
+    with pytest.raises(GitHubTransportSelectionError, match="gh CLI unavailable"):
+        GitHubWriteClient.from_env()
 
 
 def test_fetch_issue_returns_normalized_issue(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_github_transport.py
+++ b/tests/test_github_transport.py
@@ -1,0 +1,226 @@
+"""Tests for GitHub transport selection."""
+
+from __future__ import annotations
+
+from importlib.machinery import ModuleSpec
+
+import pytest
+
+from precision_squad.github_transport import (
+    GitHubTransportResolution,
+    GitHubTransportSelectionError,
+    _probe_mcp_available,
+    reset_github_transport_resolution_cache,
+    resolve_github_transport,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_transport_cache() -> None:
+    reset_github_transport_resolution_cache()
+
+
+def test_auto_selects_mcp_when_available() -> None:
+    resolution = resolve_github_transport(
+        "auto",
+        probe_mcp_available=lambda: True,
+        probe_gh_cli_available=lambda: pytest.fail("gh probe should not run"),
+    )
+
+    assert resolution == GitHubTransportResolution(
+        requested_mode="auto",
+        selected_transport="mcp",
+        mcp_available=True,
+        gh_cli_available=None,
+        decision_reason="auto_selected_mcp",
+    )
+
+
+def test_auto_selects_cli_when_mcp_is_unavailable() -> None:
+    resolution = resolve_github_transport(
+        "auto",
+        probe_mcp_available=lambda: False,
+        probe_gh_cli_available=lambda: True,
+    )
+
+    assert resolution == GitHubTransportResolution(
+        requested_mode="auto",
+        selected_transport="cli",
+        mcp_available=False,
+        gh_cli_available=True,
+        decision_reason="auto_selected_cli",
+    )
+
+
+def test_auto_errors_when_no_transport_is_available() -> None:
+    with pytest.raises(GitHubTransportSelectionError) as exc_info:
+        resolve_github_transport(
+            "auto",
+            probe_mcp_available=lambda: False,
+            probe_gh_cli_available=lambda: False,
+        )
+
+    assert exc_info.value.code == "github_transport_unavailable"
+    assert exc_info.value.requested_mode == "auto"
+    assert exc_info.value.decision_reason == "auto_no_transport_available"
+
+
+def test_mcp_mode_errors_without_cli_fallback() -> None:
+    gh_probed = False
+
+    def gh_probe() -> bool:
+        nonlocal gh_probed
+        gh_probed = True
+        return True
+
+    with pytest.raises(GitHubTransportSelectionError) as exc_info:
+        resolve_github_transport(
+            "mcp",
+            probe_mcp_available=lambda: False,
+            probe_gh_cli_available=gh_probe,
+        )
+
+    assert exc_info.value.code == "github_transport_mcp_unavailable"
+    assert exc_info.value.decision_reason == "mcp_required_unavailable"
+    assert gh_probed is False
+
+
+def test_cli_mode_errors_when_cli_is_unavailable() -> None:
+    with pytest.raises(GitHubTransportSelectionError) as exc_info:
+        resolve_github_transport(
+            "cli",
+            probe_mcp_available=lambda: pytest.fail("mcp probe should not run"),
+            probe_gh_cli_available=lambda: False,
+        )
+
+    assert exc_info.value.code == "github_transport_cli_unavailable"
+    assert exc_info.value.requested_mode == "cli"
+    assert exc_info.value.decision_reason == "cli_required_unavailable"
+
+
+def test_invalid_mode_is_rejected_deterministically() -> None:
+    with pytest.raises(GitHubTransportSelectionError) as exc_info:
+        resolve_github_transport("http")
+
+    assert exc_info.value.code == "github_transport_invalid_mode"
+    assert exc_info.value.decision_reason == "invalid_requested_mode"
+
+
+def test_resolution_is_cached_once_per_run() -> None:
+    probe_calls = {"mcp": 0, "gh": 0}
+
+    def mcp_probe() -> bool:
+        probe_calls["mcp"] += 1
+        return False
+
+    def gh_probe() -> bool:
+        probe_calls["gh"] += 1
+        return True
+
+    first = resolve_github_transport(
+        "auto",
+        probe_mcp_available=mcp_probe,
+        probe_gh_cli_available=gh_probe,
+    )
+    second = resolve_github_transport(
+        "auto",
+        probe_mcp_available=lambda: pytest.fail("mcp probe should be cached"),
+        probe_gh_cli_available=lambda: pytest.fail("gh probe should be cached"),
+    )
+
+    assert first is second
+    assert probe_calls == {"mcp": 1, "gh": 1}
+
+
+def test_terminal_failure_is_cached_once_per_run() -> None:
+    probe_calls = {"mcp": 0, "gh": 0}
+
+    def mcp_probe() -> bool:
+        probe_calls["mcp"] += 1
+        return False
+
+    def gh_probe() -> bool:
+        probe_calls["gh"] += 1
+        return False
+
+    with pytest.raises(GitHubTransportSelectionError) as first_error:
+        resolve_github_transport(
+            "auto",
+            probe_mcp_available=mcp_probe,
+            probe_gh_cli_available=gh_probe,
+        )
+
+    with pytest.raises(GitHubTransportSelectionError) as second_error:
+        resolve_github_transport(
+            "auto",
+            probe_mcp_available=lambda: pytest.fail("mcp probe should be cached"),
+            probe_gh_cli_available=lambda: pytest.fail("gh probe should be cached"),
+        )
+
+    assert second_error.value is first_error.value
+    assert probe_calls == {"mcp": 1, "gh": 1}
+
+
+def test_explicit_mode_does_not_reuse_cached_auto_resolution() -> None:
+    auto = resolve_github_transport(
+        "auto",
+        probe_mcp_available=lambda: False,
+        probe_gh_cli_available=lambda: True,
+    )
+
+    with pytest.raises(GitHubTransportSelectionError) as exc_info:
+        resolve_github_transport(
+            "mcp",
+            probe_mcp_available=lambda: False,
+            probe_gh_cli_available=lambda: pytest.fail("gh probe should not run for mcp"),
+        )
+
+    assert auto.selected_transport == "cli"
+    assert exc_info.value.code == "github_transport_mcp_unavailable"
+    assert exc_info.value.requested_mode == "mcp"
+
+
+def test_explicit_mode_keeps_own_cached_result() -> None:
+    probe_calls = {"mcp": 0, "gh": 0}
+
+    def gh_probe() -> bool:
+        probe_calls["gh"] += 1
+        return True
+
+    def mcp_probe() -> bool:
+        probe_calls["mcp"] += 1
+        return True
+
+    resolve_github_transport(
+        "auto",
+        probe_mcp_available=lambda: False,
+        probe_gh_cli_available=gh_probe,
+    )
+    first = resolve_github_transport("mcp", probe_mcp_available=mcp_probe)
+    second = resolve_github_transport(
+        "mcp",
+        probe_mcp_available=lambda: pytest.fail("mcp result should be cached for mcp mode"),
+    )
+
+    assert first is second
+    assert first.selected_transport == "mcp"
+    assert probe_calls == {"mcp": 1, "gh": 1}
+
+
+def test_probe_mcp_available_returns_false_when_mcp_module_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("precision_squad.github_transport.find_spec", lambda name: None)
+
+    assert _probe_mcp_available() is False
+
+
+def test_probe_mcp_available_returns_true_when_mcp_module_is_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "precision_squad.github_transport.find_spec",
+        lambda name: ModuleSpec(name, loader=None),
+    )
+
+    assert _probe_mcp_available() is True


### PR DESCRIPTION
Closes #48

## Summary
- add a dedicated GitHub transport selector seam for `auto`, `mcp`, and `cli`
- cache transport selection or terminal failure once per run and expose structured selection metadata
- expose resolved transport metadata from GitHub client env factories and cover the selector/env/client seams with focused tests

## Approved plan
- `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-48.md`

## Implementation notes
- uses real module discovery for MCP availability via `importlib.util.find_spec`
- keeps cache scoped by requested mode and includes a test reset hook
- preserves bounded scope by exposing transport metadata at client bootstrap without broad caller migration

## Validation evidence
- `ruff`: pass
- `focused pytest`: pass

## Run
- run id: `20260519-155817-887`