### PR TITLE
fix: define downstream stage contracts

### DIFF
--- a/src/precision_squad/docs_policy.py
+++ b/src/precision_squad/docs_policy.py
@@ -17,6 +17,17 @@ def _load_checklist() -> dict[str, Any]:
     return payload
 
 
+def load_review_checklist_rules() -> tuple[dict[str, Any], ...]:
+    """Load deterministic review checklist rules from the packaged checklist file."""
+    rules_raw = _load_checklist().get("rules")
+    if not isinstance(rules_raw, list):
+        raise ValueError("docs checklist field 'rules' must be a list")
+    rules = tuple(dict(rule) for rule in rules_raw if isinstance(rule, dict))
+    if not rules:
+        raise ValueError("docs checklist must define at least one rule")
+    return rules
+
+
 CHECKLIST = _load_checklist()
 DOC_SOURCE_CANDIDATES = tuple(str(item) for item in CHECKLIST["doc_source_candidates"])
 SETUP_SECTION_HEADINGS = tuple(str(item) for item in CHECKLIST["setup_section_headings"])
@@ -28,9 +39,7 @@ MANUAL_PREREQUISITE_SIGNALS = tuple(str(item) for item in CHECKLIST["manual_prer
 ENVIRONMENT_ASSUMPTION_SIGNALS = tuple(
     str(item) for item in CHECKLIST["environment_assumption_signals"]
 )
-DOC_POLICY_RULES: tuple[dict[str, Any], ...] = tuple(
-    dict(rule) for rule in CHECKLIST["rules"] if isinstance(rule, dict)
-)
+DOC_POLICY_RULES: tuple[dict[str, Any], ...] = load_review_checklist_rules()
 
 
 def questions_for_violations(violations: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -13,7 +13,7 @@ from .github_client import GitHubWriteClient
 from .json_events import extract_json_events
 from .models import IssueIntake, PostPublishReviewResult, ReviewAgentResult, RunRecord
 from .opencode_model import resolve_opencode_model
-from .run_store import RunStore
+from .stage_contracts import ReviewStageContract, load_review_stage_contract, render_review_prompt
 
 PULL_NUMBER_PATTERN = re.compile(r"/pull/(?P<number>[0-9]+)$")
 
@@ -26,6 +26,7 @@ class ReviewRunner(Protocol):
         run_record: RunRecord,
         run_dir: Path,
         pull_request_url: str,
+        review_contract: ReviewStageContract | None = None,
     ) -> ReviewAgentResult: ...
 
 
@@ -45,6 +46,7 @@ class OpenCodePrReviewAgent:
         run_record: RunRecord,
         run_dir: Path,
         pull_request_url: str,
+        review_contract: ReviewStageContract | None = None,
     ) -> ReviewAgentResult:
         prefix = f"post-publish-{self.role}"
         stdout_path = run_dir / f"{prefix}.stdout.log"
@@ -57,6 +59,7 @@ class OpenCodePrReviewAgent:
                 run_record=run_record,
                 run_dir=run_dir,
                 pull_request_url=pull_request_url,
+                review_contract=review_contract,
             )
         except ValueError as exc:
             return ReviewAgentResult(
@@ -151,17 +154,42 @@ def run_post_publish_review(
             architect_summary="Architect did not run.",
         )
 
+    try:
+        review_contract = load_review_stage_contract(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            pull_request_url=pull_request_url,
+            pull_number=pull_number,
+            pull_head_sha=pull_head_sha,
+            diff_loader=_fetch_pr_diff,
+        )
+    except ValueError as exc:
+        return PostPublishReviewResult(
+            status="failed_infra",
+            summary=str(exc),
+            pull_request_url=pull_request_url,
+            pull_number=pull_number,
+            pull_head_sha=pull_head_sha,
+            reviewer_status="failed_infra",
+            reviewer_summary=str(exc),
+            architect_status="failed_infra",
+            architect_summary=str(exc),
+        )
+
     reviewer_result = reviewer.review(
         intake=intake,
         run_record=run_record,
         run_dir=run_dir,
         pull_request_url=pull_request_url,
+        review_contract=review_contract,
     )
     architect_result = architect.review(
         intake=intake,
         run_record=run_record,
         run_dir=run_dir,
         pull_request_url=pull_request_url,
+        review_contract=review_contract,
     )
     if reviewer_result.status == "approved" and architect_result.status == "approved":
         return PostPublishReviewResult(
@@ -227,40 +255,19 @@ def _build_review_prompt(
     run_record: RunRecord,
     run_dir: Path,
     pull_request_url: str,
+    review_contract: ReviewStageContract | None = None,
 ) -> str:
-    approved_plan = RunStore.load_approved_plan_text(
-        run_dir,
-        issue_ref=run_record.issue_ref,
-        include_named_references=True,
-    )
-    if not approved_plan.strip():
-        raise ValueError("Review context pack is missing required approved plan")
-    pr_diff = _fetch_pr_diff(
-        intake.issue.reference.owner,
-        intake.issue.reference.repo,
-        pull_request_url,
-    )
-    if not pr_diff.strip():
-        raise ValueError("Review context pack is missing required PR diff")
-    return "\n".join(
-        [
-            f"Review role: {role}",
-            f"Run ID: {run_record.run_id}",
-            f"Issue: {intake.issue.reference}",
-            f"PR: {pull_request_url}",
-            "",
-            "## Approved Plan",
-            approved_plan,
-            "",
-            "## PR Diff",
-            pr_diff,
-            "",
-            "Review the published PR and respond with exactly one JSON object.",
-            'Use the shape: {"status":"approved|rejected","summary":"...","feedback":["..."]}',
-            "If you reject, feedback must contain concrete required changes.",
-            "Do not include markdown fences.",
-        ]
-    )
+    if review_contract is None:
+        review_contract = load_review_stage_contract(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            pull_request_url=pull_request_url,
+            pull_number=_extract_pull_number(pull_request_url),
+            pull_head_sha=None,
+            diff_loader=_fetch_pr_diff,
+        )
+    return render_review_prompt(role, review_contract)
 
 
 def _fetch_pr_diff(owner: str, repo: str, pull_request_url: str) -> str:

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -15,6 +15,7 @@ from ..intake import is_docs_remediation_issue
 from ..json_events import extract_json_events
 from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord, SideIssue
 from ..opencode_model import resolve_opencode_model
+from ..stage_contracts import DeveloperStageContract, render_developer_approved_plan_context
 
 
 @runtime_checkable
@@ -30,6 +31,7 @@ class RepairAdapter(Protocol):
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
+        developer_contract: DeveloperStageContract | None = None,
     ) -> RepairResult: ...
 
     def with_qa_feedback(self, feedback: str) -> RepairAdapter: ...
@@ -54,7 +56,10 @@ REPAIR_RESULT_SCHEMA = {
                     },
                     "summary": {
                         "type": "string",
-                        "description": "Concise synthesis of the finding — what needs fixing and why. Aim for ~500 chars.",
+                        "description": (
+                            "Concise synthesis of the finding — what needs fixing "
+                            "and why. Aim for ~500 chars."
+                        ),
                     },
                     "body": {
                         "type": "string",
@@ -101,6 +106,7 @@ class OpenCodeRepairAdapter:
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
+        developer_contract: DeveloperStageContract | None = None,
     ) -> RepairResult:
         stdout_path = run_dir / "repair.stdout.log"
         stderr_path = run_dir / "repair.stderr.log"
@@ -115,6 +121,7 @@ class OpenCodeRepairAdapter:
             contract_artifact_dir=contract_artifact_dir,
             repo_workspace=repo_workspace,
             qa_feedback=self.qa_feedback,
+            developer_contract=developer_contract,
         )
 
         command = [
@@ -240,7 +247,7 @@ def _extract_side_issues(repair_json: dict) -> tuple[SideIssue, ...]:
             continue
         labels_raw = item.get("labels", [])
         if isinstance(labels_raw, list):
-            labels = tuple(str(l) for l in labels_raw if isinstance(l, str))
+            labels = tuple(str(label) for label in labels_raw if isinstance(label, str))
         else:
             labels = ()
         side_issues.append(SideIssue(
@@ -261,16 +268,34 @@ def _build_repair_prompt(
     contract_artifact_dir: Path,
     repo_workspace: Path,
     qa_feedback: str | None,
+    developer_contract: DeveloperStageContract | None = None,
 ) -> str:
     docs_fix_prompt_path = contract_artifact_dir / "docs-fix-prompt.txt"
     docs_fix_prompt_content = ""
-    if docs_fix_prompt_path.exists():
+    issue_statement_path = run_dir / "issue.md"
+    execution_contract_path = contract_artifact_dir / "contract.json"
+    readme_snapshot_path = contract_artifact_dir / "README.snapshot.md"
+    executor_stdout_path = run_dir / "executor.stdout.log"
+    executor_stderr_path = run_dir / "executor.stderr.log"
+
+    if developer_contract is not None:
+        docs_fix_prompt_content = developer_contract.docs_fix_prompt_content or ""
+        issue_statement_path = developer_contract.issue_statement_path
+        execution_contract_path = developer_contract.execution_contract_path
+        readme_snapshot_path = developer_contract.readme_snapshot_path
+        executor_stdout_path = developer_contract.executor_stdout_path
+        executor_stderr_path = developer_contract.executor_stderr_path
+        repo_workspace = developer_contract.repo_workspace
+        approved_plan = developer_contract.approved_plan
+    elif docs_fix_prompt_path.exists():
         docs_fix_prompt_content = docs_fix_prompt_path.read_text(encoding="utf-8")
 
     json_instruction = (
         "Output a single JSON object with at least a `summary` field describing what you did. "
-        "If you discover secondary issues unrelated to the primary issue, include them in a `side_issues` array. "
-        "Each side issue must have `title` (one-line identifier), `summary` (concise synthesis, aim for ~500 chars), "
+        "If you discover secondary issues unrelated to the primary issue, include them in a "
+        "`side_issues` array. "
+        "Each side issue must have `title` (one-line identifier), `summary` "
+        "(concise synthesis, aim for ~500 chars), "
         "`body` (full verbose output for audit), and `labels` (array of GitHub label strings). "
         "Schema:\n"
         + json.dumps(REPAIR_RESULT_SCHEMA, indent=2)
@@ -281,9 +306,12 @@ def _build_repair_prompt(
             approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
             repo_workspace=repo_workspace,
+            issue_statement_path=issue_statement_path,
+            execution_contract_path=execution_contract_path,
+            readme_snapshot_path=readme_snapshot_path,
+            executor_stdout_path=executor_stdout_path,
+            executor_stderr_path=executor_stderr_path,
             docs_fix_prompt_content=docs_fix_prompt_content,
             json_instruction=json_instruction,
         )
@@ -292,9 +320,12 @@ def _build_repair_prompt(
             approved_plan=approved_plan,
             intake=intake,
             run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
             repo_workspace=repo_workspace,
+            issue_statement_path=issue_statement_path,
+            execution_contract_path=execution_contract_path,
+            readme_snapshot_path=readme_snapshot_path,
+            executor_stdout_path=executor_stdout_path,
+            executor_stderr_path=executor_stderr_path,
             docs_fix_prompt_content=docs_fix_prompt_content,
             json_instruction=json_instruction,
         )
@@ -308,9 +339,12 @@ def _build_docs_remediation_prompt(
     approved_plan: ApprovedPlan | None = None,
     intake: IssueIntake,
     run_record: RunRecord,
-    run_dir: Path,
-    contract_artifact_dir: Path,
     repo_workspace: Path,
+    issue_statement_path: Path,
+    execution_contract_path: Path,
+    readme_snapshot_path: Path,
+    executor_stdout_path: Path,
+    executor_stderr_path: Path,
     docs_fix_prompt_content: str,
     json_instruction: str,
 ) -> list[str]:
@@ -344,7 +378,7 @@ def _build_docs_remediation_prompt(
         f"Run ID: {run_record.run_id}",
         f"Issue: {intake.issue.reference}",
         f"Title: {intake.issue.title}",
-        *(_render_approved_plan_context(approved_plan)),
+        *(render_developer_approved_plan_context(approved_plan)),
         "Requirements:",
         "- Update repository documentation in the current workspace to resolve the issue.",
         "- Treat this as a docs-remediation issue, not a product code change.",
@@ -367,12 +401,12 @@ def _build_docs_remediation_prompt(
         "- Do not commit.",
         "- After edits, output your JSON result.",
         "Context files:",
-        f"- Issue statement: {run_dir / 'issue.md'}",
+        f"- Issue statement: {issue_statement_path}",
         f"- Docs fix prompt (inlined):\n\n{docs_fix_prompt_content}\n",
-        f"- Execution contract: {contract_artifact_dir / 'contract.json'}",
-        f"- README snapshot: {contract_artifact_dir / 'README.snapshot.md'}",
-        f"- Executor stdout log: {run_dir / 'executor.stdout.log'}",
-        f"- Executor stderr log: {run_dir / 'executor.stderr.log'}",
+        f"- Execution contract: {execution_contract_path}",
+        f"- README snapshot: {readme_snapshot_path}",
+        f"- Executor stdout log: {executor_stdout_path}",
+        f"- Executor stderr log: {executor_stderr_path}",
         f"Workspace repo: {repo_workspace}",
         "",
         json_instruction,
@@ -384,9 +418,12 @@ def _build_standard_repair_prompt(
     approved_plan: ApprovedPlan | None = None,
     intake: IssueIntake,
     run_record: RunRecord,
-    run_dir: Path,
-    contract_artifact_dir: Path,
     repo_workspace: Path,
+    issue_statement_path: Path,
+    execution_contract_path: Path,
+    readme_snapshot_path: Path,
+    executor_stdout_path: Path,
+    executor_stderr_path: Path,
     docs_fix_prompt_content: str,
     json_instruction: str,
 ) -> list[str]:
@@ -396,7 +433,7 @@ def _build_standard_repair_prompt(
         f"Run ID: {run_record.run_id}",
         f"Issue: {intake.issue.reference}",
         f"Title: {intake.issue.title}",
-        *(_render_approved_plan_context(approved_plan)),
+        *(render_developer_approved_plan_context(approved_plan)),
         "Requirements:",
         "- Modify code in the current workspace to resolve the issue.",
         "- Use the documented local setup/test contract as the source of truth.",
@@ -405,11 +442,11 @@ def _build_standard_repair_prompt(
         "- Do not commit.",
         "- After edits, output your JSON result.",
         "Context files:",
-        f"- Issue statement: {run_dir / 'issue.md'}",
-        f"- Execution contract: {contract_artifact_dir / 'contract.json'}",
-        f"- README snapshot: {contract_artifact_dir / 'README.snapshot.md'}",
-        f"- Executor stdout log: {run_dir / 'executor.stdout.log'}",
-        f"- Executor stderr log: {run_dir / 'executor.stderr.log'}",
+        f"- Issue statement: {issue_statement_path}",
+        f"- Execution contract: {execution_contract_path}",
+        f"- README snapshot: {readme_snapshot_path}",
+        f"- Executor stdout log: {executor_stdout_path}",
+        f"- Executor stderr log: {executor_stderr_path}",
         f"Workspace repo: {repo_workspace}",
     ]
     if docs_fix_prompt_content:
@@ -424,21 +461,4 @@ def _build_standard_repair_prompt(
     return lines
 
 
-def _render_approved_plan_context(approved_plan: ApprovedPlan | None) -> list[str]:
-    if approved_plan is None:
-        return []
-    lines = [
-        "Approved plan:",
-        f"- Summary: {approved_plan.plan_summary}",
-        "- Implementation steps:",
-        *[f"  - {step}" for step in approved_plan.implementation_steps],
-        f"- Retrieval surface summary: {approved_plan.retrieval_surface_summary or '(empty)'}",
-    ]
-    if approved_plan.named_references:
-        lines.append("- Named references:")
-        for ref in approved_plan.named_references:
-            suffix = f": {ref.description}" if ref.description else ""
-            lines.append(f"  - {ref.name} ({ref.reference_type}){suffix}")
-    else:
-        lines.append("- Named references: (none)")
-    return lines
+_extract_json_events = extract_json_events

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import openai
 from jsonschema import ValidationError, validate
 
-from ..models import ApprovedPlan
-from ..models import IssueIntake, RepairResult, RunRecord, SideIssue
+from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord, SideIssue
+from ..stage_contracts import DeveloperStageContract
 from .adapter import (
     REPAIR_RESULT_SCHEMA,
     _build_repair_prompt,
@@ -47,6 +47,7 @@ class VercelAIRepairAdapter:
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
+        developer_contract: DeveloperStageContract | None = None,
     ) -> RepairResult:
         stdout_path = run_dir / "repair.stdout.log"
 
@@ -58,6 +59,7 @@ class VercelAIRepairAdapter:
             contract_artifact_dir=contract_artifact_dir,
             repo_workspace=repo_workspace,
             qa_feedback=self.qa_feedback,
+            developer_contract=developer_contract,
         )
 
         resolved_model = self.model or os.environ.get("OPENAI_MODEL", "gpt-4o")

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import shutil
 import inspect
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -16,6 +16,7 @@ from ..github_client import GitHubClientError, GitHubWriteClient
 from ..models import ExecutionResult, IssueIntake, QaResult, RepairResult, RunRecord
 from ..rerun_context import latest_rejected_pull_request
 from ..run_store import ApprovedPlanError, RunStore
+from ..stage_contracts import load_developer_stage_contract
 from .adapter import RepairAdapter
 from .qa import (
     WorkspaceQaVerifier,
@@ -81,6 +82,22 @@ class RepairStage:
                     f"{contract_artifact_dir}"
                 ),
                 detail_codes=("repair_artifact_dir_missing",),
+            )
+
+        try:
+            developer_contract = load_developer_stage_contract(
+                approved_plan=approved_plan,
+                intake=intake,
+                run_record=run_record,
+                run_dir=run_dir,
+                contract_artifact_dir=contract_artifact_dir,
+                repo_workspace=(run_dir / "repair-workspace" / "repo").resolve(),
+            )
+        except ValueError as exc:
+            return RepairResult(
+                status="failed_infra",
+                summary=str(exc),
+                detail_codes=("repair_stage_contract_invalid",),
             )
 
         workspace_path = (run_dir / "repair-workspace").resolve()
@@ -152,6 +169,7 @@ class RepairStage:
             "run_dir": run_dir,
             "contract_artifact_dir": contract_artifact_dir,
             "repo_workspace": repo_workspace,
+            "developer_contract": developer_contract,
         }
         parameters = inspect.signature(self.adapter.repair).parameters
         if "approved_plan" not in parameters:

--- a/src/precision_squad/stage_contracts.py
+++ b/src/precision_squad/stage_contracts.py
@@ -1,0 +1,216 @@
+"""Explicit downstream stage contracts for developer and review stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .docs_policy import load_review_checklist_rules
+from .models import ApprovedPlan, IssueIntake, RunRecord
+from .run_store import RunStore
+
+DOCS_CHECKLIST_SOURCE = "src/precision_squad/data/docs_checklist.json"
+_SURFACED_DESIGN_DECISIONS_EMPTY = (
+    "none (reserved for issue #55; intentionally empty for issue #54)"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeveloperStageContract:
+    """Explicit allowlisted inputs for developer-stage prompt assembly."""
+
+    approved_plan: ApprovedPlan
+    run_id: str
+    issue_ref: str
+    issue_title: str
+    issue_statement_path: Path
+    execution_contract_path: Path
+    readme_snapshot_path: Path
+    executor_stdout_path: Path
+    executor_stderr_path: Path
+    repo_workspace: Path
+    docs_fix_prompt_content: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewStageContract:
+    """Explicit allowlisted inputs for review-stage prompt assembly."""
+
+    approved_plan_text: str
+    pr_diff: str
+    checklist_rules: tuple[dict[str, Any], ...]
+    run_id: str
+    issue_ref: str
+    pull_request_url: str
+    pull_number: int | None
+    pull_head_sha: str | None
+    surfaced_design_decisions: str = _SURFACED_DESIGN_DECISIONS_EMPTY
+
+
+def load_developer_stage_contract(
+    *,
+    approved_plan: ApprovedPlan,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    run_dir: Path,
+    contract_artifact_dir: Path,
+    repo_workspace: Path,
+) -> DeveloperStageContract:
+    """Load and validate the explicit developer-stage contract inputs."""
+    issue_statement_path = _require_file(
+        run_dir / "issue.md",
+        "issue statement artifact",
+    )
+    execution_contract_path = _require_file(
+        contract_artifact_dir / "contract.json",
+        "execution contract artifact",
+    )
+    readme_snapshot_path = _require_file(
+        contract_artifact_dir / "README.snapshot.md",
+        "README snapshot artifact",
+    )
+    executor_stdout_path = _require_file(
+        run_dir / "executor.stdout.log",
+        "executor stdout log",
+    )
+    executor_stderr_path = _require_file(
+        run_dir / "executor.stderr.log",
+        "executor stderr log",
+    )
+
+    docs_fix_prompt_path = contract_artifact_dir / "docs-fix-prompt.txt"
+    docs_fix_prompt_content = None
+    if docs_fix_prompt_path.exists():
+        docs_fix_prompt_content = docs_fix_prompt_path.read_text(encoding="utf-8")
+
+    return DeveloperStageContract(
+        approved_plan=approved_plan,
+        run_id=run_record.run_id,
+        issue_ref=str(intake.issue.reference),
+        issue_title=intake.issue.title,
+        issue_statement_path=issue_statement_path,
+        execution_contract_path=execution_contract_path,
+        readme_snapshot_path=readme_snapshot_path,
+        executor_stdout_path=executor_stdout_path,
+        executor_stderr_path=executor_stderr_path,
+        repo_workspace=repo_workspace,
+        docs_fix_prompt_content=docs_fix_prompt_content,
+    )
+
+
+def load_review_stage_contract(
+    *,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    run_dir: Path,
+    pull_request_url: str,
+    pull_number: int | None,
+    pull_head_sha: str | None,
+    diff_loader: Callable[[str, str, str], str],
+) -> ReviewStageContract:
+    """Load and validate the explicit review-stage contract inputs."""
+    approved_plan_text = RunStore.load_approved_plan_text(
+        run_dir,
+        issue_ref=run_record.issue_ref,
+        include_named_references=True,
+    )
+    if not approved_plan_text.strip():
+        raise ValueError("Review context pack is missing required approved plan")
+
+    pr_diff = diff_loader(
+        intake.issue.reference.owner,
+        intake.issue.reference.repo,
+        pull_request_url,
+    )
+    if not pr_diff.strip():
+        raise ValueError("Review context pack is missing required PR diff")
+
+    checklist_rules = load_review_checklist_rules()
+    if not checklist_rules:
+        raise ValueError("Review context pack is missing required checklist material")
+
+    return ReviewStageContract(
+        approved_plan_text=approved_plan_text,
+        pr_diff=pr_diff,
+        checklist_rules=checklist_rules,
+        run_id=run_record.run_id,
+        issue_ref=str(intake.issue.reference),
+        pull_request_url=pull_request_url,
+        pull_number=pull_number,
+        pull_head_sha=pull_head_sha,
+    )
+
+
+def render_developer_approved_plan_context(approved_plan: ApprovedPlan | None) -> list[str]:
+    """Render approved-plan context for developer prompts from the canonical artifact only."""
+    if approved_plan is None:
+        return []
+    lines = [
+        "Approved plan:",
+        f"- Summary: {approved_plan.plan_summary}",
+        "- Implementation steps:",
+        *[f"  - {step}" for step in approved_plan.implementation_steps],
+        f"- Retrieval surface summary: {approved_plan.retrieval_surface_summary or '(empty)'}",
+    ]
+    if approved_plan.named_references:
+        lines.append("- Named references:")
+        for ref in approved_plan.named_references:
+            suffix = f": {ref.description}" if ref.description else ""
+            lines.append(f"  - {ref.name} ({ref.reference_type}){suffix}")
+    else:
+        lines.append("- Named references: (none)")
+    return lines
+
+
+def render_review_prompt(role: str, contract: ReviewStageContract) -> str:
+    """Render a review prompt from the explicit review-stage contract."""
+    checklist_lines: list[str] = []
+    for rule in contract.checklist_rules:
+        checklist_lines.extend(
+            [
+                f"- [{_blocking_marker(rule)}] {rule['code']}: {rule['requirement']}",
+                f"  Question: {rule['question']}",
+            ]
+        )
+    metadata_lines = [
+        f"Review role: {role}",
+        f"Run ID: {contract.run_id}",
+        f"Issue: {contract.issue_ref}",
+        f"PR: {contract.pull_request_url}",
+        "PR Number: "
+        f"{contract.pull_number if contract.pull_number is not None else '(unavailable)'}",
+        f"PR Head SHA: {contract.pull_head_sha or '(unavailable)'}",
+    ]
+    return "\n".join(
+        [
+            *metadata_lines,
+            "",
+            "## Approved Plan",
+            contract.approved_plan_text,
+            "",
+            f"## Deterministic Review Checklist ({DOCS_CHECKLIST_SOURCE})",
+            *checklist_lines,
+            "",
+            "## Surfaced Design Decisions",
+            f"- {contract.surfaced_design_decisions}",
+            "",
+            "## PR Diff",
+            contract.pr_diff,
+            "",
+            "Review the published PR and respond with exactly one JSON object.",
+            'Use the shape: {"status":"approved|rejected","summary":"...","feedback":["..."]}',
+            "If you reject, feedback must contain concrete required changes.",
+            "Do not include markdown fences.",
+        ]
+    )
+
+
+def _require_file(path: Path, label: str) -> Path:
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"Repair stage is missing required {label}: {path}")
+    return path
+
+
+def _blocking_marker(rule: dict[str, Any]) -> str:
+    return "blocking" if bool(rule.get("blocking")) else "advisory"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -6,10 +6,12 @@ import json
 from pathlib import Path
 
 from precision_squad.models import (
+    ApprovedPlan,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    NamedReference,
     RunRecord,
 )
 from precision_squad.repair.adapter import (
@@ -18,6 +20,7 @@ from precision_squad.repair.adapter import (
     _extract_side_issues,
     _parse_repair_json,
 )
+from precision_squad.stage_contracts import load_developer_stage_contract
 
 # ---------------------------------------------------------------------------
 # _extract_json_events
@@ -295,6 +298,23 @@ def _make_run_record() -> RunRecord:
     )
 
 
+def _make_approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Implement the fix.",
+        implementation_steps=("Update the code", "Update the tests"),
+        named_references=(
+            NamedReference(
+                name="src/app.py",
+                reference_type="file",
+                description="Primary implementation",
+            ),
+        ),
+        retrieval_surface_summary="src/app.py, tests/test_app.py",
+        approved=True,
+    )
+
+
 def test_build_repair_prompt_non_docs_no_docs_fix_prompt(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
@@ -408,3 +428,46 @@ def test_build_repair_prompt_appends_qa_feedback(tmp_path: Path) -> None:
 
     assert "QA feedback from the previous attempt:" in prompt
     assert "Tests failed: test_foo" in prompt
+
+
+def test_build_repair_prompt_uses_explicit_developer_contract_inputs(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source\n", encoding="utf-8")
+    (contract_dir / "docs-fix-prompt.txt").write_text("Side issue details\n", encoding="utf-8")
+
+    developer_contract = load_developer_stage_contract(
+        approved_plan=_make_approved_plan(),
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path / "workspace" / "repo",
+    )
+
+    prompt = _build_repair_prompt(
+        approved_plan=None,
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path,
+        qa_feedback=None,
+        developer_contract=developer_contract,
+    )
+
+    assert "- Summary: Implement the fix." in prompt
+    assert "  - Update the code" in prompt
+    assert "- Retrieval surface summary: src/app.py, tests/test_app.py" in prompt
+    assert "  - src/app.py (file): Primary implementation" in prompt
+    assert f"- Issue statement: {run_dir / 'issue.md'}" in prompt
+    assert f"- Execution contract: {contract_dir / 'contract.json'}" in prompt
+    assert f"- README snapshot: {contract_dir / 'README.snapshot.md'}" in prompt

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,6 +10,7 @@ import pytest
 
 from precision_squad.executor import DocsFirstExecutor
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
@@ -28,7 +29,6 @@ from precision_squad.repair import (
     merge_docs_remediation_execution_result,
     merge_execution_result,
 )
-from precision_squad.models import ApprovedPlan
 
 
 def _intake() -> IssueIntake:
@@ -353,6 +353,11 @@ def test_repair_stage_reports_not_configured_when_command_missing(tmp_path: Path
     run_dir.mkdir()
     contract_dir = run_dir / "execution-contract"
     contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
     (run_dir / "approved-plan.json").write_text(
         json.dumps(
             {
@@ -398,6 +403,11 @@ def test_repair_stage_clears_existing_workspace_before_clone(
     run_dir.mkdir()
     contract_dir = run_dir / "execution-contract"
     contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
     (run_dir / "approved-plan.json").write_text(
         json.dumps(
             {
@@ -529,6 +539,56 @@ def test_repair_stage_fails_before_workspace_side_effects_when_approved_plan_inv
     assert result.status == "failed_infra"
     assert "approved plan" in result.summary.lower()
     assert "repair_approved_plan_invalid" in result.detail_codes
+
+
+def test_repair_stage_fails_before_workspace_side_effects_when_required_contract_artifact_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+
+    def fail_if_git_runs(*args, **kwargs):
+        raise AssertionError("git commands should not run before stage-contract validation")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            raise AssertionError("adapter should not run before stage-contract validation")
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fail_if_git_runs)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert "required readme snapshot artifact" in result.summary.lower()
+    assert result.detail_codes == ("repair_stage_contract_invalid",)
 
 
 def test_repair_stage_with_no_adapter_still_fails_when_approved_plan_missing(tmp_path: Path) -> None:

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -78,6 +78,8 @@ def _write_raw_approved_plan(run_dir: Path, raw_payload: str) -> None:
 def test_run_post_publish_review_reopens_issue_on_rejection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _write_approved_plan(tmp_path)
+
     class StubAgent:
         def __init__(self, result: ReviewAgentResult) -> None:
             self._result = result
@@ -105,6 +107,10 @@ def test_run_post_publish_review_reopens_issue_on_rejection(
     monkeypatch.setattr(
         "precision_squad.post_publish_review.GitHubWriteClient.from_env",
         lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
     )
 
     result = run_post_publish_review(
@@ -144,6 +150,8 @@ def test_run_post_publish_review_reopens_issue_on_rejection(
 
 
 def test_run_post_publish_review_approves_when_both_agents_pass(tmp_path: Path) -> None:
+    _write_approved_plan(tmp_path)
+
     class StubAgent:
         def __init__(self, result: ReviewAgentResult) -> None:
             self._result = result
@@ -161,6 +169,10 @@ def test_run_post_publish_review_approves_when_both_agents_pass(tmp_path: Path) 
     monkeypatch.setattr(
         "precision_squad.post_publish_review.GitHubWriteClient.from_env",
         lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
     )
     try:
         result = run_post_publish_review(
@@ -531,6 +543,79 @@ def test_build_review_prompt_rejects_canonical_invalid_approved_plan_cases(
             run_dir=tmp_path,
             pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
         )
+
+
+def test_build_review_prompt_includes_checklist_source_and_empty_design_decisions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_approved_plan(tmp_path)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+
+    prompt = _build_review_prompt(
+        role="reviewer",
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+    )
+
+    assert "## Deterministic Review Checklist (src/precision_squad/data/docs_checklist.json)" in prompt
+    assert "docs_entrypoint_present" in prompt
+    assert "## Surfaced Design Decisions" in prompt
+    assert "reserved for issue #55" in prompt
+    assert "PR Number: 13" in prompt
+    assert "PR Head SHA: (unavailable)" in prompt
+
+
+def test_run_post_publish_review_fails_fast_when_checklist_loading_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_approved_plan(tmp_path)
+
+    def fail_if_agent_runs(**kwargs):
+        raise AssertionError("review agents should not run before checklist validation")
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.stage_contracts.load_review_checklist_rules",
+        lambda: (_ for _ in ()).throw(ValueError("docs checklist field 'rules' must be a list")),
+    )
+
+    class StubWriter:
+        def get_pull_request_head_sha(self, owner: str, repo: str, pull_number: int):
+            del owner, repo, pull_number
+            return "head-sha"
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+
+    result = run_post_publish_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        reviewer=cast(ReviewRunner, type("StubReviewer", (), {"review": staticmethod(fail_if_agent_runs)})()),
+        architect=cast(ReviewRunner, type("StubArchitect", (), {"review": staticmethod(fail_if_agent_runs)})()),
+    )
+
+    assert result.status == "failed_infra"
+    assert "docs checklist field 'rules' must be a list" in result.summary
+    assert result.reviewer_status == "failed_infra"
+    assert result.architect_status == "failed_infra"
 
 
 def test_parse_review_output_accepts_prose_before_json() -> None:

--- a/tests/test_stage_contracts.py
+++ b/tests/test_stage_contracts.py
@@ -1,0 +1,218 @@
+"""Tests for explicit downstream stage contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from precision_squad.models import (
+    ApprovedPlan,
+    GitHubIssue,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    NamedReference,
+    RunRecord,
+)
+from precision_squad.stage_contracts import (
+    DOCS_CHECKLIST_SOURCE,
+    load_developer_stage_contract,
+    load_review_stage_contract,
+    render_developer_approved_plan_context,
+    render_review_prompt,
+)
+
+
+def _intake() -> IssueIntake:
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+
+def _record(run_dir: Path) -> RunRecord:
+    return RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-27T00:00:00Z",
+        updated_at="2026-04-27T00:00:00Z",
+        run_dir=str(run_dir),
+    )
+
+
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        plan_summary="Review the implementation against the approved plan.",
+        implementation_steps=("Inspect the diff", "Verify the CLI output"),
+        named_references=(
+            NamedReference(
+                name="src/precision_squad/cli.py",
+                reference_type="file",
+                description="CLI entry point",
+            ),
+        ),
+        retrieval_surface_summary="src/precision_squad/cli.py, tests/test_cli.py",
+        approved=True,
+    )
+
+
+def _write_approved_plan(run_dir: Path) -> None:
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Review the implementation against the approved plan.",
+                "implementation_steps": ["Inspect the diff", "Verify the CLI output"],
+                "named_references": [
+                    {
+                        "name": "src/precision_squad/cli.py",
+                        "reference_type": "file",
+                        "description": "CLI entry point",
+                    }
+                ],
+                "retrieval_surface_summary": "src/precision_squad/cli.py, tests/test_cli.py",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_developer_artifacts(run_dir: Path, contract_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    contract_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
+
+
+def test_load_developer_stage_contract_requires_allowlisted_artifacts(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    contract_dir = run_dir / "execution-contract"
+    _write_developer_artifacts(run_dir, contract_dir)
+
+    contract = load_developer_stage_contract(
+        approved_plan=_approved_plan(),
+        intake=_intake(),
+        run_record=_record(run_dir),
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=tmp_path / "workspace" / "repo",
+    )
+
+    assert contract.issue_statement_path == run_dir / "issue.md"
+    assert contract.execution_contract_path == contract_dir / "contract.json"
+    assert contract.readme_snapshot_path == contract_dir / "README.snapshot.md"
+    assert contract.executor_stdout_path == run_dir / "executor.stdout.log"
+    assert contract.executor_stderr_path == run_dir / "executor.stderr.log"
+
+
+def test_load_developer_stage_contract_fails_when_required_artifact_missing(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    contract_dir = run_dir / "execution-contract"
+    _write_developer_artifacts(run_dir, contract_dir)
+    (contract_dir / "README.snapshot.md").unlink()
+
+    with pytest.raises(ValueError, match="README snapshot artifact"):
+        load_developer_stage_contract(
+            approved_plan=_approved_plan(),
+            intake=_intake(),
+            run_record=_record(run_dir),
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=tmp_path / "workspace" / "repo",
+        )
+
+
+def test_render_developer_approved_plan_context_uses_canonical_fields_only() -> None:
+    lines = render_developer_approved_plan_context(_approved_plan())
+
+    assert lines == [
+        "Approved plan:",
+        "- Summary: Review the implementation against the approved plan.",
+        "- Implementation steps:",
+        "  - Inspect the diff",
+        "  - Verify the CLI output",
+        "- Retrieval surface summary: src/precision_squad/cli.py, tests/test_cli.py",
+        "- Named references:",
+        "  - src/precision_squad/cli.py (file): CLI entry point",
+    ]
+
+
+def test_load_review_stage_contract_uses_deterministic_checklist_and_empty_decision_slot(
+    tmp_path: Path,
+) -> None:
+    _write_approved_plan(tmp_path)
+
+    contract = load_review_stage_contract(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        pull_number=13,
+        pull_head_sha="head-sha",
+        diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+    )
+
+    assert contract.pull_number == 13
+    assert contract.pull_head_sha == "head-sha"
+    assert contract.checklist_rules[0]["code"] == "docs_entrypoint_present"
+    assert contract.surfaced_design_decisions.startswith("none")
+
+
+def test_render_review_prompt_includes_only_required_review_inputs(tmp_path: Path) -> None:
+    _write_approved_plan(tmp_path)
+    contract = load_review_stage_contract(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        pull_number=13,
+        pull_head_sha="head-sha",
+        diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+    )
+
+    prompt = render_review_prompt("reviewer", contract)
+
+    assert f"## Deterministic Review Checklist ({DOCS_CHECKLIST_SOURCE})" in prompt
+    assert "docs_entrypoint_present" in prompt
+    assert "## Surfaced Design Decisions" in prompt
+    assert "reserved for issue #55" in prompt
+    assert "PR Head SHA: head-sha" in prompt
+    assert "## PR Diff" in prompt
+
+
+def test_load_review_stage_contract_fails_when_checklist_loader_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_approved_plan(tmp_path)
+    monkeypatch.setattr(
+        "precision_squad.stage_contracts.load_review_checklist_rules",
+        lambda: (_ for _ in ()).throw(ValueError("docs checklist field 'rules' must be a list")),
+    )
+
+    with pytest.raises(ValueError, match="docs checklist field 'rules' must be a list"):
+        load_review_stage_contract(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            pull_number=13,
+            pull_head_sha="head-sha",
+            diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+        )


### PR DESCRIPTION
Closes #54

## Summary
- define explicit downstream developer and review stage contracts anchored to the canonical approved plan
- add deterministic review checklist loading and explicit empty surfaced-design-decision slot behavior for issue 54
- add focused contract and fail-fast tests for adapter, executor, review, and stage contract seams

## Approved plan
- `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-54.md`

## Notable implementation decisions
- introduce narrow `stage_contracts` helpers instead of broader extraction work
- keep review checklist sourcing through the existing docs-policy seam
- keep surfaced design decisions explicitly empty for `#54`, reserved for later issue work

## Validation evidence
- implementation review already passed for run `20260519-155817-887`
- controller supplied head commit: `8d366e0f21580830947893a0ca2e1800aa3f6c6b`
- focused validation artifact paths were not supplied to completion; no additional completion-phase code changes were made