### PR TITLE
fix: require explicit repair run selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ CLI-only for this feature:
 - positional arguments such as `issue_ref` and `run_id`
 - command and subcommand names
 - `retry_from`, because run selection remains an explicit invocation-scoped operator choice
+- `fresh`, because fresh-vs-retry selection remains an explicit invocation-scoped operator choice
+
+Run selection for `repair issue`:
+
+- `--fresh` starts a fresh run explicitly when prior local runs exist
+- `--retry-from <run-id>` retries exactly that stored local run
+- `--fresh` and `--retry-from` are mutually exclusive
+- if no prior local runs exist for the issue, the command proceeds as a fresh run without prompting
+- if prior local runs exist and neither flag is supplied, the CLI prompts only when both stdin and stdout are TTYs
+- in non-interactive mode with prior local runs and no explicit selection, the CLI fails and tells the operator to pass `--fresh` or `--retry-from <run-id>`
+- fresh runs still require `--approved-plan-path`
+- retry remains the only path that may omit `--approved-plan-path`, and only by carrying forward the previously persisted approved plan
 
 Legacy alias still supported:
 

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -21,7 +21,7 @@ from .coordinator import PublishRunParams, RepairIssueParams, RunCoordinator
 from .env import load_local_env
 from .executor import DocsFirstExecutor
 from .github_client import GitHubClientError, GitHubWriteClient
-from .intake import load_issue_intake
+from .intake import canonicalize_local_issue_ref, load_issue_intake
 from .models import (
     ApprovedPlan,
     ExecutionResult,
@@ -49,7 +49,7 @@ from .repair import (
     run_repair_qa_loop,
     synthesis_artifacts_ready,
 )
-from .run_store import ApprovedPlanError, load_approved_plan_artifact
+from .run_store import ApprovedPlanError, RunStore, load_approved_plan_artifact
 
 # Keep a local alias so tests can monkeypatch the shared executor class through this module.
 _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
@@ -114,10 +114,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=argparse.SUPPRESS,
         help="Optional model override for post-publish review agents.",
     )
-    issue_parser.add_argument(
+    run_selection_group = issue_parser.add_mutually_exclusive_group()
+    run_selection_group.add_argument(
         "--retry-from",
         default=argparse.SUPPRESS,
         help="Existing run ID to retry from. Increments attempt counter.",
+    )
+    run_selection_group.add_argument(
+        "--fresh",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Start a fresh run explicitly when prior local runs exist.",
     )
     issue_parser.add_argument(
         "--approved-plan-path",
@@ -172,15 +179,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _repair_issue(args: argparse.Namespace) -> int:
-    if args.retry_from is None and not args.approved_plan_path:
+    retry_from = _resolve_repair_retry_from(args)
+    approved_plan: ApprovedPlan | None = None
+    if args.approved_plan_path:
+        approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
+    if retry_from is None and approved_plan is None:
         raise ValueError(
             "Fresh repair issue runs require --approved-plan-path; retries may omit it only "
             "when carrying forward the prior approved-plan.json."
         )
 
-    approved_plan: ApprovedPlan | None = None
-    if args.approved_plan_path:
-        approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
     intake = load_issue_intake(args.issue_ref)
     report = RunCoordinator().repair_issue(
         params=RepairIssueParams(
@@ -191,7 +199,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
             repair_agent=args.repair_agent,
             repair_model=args.repair_model,
             review_model=args.review_model,
-            retry_from=args.retry_from,
+            retry_from=retry_from,
             approved_plan=approved_plan,
         ),
         intake=intake,
@@ -610,6 +618,73 @@ def _load_approved_plan(path: Path, issue_ref: str) -> ApprovedPlan:
         raise ValueError(str(exc)) from exc
 
 
+def _resolve_repair_retry_from(args: argparse.Namespace) -> str | None:
+    store = RunStore(Path(args.runs_dir))
+
+    if args.retry_from is not None:
+        _validate_retry_from(store, issue_ref=args.issue_ref, run_id=args.retry_from)
+        return args.retry_from
+
+    if args.fresh:
+        return None
+
+    prior_runs = store.list_runs_for_issue(args.issue_ref)
+    if not prior_runs:
+        return None
+
+    if not _repair_issue_prompt_is_interactive():
+        raise ValueError(
+            "Prior local runs already exist for this issue. Pass either --retry-from <run-id> "
+            "or --fresh."
+        )
+
+    choice = _prompt_for_run_selection(prior_runs)
+    if choice == "fresh":
+        return None
+    return choice
+
+
+def _validate_retry_from(store: RunStore, *, issue_ref: str, run_id: str) -> None:
+    try:
+        record = store.load_run(run_id)
+    except ValueError as exc:
+        raise ValueError(f"Retry run not found: {run_id}") from exc
+
+    if record.run_id != run_id:
+        raise ValueError(f"Retry run not found: {run_id}")
+
+    if canonicalize_local_issue_ref(record.issue_ref) != canonicalize_local_issue_ref(issue_ref):
+        raise ValueError(
+            f"Retry run {run_id} belongs to {record.issue_ref}, not requested issue {issue_ref}."
+        )
+
+
+def _repair_issue_prompt_is_interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _prompt_for_run_selection(prior_runs: Sequence[RunRecord]) -> str:
+    print("Prior local runs exist for this issue. Choose 'fresh' or one of the run IDs:")
+    for record in prior_runs:
+        print(
+            "- "
+            f"{record.run_id} "
+            f"(attempt={record.attempt}, created_at={record.created_at}, status={record.status})"
+        )
+
+    valid_choices = {record.run_id for record in prior_runs}
+    while True:
+        try:
+            choice = input("Run selection [fresh/<run-id>]: ").strip()
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise ValueError("Run selection aborted.") from exc
+
+        if choice == "fresh" or choice in valid_choices:
+            return choice
+
+        print("Invalid selection. Enter 'fresh' or a listed run ID.")
+
+
 def _as_issue_assessment_status(value: Any) -> Literal["runnable", "blocked"]:
     text = _as_str(value)
     if text == "runnable":
@@ -786,6 +861,7 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
             "repair_model": None,
             "review_model": None,
             "retry_from": None,
+            "fresh": False,
             "approved_plan_path": None,
         },
         validate=_validate_repair_issue_args,

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -8,7 +8,7 @@ from typing import Protocol
 
 from .executor import DocsFirstExecutor
 from .governance import apply_governance, evaluate_run
-from .intake import IssueIntake, is_docs_remediation_issue
+from .intake import IssueIntake, canonicalize_local_issue_ref, is_docs_remediation_issue
 from .models import (
     ApprovedPlan,
     EvaluationResult,
@@ -191,21 +191,12 @@ class RunCoordinator:
         if params.retry_from is not None:
             try:
                 previous_record = store.load_run(params.retry_from)
+                if not _same_local_issue_ref(previous_record.issue_ref, params.issue_ref):
+                    return _blocked_retry_report(intake=intake, issue_ref=params.issue_ref)
                 attempt = previous_record.attempt + 1
                 previous_run_dir = Path(previous_record.run_dir).resolve()
             except ValueError:
-                return RepairIssueReport(
-                    intake=intake,
-                    run_record=RunRecord(
-                        run_id="",
-                        issue_ref=params.issue_ref,
-                        status="blocked",
-                        created_at="",
-                        updated_at="",
-                        run_dir="",
-                    ),
-                    exit_code=3,
-                )
+                return _blocked_retry_report(intake=intake, issue_ref=params.issue_ref)
 
         effective_approved_plan = params.approved_plan
         if effective_approved_plan is None and previous_run_dir is not None:
@@ -226,18 +217,7 @@ class RunCoordinator:
                     f"structural validation: {exc}"
                 ) from exc
             except ValueError:
-                return RepairIssueReport(
-                    intake=intake,
-                    run_record=RunRecord(
-                        run_id="",
-                        issue_ref=params.issue_ref,
-                        status="blocked",
-                        created_at="",
-                        updated_at="",
-                        run_dir="",
-                    ),
-                    exit_code=3,
-                )
+                return _blocked_retry_report(intake=intake, issue_ref=params.issue_ref)
 
         # Check if escalated (max 3 attempts exceeded)
         if attempt > 3:
@@ -595,3 +575,22 @@ class RunCoordinator:
             publish_result=result,
             post_publish_review_result=review_result,
         )
+
+
+def _same_local_issue_ref(left: str, right: str) -> bool:
+    return canonicalize_local_issue_ref(left) == canonicalize_local_issue_ref(right)
+
+
+def _blocked_retry_report(*, intake: IssueIntake, issue_ref: str) -> RepairIssueReport:
+    return RepairIssueReport(
+        intake=intake,
+        run_record=RunRecord(
+            run_id="",
+            issue_ref=issue_ref,
+            status="blocked",
+            created_at="",
+            updated_at="",
+            run_dir="",
+        ),
+        exit_code=3,
+    )

--- a/src/precision_squad/intake.py
+++ b/src/precision_squad/intake.py
@@ -32,6 +32,12 @@ def parse_issue_reference(raw: str) -> IssueReference:
     )
 
 
+def canonicalize_local_issue_ref(issue_ref: str | IssueReference) -> str:
+    """Return the canonical local issue reference for run matching."""
+    reference = parse_issue_reference(issue_ref) if isinstance(issue_ref, str) else issue_ref
+    return f"{reference.owner.lower()}/{reference.repo.lower()}#{reference.number}"
+
+
 def assess_issue(issue: GitHubIssue) -> IssueAssessment:
     """Determine whether the issue is runnable or should be blocked."""
     if is_docs_remediation_issue(issue):

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Literal, cast
 from uuid import uuid4
 
+from .intake import canonicalize_local_issue_ref
 from .models import (
     ApprovedPlan,
     EvaluationResult,
@@ -97,6 +98,30 @@ class RunStore:
         """Write an updated run record."""
         run_dir = Path(record.run_dir).resolve()
         self._write_json(run_dir / "run-record.json", record)
+
+    def list_runs_for_issue(self, issue_ref: str) -> list[RunRecord]:
+        """Return prior local runs for one canonical issue, newest first."""
+        if not self.root.exists():
+            return []
+
+        canonical_issue_ref = canonicalize_local_issue_ref(issue_ref)
+        matches: list[RunRecord] = []
+        for child in self.root.iterdir():
+            if not child.is_dir():
+                continue
+            record_path = child / "run-record.json"
+            if not record_path.exists():
+                continue
+            try:
+                record = _read_run_record(record_path)
+            except (OSError, ValueError, JSONDecodeError, KeyError, TypeError):
+                continue
+            if canonicalize_local_issue_ref(record.issue_ref) == canonical_issue_ref:
+                matches.append(record)
+
+        matches.sort(key=lambda record: record.run_id)
+        matches.sort(key=lambda record: record.created_at, reverse=True)
+        return matches
 
     def write_execution_result(self, run_dir: Path, result: ExecutionResult) -> None:
         self._write_json(run_dir / "execution-result.json", result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 
 from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
-from precision_squad.cli import main
+from precision_squad.cli import _prompt_for_run_selection, _repair_issue_prompt_is_interactive, main
 from precision_squad.coordinator import RepairIssueReport
 from precision_squad.models import (
     ApprovedPlan,
@@ -24,7 +24,9 @@ from precision_squad.models import (
     PublishPlan,
     PublishResult,
     RunRecord,
+    RunRequest,
 )
+from precision_squad.run_store import RunStore
 
 
 def test_main_without_args_shows_help(capsys) -> None:
@@ -1293,20 +1295,7 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
     """Config file values are used when CLI args are not provided."""
     repo_path = tmp_path / "repo-from-config"
     runs_dir = tmp_path / "runs-from-config"
-    plan_path = tmp_path / "approved-plan.json"
-    plan_path.write_text(
-        json.dumps(
-            {
-                "issue_ref": "owner/repo#1",
-                "plan_summary": "Repair the issue.",
-                "implementation_steps": ["Apply minimal change"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            }
-        ),
-        encoding="utf-8",
-    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
     config_file = tmp_path / ".precision-squad.toml"
     config_file.write_text(
         (
@@ -1405,20 +1394,7 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
 
 
 def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    plan_path = tmp_path / "approved-plan.json"
-    plan_path.write_text(
-        json.dumps(
-            {
-                "issue_ref": "owner/repo#1",
-                "plan_summary": "Repair the issue.",
-                "implementation_steps": ["Apply minimal change"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            }
-        ),
-        encoding="utf-8",
-    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
     config_file = tmp_path / ".precision-squad.toml"
     config_file.write_text(
         (
@@ -1685,20 +1661,7 @@ def test_repair_issue_no_publish_cli_overrides_true_config(
 ) -> None:
     repo_path = tmp_path / "repo-from-config"
     runs_dir = tmp_path / "runs-from-config"
-    plan_path = tmp_path / "approved-plan.json"
-    plan_path.write_text(
-        json.dumps(
-            {
-                "issue_ref": "owner/repo#1",
-                "plan_summary": "Repair the issue.",
-                "implementation_steps": ["Apply minimal change"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            }
-        ),
-        encoding="utf-8",
-    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
     (tmp_path / ".precision-squad.toml").write_text(
         (
             "[repair.issue]\n"
@@ -2103,6 +2066,396 @@ def test_run_issue_requires_approved_plan_path_for_fresh_runs(
     assert not (tmp_path / "runs").exists()
 
 
+def test_run_issue_explicit_fresh_without_approved_plan_path_fails_before_intake(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--fresh",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "require --approved-plan-path" in captured.err
+
+
+def test_run_issue_retry_from_missing_run_fails_before_intake(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--retry-from",
+            "missing-run",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Retry run not found" in captured.err
+
+
+def test_run_issue_retry_from_other_issue_fails_before_intake(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 2),
+            title="Other issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/2",
+        ),
+        summary="Other issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(RunRequest(issue_ref="Owner/Repo#2", runs_dir=str(runs_dir)), intake)
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+            "--retry-from",
+            record.run_id,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "belongs to" in captured.err
+
+
+def test_run_issue_non_interactive_ambiguous_prior_runs_requires_explicit_selection(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    store.create_run(
+        RunRequest(issue_ref="Owner/Repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    monkeypatch.setattr(
+        "precision_squad.cli._repair_issue_prompt_is_interactive",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "--retry-from <run-id>" in captured.err
+    assert "--fresh" in captured.err
+
+
+def test_run_issue_prompt_selected_fresh_without_plan_fails_before_intake(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    monkeypatch.setattr("precision_squad.cli._repair_issue_prompt_is_interactive", lambda: True)
+    monkeypatch.setattr("precision_squad.cli._prompt_for_run_selection", lambda runs: "fresh")
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "require --approved-plan-path" in captured.err
+
+
+def test_run_issue_prompt_selected_retry_can_continue_without_new_plan_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(
+        RunRequest(issue_ref="Owner/Repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    store.write_approved_plan(Path(record.run_dir), ApprovedPlan(
+        issue_ref="Owner/Repo#1",
+        plan_summary="Plan",
+        implementation_steps=("Step",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    ))
+    monkeypatch.setattr("precision_squad.cli._repair_issue_prompt_is_interactive", lambda: True)
+    monkeypatch.setattr("precision_squad.cli._prompt_for_run_selection", lambda runs: record.run_id)
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake_payload)
+
+    captured: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, intake, dependencies
+        captured["retry_from"] = params.retry_from
+        return RepairIssueReport(
+            intake=intake_payload,
+            run_record=RunRecord(
+                run_id="run-next",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(runs_dir / "run-next"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="done",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
+            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
+            publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+        ]
+    )
+
+    assert status == 0
+    assert captured["retry_from"] == record.run_id
+
+
+def test_run_issue_explicit_fresh_bypasses_ambiguity_and_calls_coordinator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    prior_intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    store.create_run(RunRequest(issue_ref="Owner/Repo#1", runs_dir=str(runs_dir)), prior_intake)
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: prior_intake)
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    captured: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, intake, dependencies
+        captured["retry_from"] = params.retry_from
+        return RepairIssueReport(
+            intake=prior_intake,
+            run_record=RunRecord(
+                run_id="run-1",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(runs_dir / "run-1"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="done",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
+            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
+            publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+            "--fresh",
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    assert status == 0
+    assert captured["retry_from"] is None
+
+
+def test_prompt_for_run_selection_reprompts_on_invalid_input(
+    capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs = [
+        RunRecord(
+            run_id="run-2",
+            issue_ref="owner/repo#1",
+            status="runnable",
+            created_at="2026-05-02T00:00:00Z",
+            updated_at="2026-05-02T00:00:00Z",
+            run_dir="/tmp/run-2",
+            attempt=2,
+        )
+    ]
+    responses = iter(["bad", "run-2"])
+    monkeypatch.setattr("builtins.input", lambda prompt: next(responses))
+
+    choice = _prompt_for_run_selection(runs)
+
+    captured = capsys.readouterr()
+    assert choice == "run-2"
+    assert "Invalid selection" in captured.out
+
+
+def test_prompt_for_run_selection_aborts_on_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = [
+        RunRecord(
+            run_id="run-2",
+            issue_ref="owner/repo#1",
+            status="runnable",
+            created_at="2026-05-02T00:00:00Z",
+            updated_at="2026-05-02T00:00:00Z",
+            run_dir="/tmp/run-2",
+            attempt=2,
+        )
+    ]
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    with pytest.raises(ValueError, match="aborted"):
+        _prompt_for_run_selection(runs)
+
+
+def test_repair_issue_prompt_is_interactive_requires_both_ttys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    assert _repair_issue_prompt_is_interactive() is False
+
+
 def test_repair_issue_help_mentions_fresh_run_approved_plan_requirement(capsys) -> None:
     with pytest.raises(SystemExit) as exc_info:
         main(["repair", "issue", "--help"])
@@ -2111,6 +2464,26 @@ def test_repair_issue_help_mentions_fresh_run_approved_plan_requirement(capsys) 
     assert exc_info.value.code == 0
     assert "Required for fresh" in captured.out
     assert "retries may omit it" in captured.out
+
+
+def test_repair_issue_parser_rejects_fresh_with_retry_from(capsys, tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "repair",
+                "issue",
+                "owner/repo#1",
+                "--repo-path",
+                str(tmp_path),
+                "--fresh",
+                "--retry-from",
+                "run-1",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in captured.err
 
 
 def test_load_approved_plan_rejects_missing_retrieval_surface_summary(
@@ -2430,7 +2803,7 @@ class TestLoadApprovedPlanValidation:
         )
         from precision_squad.cli import _load_approved_plan
 
-        with pytest.raises(ValueError, match="implementation_steps\[1\]"):
+        with pytest.raises(ValueError, match=r"implementation_steps\[1\]"):
             _load_approved_plan(plan_path, "owner/repo#1")
 
     def test_returns_approved_plan(self, tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,6 +202,20 @@ def test_load_command_config_rejects_unknown_keys(tmp_path: Path) -> None:
         )
 
 
+def test_load_command_config_rejects_fresh_key(tmp_path: Path) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[repair.issue]\nrepo_path = \"repo\"\nfresh = true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unknown config key 'fresh'"):
+        load_command_config(
+            start_dir=tmp_path,
+            table=("repair", "issue"),
+            supported_tables=SUPPORTED_TABLES,
+        )
+
+
 def test_load_command_config_returns_only_active_command_table(tmp_path: Path) -> None:
     (tmp_path / ".precision-squad.toml").write_text(
         (

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -6,6 +6,7 @@ import pytest
 
 from precision_squad.intake import (
     build_issue_intake,
+    canonicalize_local_issue_ref,
     is_docs_remediation_issue,
     parse_issue_reference,
 )
@@ -70,6 +71,10 @@ def test_parse_issue_reference_accepts_expected_format() -> None:
 def test_parse_issue_reference_rejects_invalid_format() -> None:
     with pytest.raises(ValueError):
         parse_issue_reference("markdown-pdf-renderer#9")
+
+
+def test_canonicalize_local_issue_ref_normalizes_owner_and_repo_casing() -> None:
+    assert canonicalize_local_issue_ref("Owner/Repo#64") == "owner/repo#64"
 
 
 def test_build_issue_intake_blocks_plan_issue() -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -219,6 +219,35 @@ def test_retry_from_nonexistent_run(tmp_path: Path) -> None:
     assert report.exit_code == 3
 
 
+def test_retry_from_different_issue_returns_blocked_report(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    other_intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 2),
+            title="Other issue",
+            body="Fix the other bug.",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/2",
+        ),
+        summary="Other issue",
+        problem_statement="Fix the other bug.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    request = RunRequest(issue_ref="Owner/Repo#2", runs_dir=str(store.root))
+    previous = store.create_run(request, other_intake)
+    store.write_approved_plan(Path(previous.run_dir), _approved_plan("Owner/Repo#2"))
+
+    report = RunCoordinator().repair_issue(
+        params=_make_params(tmp_path, retry_from=previous.run_id),
+        intake=_make_intake(),
+        dependencies=MagicMock(),
+    )
+
+    assert report.exit_code == 3
+    assert report.run_record.status == "blocked"
+
+
 def test_retry_attempt_stored_in_run_record(tmp_path: Path) -> None:
     """Test that attempt number is persisted in run record."""
     store = RunStore(tmp_path / "runs")

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -279,6 +279,66 @@ def test_render_approved_plan_text(tmp_path: Path) -> None:
     assert "Retrieval Surface" in text
 
 
+def test_list_runs_for_issue_filters_by_canonical_issue_and_orders_newest_first(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True)
+
+    same_issue_old = store.root / "run-old"
+    same_issue_old.mkdir()
+    (same_issue_old / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-old",
+                "issue_ref": "Owner/Repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-02T00:00:00Z",
+                "updated_at": "2026-05-02T00:00:00Z",
+                "run_dir": str(same_issue_old),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    same_issue_new = store.root / "run-new"
+    same_issue_new.mkdir()
+    (same_issue_new / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-new",
+                "issue_ref": "owner/repo#1",
+                "status": "blocked",
+                "created_at": "2026-05-02T00:00:00Z",
+                "updated_at": "2026-05-02T00:00:00Z",
+                "run_dir": str(same_issue_new),
+                "attempt": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    different_issue = store.root / "run-other"
+    different_issue.mkdir()
+    (different_issue / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-other",
+                "issue_ref": "owner/repo#2",
+                "status": "runnable",
+                "created_at": "2026-05-03T00:00:00Z",
+                "updated_at": "2026-05-03T00:00:00Z",
+                "run_dir": str(different_issue),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    records = store.list_runs_for_issue("owner/repo#1")
+
+    assert [record.run_id for record in records] == ["run-new", "run-old"]
+
+
 def _write_plan(path: Path, payload: dict[str, object]) -> Path:
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path


### PR DESCRIPTION
Closes #64

## Summary
- require explicit fresh vs retry selection when prior local runs exist for the same issue
- add canonical local issue ref matching and deterministic same-issue run discovery
- preserve the fresh-run approved-plan boundary while adding prompt and non-interactive failure coverage

## Approved plan
- Local approved plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-64.md`
- Durable issue comment: https://github.com/cracklings3d/precision-squad/issues/64#issuecomment-4446594103

## Notable implementation decisions
- resolve retry/fresh selection in `cli.py` before GitHub intake
- keep a defensive same-issue retry guard in `RunCoordinator.repair_issue()` for direct callers
- keep `fresh` and `retry_from` CLI-only and out of persisted config

## Validation evidence
- Implementation review passed before completion handoff
- No additional validation command output was supplied in run artifacts for run `20260519-155817-887`