### PR TITLE
docs: align README baseline for issue 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,9 @@ It keeps product logic in this repository and treats repository documentation as
 
 ## Status
 
-This repository is in bootstrap.
+This repository is an active docs-first workflow control system for issue-driven repair work.
 
-The current near-term milestones are:
-
-1. bootstrap the Python package, tooling, CI, and issue/PR workflow assets
-2. implement GitHub PAT-backed issue intake
-3. add the local run store
-4. define the executor seam and documented local contract extraction
-5. build the first end-to-end CLI flow
-6. add governance v1 and publishing v1
+Governance produces **Approved** or **Blocked** verdicts. Quality tags are informational and do not gate publishing.
 
 ## Product Boundary
 
@@ -32,7 +25,7 @@ The current near-term milestones are:
 
 ## MVP Shape
 
-The first MVP should prove one control loop:
+The MVP control loop is:
 
 1. accept a GitHub issue
 2. normalize it into a runnable request
@@ -146,7 +139,7 @@ Legacy alias still supported:
 python -m precision_squad.cli run issue owner/repo#number --repo-path <local-repo>
 ```
 
-Publish an approved or provisional stored run without rerunning repair:
+Publish a stored run without rerunning repair:
 
 ```bash
 python -m precision_squad.cli publish run <run-id>
@@ -179,10 +172,12 @@ If you use the `skills` ecosystem directly, this repo also exposes a skill packa
 
 ## Issue Workflow
 
-This repository follows an issue-first GitHub workflow:
+This repository follows an issue-driven GitHub workflow:
 
-1. define work in a GitHub issue
-2. implement it through a linked PR
-3. keep the PR scoped to the issue
+1. define and track work through a GitHub issue
+2. implement it through one scoped PR
+3. keep the branch, commits, and file changes limited to that issue
+
+Unrelated fixes, refactors, or follow-on improvements should move to separate issues and PRs.
 
 PRs should include a closing reference such as `Closes #123`.


### PR DESCRIPTION
Closes #50

## Summary
- align `README.md` status wording with the post-ADR-007 baseline
- replace obsolete bootstrap and workflow terminology with the current issue-driven wording
- keep the change scoped to the README only

## Approved plan
- `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-50.md`

## Implementation decisions
- keep the edit limited to `README.md`
- update governance wording to `Approved` / `Blocked` and make quality tags informational only
- update issue workflow wording to reflect issue-driven, one-issue-per-PR scope discipline

## Validation evidence
- implementation review already passed before completion phase
- docs-only change; no code or test execution required by the approved plan
- remote branch head: `33840bca17c91caa9511e780261bf14d00495373`