### PR TITLE
fix: enforce decision log artifacts

### DIFF
--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -11,6 +11,7 @@ from .governance import apply_governance, evaluate_run
 from .intake import IssueIntake, canonicalize_local_issue_ref, is_docs_remediation_issue
 from .models import (
     ApprovedPlan,
+    DecisionLogArtifact,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
@@ -22,7 +23,7 @@ from .models import (
     RunRecord,
     RunRequest,
 )
-from .publishing import build_publish_plan
+from .publishing import RequiredDecisionLogArtifactMissingError, build_publish_plan
 from .repair import RepairAdapter
 from .run_store import ApprovedPlanNotFoundError, ApprovedPlanValidationError, RunStore
 
@@ -392,6 +393,14 @@ class RunCoordinator:
             ),
         )
         store.write_repair_result(run_dir, repair_result)
+        if repair_result.status == "completed":
+            store.write_decision_log(
+                run_dir,
+                DecisionLogArtifact(
+                    attempt=record.attempt,
+                    entries=repair_result.design_decisions,
+                ),
+            )
         validation_result = None
         validation_scope_summary = None
         if repair_result.status == "completed" and repair_result.workspace_path:
@@ -445,6 +454,14 @@ class RunCoordinator:
             ),
         )
         store.write_repair_result(run_dir, repair_result)
+        if repair_result.status == "completed":
+            store.write_decision_log(
+                run_dir,
+                DecisionLogArtifact(
+                    attempt=record.attempt,
+                    entries=repair_result.design_decisions,
+                ),
+            )
         if baseline_qa_result is not None:
             store.write_qa_result(run_dir, baseline_qa_result)
         if qa_result is not None:
@@ -476,7 +493,27 @@ class RunCoordinator:
         store.write_evaluation_result(run_dir, evaluation_result)
         verdict = apply_governance(intake, execution_result, evaluation_result)
         store.write_governance_verdict(run_dir, verdict)
-        publish_plan = build_publish_plan(intake, record, verdict, repair_result)
+        try:
+            publish_plan = build_publish_plan(intake, record, verdict, repair_result)
+        except RequiredDecisionLogArtifactMissingError as exc:
+            execution_result = ExecutionResult(
+                status="failed_infra",
+                executor_name=execution_result.executor_name,
+                summary=str(exc),
+                detail_codes=tuple(
+                    dict.fromkeys((*execution_result.detail_codes, "missing_decision_log_artifact"))
+                ),
+                artifact_dir=execution_result.artifact_dir,
+                stdout_path=execution_result.stdout_path,
+                stderr_path=execution_result.stderr_path,
+                quality=execution_result.quality,
+            )
+            store.write_execution_result(run_dir, execution_result)
+            evaluation_result = evaluate_run(intake, execution_result)
+            store.write_evaluation_result(run_dir, evaluation_result)
+            verdict = apply_governance(intake, execution_result, evaluation_result)
+            store.write_governance_verdict(run_dir, verdict)
+            publish_plan = build_publish_plan(intake, record, verdict)
         store.write_publish_plan(run_dir, publish_plan)
         publish_result = dependencies.execute_publish_plan(
             intake,

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -133,6 +133,26 @@ class SideIssue:
 
 
 @dataclass(frozen=True, slots=True)
+class DesignDecision:
+    """One non-obvious implementation choice recorded for a single repair attempt."""
+
+    sequence: int
+    summary: str
+    rationale: str
+    plan_steps: tuple[str, ...] = ()
+    named_references: tuple[str, ...] = ()
+    affected_targets: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionLogArtifact:
+    """Canonical persisted developer decision log for a single repair attempt."""
+
+    attempt: int
+    entries: tuple[DesignDecision, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RepairResult:
     """Normalized result for the post-synthesis repair stage."""
 
@@ -144,6 +164,7 @@ class RepairResult:
     stdout_path: str | None = None
     stderr_path: str | None = None
     side_issues: tuple[SideIssue, ...] = ()
+    design_decisions: tuple[DesignDecision, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from .docs_remediation import (
@@ -19,6 +20,11 @@ from .docs_remediation import (
 from .intake import is_docs_remediation_issue
 from .models import GovernanceVerdict, IssueIntake, PublishPlan, RepairResult, RunRecord
 from .rerun_context import latest_rejected_pull_request
+from .run_store import RunStore
+
+
+class RequiredDecisionLogArtifactMissingError(ValueError):
+    """Raised when a completed repair attempt is missing its required decision-log artifact."""
 
 
 def build_publish_plan(
@@ -41,6 +47,10 @@ def build_publish_plan(
                 + f"- Issue: `{intake.issue.reference}`\n"
                 + f"- Governance verdict: `{verdict.status}`\n"
                 + context_note
+                + _render_design_decisions_section(
+                    run_record,
+                    require_artifact=repair_result is not None and repair_result.status == "completed",
+                )
             ),
             reason_codes=verdict.reason_codes,
             pull_request_url=rejected_pr.url if rejected_pr else None,
@@ -228,3 +238,32 @@ def _finding_matches_reason_codes(
         code in reason_codes and rule_id in mapped_rule_ids
         for code, mapped_rule_ids in umbrella_mapping.items()
     )
+
+
+def _render_design_decisions_section(
+    run_record: RunRecord, *, require_artifact: bool = False
+) -> str:
+    try:
+        artifact = RunStore.load_decision_log(Path(run_record.run_dir), attempt=run_record.attempt)
+    except FileNotFoundError as exc:
+        if not require_artifact:
+            return ""
+        raise RequiredDecisionLogArtifactMissingError(
+            "Missing required decision-log artifact for "
+            f"run {run_record.run_id} attempt {run_record.attempt}: {exc.filename}"
+        ) from exc
+    if not artifact.entries:
+        return ""
+
+    payload = [
+        {
+            "sequence": entry.sequence,
+            "summary": entry.summary,
+            "rationale": entry.rationale,
+            "plan_steps": list(entry.plan_steps),
+            "named_references": list(entry.named_references),
+            "affected_targets": list(entry.affected_targets),
+        }
+        for entry in artifact.entries
+    ]
+    return "\n## Design Decisions\n```json\n" + json.dumps(payload, indent=2) + "\n```\n"

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -13,7 +13,14 @@ from jsonschema import ValidationError, validate
 from ..docs_remediation import extract_docs_target_findings
 from ..intake import is_docs_remediation_issue
 from ..json_events import extract_json_events
-from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord, SideIssue
+from ..models import (
+    ApprovedPlan,
+    DesignDecision,
+    IssueIntake,
+    RepairResult,
+    RunRecord,
+    SideIssue,
+)
 from ..opencode_model import resolve_opencode_model
 from ..stage_contracts import DeveloperStageContract, render_developer_approved_plan_context
 
@@ -78,6 +85,45 @@ REPAIR_RESULT_SCHEMA = {
                     },
                 },
                 "required": ["title", "summary", "body"],
+            },
+        },
+        "design_decisions": {
+            "type": "array",
+            "description": "Non-obvious implementation choices made during the repair.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sequence": {
+                        "type": "integer",
+                        "description": "Stable order within the current attempt.",
+                    },
+                    "summary": {
+                        "type": "string",
+                        "pattern": ".*\\S.*",
+                        "description": "Concise description of the decision.",
+                    },
+                    "rationale": {
+                        "type": "string",
+                        "pattern": ".*\\S.*",
+                        "description": "Why this path was chosen.",
+                    },
+                    "plan_steps": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Relevant approved-plan steps.",
+                    },
+                    "named_references": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Relevant approved-plan named references.",
+                    },
+                    "affected_targets": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Affected files, interfaces, or seams.",
+                    },
+                },
+                "required": ["sequence", "summary", "rationale"],
             },
         },
     },
@@ -154,8 +200,9 @@ class OpenCodeRepairAdapter:
         )
         stdout_path.write_text(command_result.stdout, encoding="utf-8", errors="ignore")
         stderr_path.write_text(command_result.stderr, encoding="utf-8", errors="ignore")
+        json_events = extract_json_events(command_result.stdout)
         transcript_path.write_text(
-            json.dumps(extract_json_events(command_result.stdout), indent=2) + "\n",
+            json.dumps(json_events, indent=2) + "\n",
             encoding="utf-8",
         )
 
@@ -202,9 +249,22 @@ class OpenCodeRepairAdapter:
             )
 
         repair_json = _parse_repair_json(command_result.stdout)
+        last_event = json_events[-1] if json_events else None
+        if repair_json is None and isinstance(last_event, dict) and "design_decisions" in last_event:
+            return RepairResult(
+                status="blocked",
+                summary="Repair agent produced malformed structured output for `design_decisions`.",
+                detail_codes=("repair_result_invalid",),
+                workspace_path=str(repo_workspace.parent),
+                patch_path=str(patch_path),
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+            )
         side_issues: tuple[SideIssue, ...] = ()
+        design_decisions: tuple[DesignDecision, ...] = ()
         if repair_json is not None:
             side_issues = _extract_side_issues(repair_json)
+            design_decisions = _extract_design_decisions(repair_json)
 
         return RepairResult(
             status="completed",
@@ -219,6 +279,7 @@ class OpenCodeRepairAdapter:
             stdout_path=str(stdout_path),
             stderr_path=str(stderr_path),
             side_issues=side_issues,
+            design_decisions=design_decisions,
         )
 
 
@@ -265,6 +326,46 @@ def _extract_side_issues(repair_json: dict) -> tuple[SideIssue, ...]:
             )
         )
     return tuple(side_issues)
+
+
+def _extract_design_decisions(repair_json: dict) -> tuple[DesignDecision, ...]:
+    """Extract structured design decisions from validated repair output."""
+    decisions_raw = repair_json.get("design_decisions")
+    if not isinstance(decisions_raw, list):
+        return ()
+
+    decisions: list[DesignDecision] = []
+    for item in decisions_raw:
+        if not isinstance(item, dict):
+            continue
+        sequence = item.get("sequence")
+        summary = item.get("summary")
+        rationale = item.get("rationale")
+        if (
+            not isinstance(sequence, int)
+            or not isinstance(summary, str)
+            or not isinstance(rationale, str)
+            or not summary.strip()
+            or not rationale.strip()
+        ):
+            continue
+        decisions.append(
+            DesignDecision(
+                sequence=sequence,
+                summary=summary,
+                rationale=rationale,
+                plan_steps=_extract_string_tuple(item.get("plan_steps")),
+                named_references=_extract_string_tuple(item.get("named_references")),
+                affected_targets=_extract_string_tuple(item.get("affected_targets")),
+            )
+        )
+    return tuple(decisions)
+
+
+def _extract_string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
 
 
 def _build_repair_prompt(

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -10,11 +10,12 @@ from pathlib import Path
 import openai
 from jsonschema import ValidationError, validate
 
-from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord, SideIssue
+from ..models import ApprovedPlan, DesignDecision, IssueIntake, RepairResult, RunRecord, SideIssue
 from ..stage_contracts import DeveloperStageContract
 from .adapter import (
     REPAIR_RESULT_SCHEMA,
     _build_repair_prompt,
+    _extract_design_decisions,
     _extract_side_issues,
 )
 
@@ -87,8 +88,10 @@ class VercelAIRepairAdapter:
 
         repair_json = _parse_llm_response(raw_content)
         side_issues: tuple[SideIssue, ...] = ()
+        design_decisions: tuple[DesignDecision, ...] = ()
         if repair_json is not None:
             side_issues = _extract_side_issues(repair_json)
+            design_decisions = _extract_design_decisions(repair_json)
 
         if repair_json is None:
             return RepairResult(
@@ -104,6 +107,7 @@ class VercelAIRepairAdapter:
             detail_codes=("repair_stage_completed",),
             stdout_path=str(stdout_path),
             side_issues=side_issues,
+            design_decisions=design_decisions,
         )
 
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 from .intake import canonicalize_local_issue_ref
 from .models import (
     ApprovedPlan,
+    DecisionLogArtifact,
+    DesignDecision,
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
@@ -29,6 +31,7 @@ from .models import (
 
 PersistedArtifact = (
     ApprovedPlan
+    | DecisionLogArtifact
     | EvaluationResult
     | ExecutionResult
     | GovernanceVerdict
@@ -43,6 +46,7 @@ PersistedArtifact = (
 )
 
 APPROVED_PLAN_FILENAME = "approved-plan.json"
+DECISION_LOG_FILENAME_TEMPLATE = "decision-log.attempt-{attempt}.json"
 _ALLOWED_NAMED_REFERENCE_TYPES = {"file", "interface", "symbol", "example"}
 
 
@@ -149,6 +153,16 @@ class RunStore:
 
     def write_repair_result(self, run_dir: Path, result: RepairResult) -> None:
         self._write_json(run_dir / "repair-result.json", result)
+
+    def write_decision_log(self, run_dir: Path, artifact: DecisionLogArtifact) -> None:
+        self._write_json(run_dir / _decision_log_filename(artifact.attempt), artifact)
+
+    @staticmethod
+    def load_decision_log(run_dir: Path, *, attempt: int) -> DecisionLogArtifact:
+        path = run_dir / _decision_log_filename(attempt)
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        return _parse_decision_log_payload(payload)
 
     def write_qa_result(self, run_dir: Path, result: QaResult) -> None:
         suffix = "" if result.phase in {"repair", "final"} else f"-{result.phase}"
@@ -424,3 +438,66 @@ def render_approved_plan_text(
             desc_suffix = f": {ref.description}" if ref.description else ""
             lines.append(f"- {ref.name}{ref_type_suffix}{desc_suffix}")
     return "\n".join(lines)
+
+
+def _decision_log_filename(attempt: int) -> str:
+    return DECISION_LOG_FILENAME_TEMPLATE.format(attempt=attempt)
+
+
+def _parse_decision_log_payload(payload: object) -> DecisionLogArtifact:
+    if not isinstance(payload, dict):
+        raise ValueError("Decision log payload must be a JSON object")
+
+    attempt = payload.get("attempt")
+    entries_raw = payload.get("entries")
+    if not isinstance(attempt, int):
+        raise ValueError("Decision log field 'attempt' must be an integer")
+    if not isinstance(entries_raw, list):
+        raise ValueError("Decision log field 'entries' must be a list")
+
+    entries: list[DesignDecision] = []
+    for index, item in enumerate(entries_raw, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"Decision log entries[{index}] must be an object")
+        sequence = item.get("sequence")
+        summary = item.get("summary")
+        rationale = item.get("rationale")
+        plan_steps = _read_decision_log_string_list(item, field_name="plan_steps", index=index)
+        named_references = _read_decision_log_string_list(
+            item,
+            field_name="named_references",
+            index=index,
+        )
+        affected_targets = _read_decision_log_string_list(
+            item,
+            field_name="affected_targets",
+            index=index,
+        )
+        if not isinstance(sequence, int):
+            raise ValueError(f"Decision log entries[{index}].sequence must be an integer")
+        if not isinstance(summary, str) or not summary.strip():
+            raise ValueError(f"Decision log entries[{index}].summary must be a non-empty string")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise ValueError(
+                f"Decision log entries[{index}].rationale must be a non-empty string"
+            )
+        entries.append(
+            DesignDecision(
+                sequence=sequence,
+                summary=summary,
+                rationale=rationale,
+                plan_steps=plan_steps,
+                named_references=named_references,
+                affected_targets=affected_targets,
+            )
+        )
+    return DecisionLogArtifact(attempt=attempt, entries=tuple(entries))
+
+
+def _read_decision_log_string_list(
+    payload: dict[str, object], *, field_name: str, index: int
+) -> tuple[str, ...]:
+    raw = payload.get(field_name, [])
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ValueError(f"Decision log entries[{index}].{field_name} must be a list of strings")
+    return tuple(raw)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -16,6 +16,7 @@ from precision_squad.models import (
 )
 from precision_squad.repair.adapter import (
     _build_repair_prompt,
+    _extract_design_decisions,
     _extract_json_events,
     _extract_side_issues,
     _parse_repair_json,
@@ -81,6 +82,25 @@ def test_parse_repair_json_valid_with_side_issues() -> None:
     assert len(result["side_issues"]) == 1
 
 
+def test_parse_repair_json_valid_with_design_decisions() -> None:
+    payload = {
+        "summary": "Fixed the bug.",
+        "design_decisions": [
+            {
+                "sequence": 1,
+                "summary": "Persist in coordinator",
+                "rationale": "Publish plan must consume stored evidence.",
+                "plan_steps": ["Persist artifact before publish-plan construction"],
+                "named_references": ["src/precision_squad/coordinator.py"],
+                "affected_targets": ["src/precision_squad/coordinator.py"],
+            }
+        ],
+    }
+    result = _parse_repair_json(json.dumps(payload))
+    assert result is not None
+    assert len(result["design_decisions"]) == 1
+
+
 def test_parse_repair_json_empty_stdout() -> None:
     assert _parse_repair_json("") is None
 
@@ -137,6 +157,92 @@ def test_parse_repair_json_side_issue_wrong_field_types() -> None:
         "side_issues": [{"title": 123, "summary": "ok", "body": "ok"}],
     })
     assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_design_decisions_wrong_type() -> None:
+    stdout = json.dumps({"summary": "done", "design_decisions": "bad"})
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_design_decision_missing_required_fields() -> None:
+    stdout = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": 1, "summary": "Missing rationale"}],
+        }
+    )
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_design_decision_wrong_field_types() -> None:
+    stdout = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": "1", "summary": "s", "rationale": "r"}],
+        }
+    )
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_design_decision_rejects_whitespace_summary() -> None:
+    stdout = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": 1, "summary": "   ", "rationale": "r"}],
+        }
+    )
+    assert _parse_repair_json(stdout) is None
+
+
+def test_parse_repair_json_design_decision_rejects_whitespace_rationale() -> None:
+    stdout = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": 1, "summary": "s", "rationale": "\t  \n"}],
+        }
+    )
+    assert _parse_repair_json(stdout) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_design_decisions
+# ---------------------------------------------------------------------------
+
+
+def test_extract_design_decisions_valid() -> None:
+    data = {
+        "summary": "done",
+        "design_decisions": [
+            {
+                "sequence": 1,
+                "summary": "Persist in coordinator",
+                "rationale": "Publish must read persisted evidence.",
+                "plan_steps": ["Persist artifact before publish-plan construction"],
+                "named_references": ["src/precision_squad/coordinator.py"],
+                "affected_targets": ["src/precision_squad/coordinator.py"],
+            }
+        ],
+    }
+    decisions = _extract_design_decisions(data)
+    assert len(decisions) == 1
+    assert decisions[0].sequence == 1
+    assert decisions[0].summary == "Persist in coordinator"
+    assert decisions[0].named_references == ("src/precision_squad/coordinator.py",)
+
+
+def test_extract_design_decisions_no_key_returns_empty() -> None:
+    assert _extract_design_decisions({"summary": "done"}) == ()
+
+
+def test_extract_design_decisions_skips_whitespace_only_fields() -> None:
+    data = {
+        "summary": "done",
+        "design_decisions": [
+            {"sequence": 1, "summary": "   ", "rationale": "Valid rationale"},
+            {"sequence": 2, "summary": "Valid summary", "rationale": "\n\t "},
+        ],
+    }
+    assert _extract_design_decisions(data) == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,173 @@
+"""Focused tests for decision-log persistence in RunCoordinator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from precision_squad.coordinator import RepairIssueParams, RunCoordinator
+from precision_squad.models import (
+    ApprovedPlan,
+    ExecutionResult,
+    GitHubIssue,
+    IssueAssessment,
+    IssueIntake,
+    IssueReference,
+    PublishPlan,
+    PublishResult,
+    QaResult,
+    RepairResult,
+)
+from precision_squad.run_store import RunStore
+
+
+def _approved_plan() -> ApprovedPlan:
+    return ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Fix the bug with a minimal change.",
+        implementation_steps=("Update the implementation",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    )
+
+
+def _make_intake() -> IssueIntake:
+    return IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Test issue",
+            body="Fix the bug.",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Test issue",
+        problem_statement="Fix the bug.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+
+
+def _make_params(tmp_path: Path) -> RepairIssueParams:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir(exist_ok=True)
+    return RepairIssueParams(
+        issue_ref="owner/repo#1",
+        runs_dir=tmp_path / "runs",
+        repo_path=repo_path,
+        publish=False,
+        repair_agent="none",
+        repair_model=None,
+        review_model=None,
+        approved_plan=_approved_plan(),
+    )
+
+
+def test_repair_issue_persists_empty_decision_log_before_publish(tmp_path: Path, monkeypatch) -> None:
+    execution_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Execution completed.",
+        detail_codes=(),
+        artifact_dir=str(tmp_path / "artifacts"),
+    )
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed.",
+        detail_codes=("repair_stage_completed",),
+        design_decisions=(),
+    )
+    baseline = QaResult(status="passed", summary="Baseline passed.", detail_codes=(), phase="baseline")
+    final = QaResult(status="passed", summary="Final passed.", detail_codes=(), phase="final")
+
+    import precision_squad.coordinator as coord_module
+
+    monkeypatch.setattr(
+        coord_module.DocsFirstExecutor,
+        "execute",
+        lambda self, intake, run_record, run_dir: execution_result,
+    )
+
+    captured_run_dir: Path | None = None
+    captured_plan: PublishPlan | None = None
+
+    def execute_publish_plan(intake, plan, *, publish, run_dir=None):
+        nonlocal captured_run_dir, captured_plan
+        captured_run_dir = run_dir
+        captured_plan = plan
+        assert run_dir is not None
+        payload = RunStore(tmp_path / "runs").load_decision_log(run_dir, attempt=1)
+        assert payload.entries == ()
+        return PublishResult(status="dry_run", target=plan.status, summary="Dry run", url=None)
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = True
+    dependencies.run_repair_qa_loop.return_value = (repair_result, baseline, final)
+    dependencies.merge_execution_result.return_value = execution_result
+    dependencies.execute_publish_plan.side_effect = execute_publish_plan
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    report = RunCoordinator().repair_issue(
+        params=_make_params(tmp_path),
+        intake=_make_intake(),
+        dependencies=dependencies,
+    )
+
+    run_dir = Path(report.run_record.run_dir)
+    assert (run_dir / "decision-log.attempt-1.json").exists()
+    assert captured_run_dir == run_dir
+    assert captured_plan is not None
+    assert "## Design Decisions" not in captured_plan.body
+
+
+def test_repair_issue_marks_missing_decision_log_artifact_as_failed_infra(
+    tmp_path: Path, monkeypatch
+) -> None:
+    execution_result = ExecutionResult(
+        status="completed",
+        executor_name="test",
+        summary="Execution completed.",
+        detail_codes=(),
+        artifact_dir=str(tmp_path / "artifacts"),
+    )
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed.",
+        detail_codes=("repair_stage_completed",),
+    )
+    baseline = QaResult(status="passed", summary="Baseline passed.", detail_codes=(), phase="baseline")
+    final = QaResult(status="passed", summary="Final passed.", detail_codes=(), phase="final")
+
+    import precision_squad.coordinator as coord_module
+
+    monkeypatch.setattr(
+        coord_module.DocsFirstExecutor,
+        "execute",
+        lambda self, intake, run_record, run_dir: execution_result,
+    )
+    monkeypatch.setattr(coord_module.RunStore, "write_decision_log", lambda self, run_dir, artifact: None)
+
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = True
+    dependencies.run_repair_qa_loop.return_value = (repair_result, baseline, final)
+    dependencies.merge_execution_result.return_value = execution_result
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="issue_comment",
+        summary="Dry run",
+        url=None,
+    )
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    report = RunCoordinator().repair_issue(
+        params=_make_params(tmp_path),
+        intake=_make_intake(),
+        dependencies=dependencies,
+    )
+
+    assert report.execution_result is not None
+    assert report.execution_result.status == "failed_infra"
+    assert "missing_decision_log_artifact" in report.execution_result.detail_codes
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "blocked"
+    assert report.publish_plan is not None
+    assert report.publish_plan.status == "issue_comment"

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -50,6 +50,22 @@ def test_parse_llm_response_valid_with_side_issues() -> None:
     assert len(result["side_issues"]) == 1
 
 
+def test_parse_llm_response_valid_with_design_decisions() -> None:
+    payload = {
+        "summary": "Fixed the bug.",
+        "design_decisions": [
+            {
+                "sequence": 1,
+                "summary": "Persist in coordinator",
+                "rationale": "Publish plan must read persisted evidence.",
+            }
+        ],
+    }
+    result = _parse_llm_response(json.dumps(payload))
+    assert result is not None
+    assert len(result["design_decisions"]) == 1
+
+
 def test_parse_llm_response_empty_string() -> None:
     assert _parse_llm_response("") is None
 
@@ -76,6 +92,33 @@ def test_parse_llm_response_side_issues_wrong_type() -> None:
 
 def test_parse_llm_response_side_issue_missing_required() -> None:
     payload = json.dumps({"summary": "done", "side_issues": [{"title": "Only title"}]})
+    assert _parse_llm_response(payload) is None
+
+
+def test_parse_llm_response_design_decision_missing_required() -> None:
+    payload = json.dumps(
+        {"summary": "done", "design_decisions": [{"sequence": 1, "summary": "Only summary"}]}
+    )
+    assert _parse_llm_response(payload) is None
+
+
+def test_parse_llm_response_design_decision_rejects_whitespace_summary() -> None:
+    payload = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": 1, "summary": "   ", "rationale": "Valid rationale"}],
+        }
+    )
+    assert _parse_llm_response(payload) is None
+
+
+def test_parse_llm_response_design_decision_rejects_whitespace_rationale() -> None:
+    payload = json.dumps(
+        {
+            "summary": "done",
+            "design_decisions": [{"sequence": 1, "summary": "Valid summary", "rationale": "\n\t "}],
+        }
+    )
     assert _parse_llm_response(payload) is None
 
 
@@ -332,6 +375,51 @@ def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
     assert result.status == "completed"
     assert len(result.side_issues) == 1
     assert result.side_issues[0].title == "Other bug"
+
+
+def test_repair_adapter_with_design_decisions(tmp_path: Path) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    payload = {
+        "summary": "Fixed the bug.",
+        "design_decisions": [
+            {
+                "sequence": 1,
+                "summary": "Persist in coordinator",
+                "rationale": "Publish plan must load stored evidence.",
+                "plan_steps": ["Persist artifact before publish-plan construction"],
+            }
+        ],
+    }
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(payload)
+
+    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        adapter = VercelAIRepairAdapter(model="gpt-4o")
+        result = adapter.repair(
+            approved_plan=_approved_plan(),
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_dir,
+            repo_workspace=repo_workspace,
+        )
+
+    assert result.status == "completed"
+    assert len(result.design_decisions) == 1
+    assert result.design_decisions[0].summary == "Persist in coordinator"
 
 
 def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from precision_squad.models import (
+    DecisionLogArtifact,
+    DesignDecision,
     GitHubIssue,
     GovernanceVerdict,
     IssueAssessment,
@@ -15,7 +19,11 @@ from precision_squad.models import (
     RunRecord,
     SideIssue,
 )
-from precision_squad.publishing import build_publish_plan
+from precision_squad.publishing import (
+    RequiredDecisionLogArtifactMissingError,
+    build_publish_plan,
+)
+from precision_squad.run_store import RunStore
 
 
 def test_build_publish_plan_creates_draft_pr_for_approved() -> None:
@@ -49,6 +57,140 @@ def test_build_publish_plan_creates_draft_pr_for_approved() -> None:
 
     assert plan.status == "draft_pr"
     assert plan.title == "Add --version flag to CLI"
+
+
+def test_build_publish_plan_includes_design_decisions_from_persisted_artifact(tmp_path: Path) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    run_record = RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=str(run_dir),
+    )
+    RunStore(tmp_path / "runs").write_decision_log(
+        run_dir,
+        DecisionLogArtifact(
+            attempt=1,
+            entries=(
+                DesignDecision(
+                    sequence=1,
+                    summary="Persist in coordinator",
+                    rationale="Publishing must read canonical persisted evidence.",
+                    plan_steps=("Persist the current attempt's decision log",),
+                    named_references=("src/precision_squad/coordinator.py",),
+                    affected_targets=("src/precision_squad/coordinator.py",),
+                ),
+            ),
+        ),
+    )
+    verdict = GovernanceVerdict(
+        status="approved",
+        summary="QA passed.",
+        reason_codes=(),
+    )
+
+    plan = build_publish_plan(intake, run_record, verdict)
+
+    assert "## Design Decisions" in plan.body
+    assert "```json" in plan.body
+    assert "Persist in coordinator" in plan.body
+    assert "canonical persisted evidence" in plan.body
+
+
+def test_build_publish_plan_omits_design_decisions_when_artifact_empty(tmp_path: Path) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    run_record = RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=str(run_dir),
+    )
+    RunStore(tmp_path / "runs").write_decision_log(
+        run_dir,
+        DecisionLogArtifact(attempt=1, entries=()),
+    )
+    verdict = GovernanceVerdict(
+        status="approved",
+        summary="QA passed.",
+        reason_codes=(),
+    )
+
+    plan = build_publish_plan(intake, run_record, verdict)
+
+    assert "## Design Decisions" not in plan.body
+
+
+def test_build_publish_plan_fails_when_completed_repair_missing_decision_log_artifact(
+    tmp_path: Path,
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 9),
+            title="[Enhancement] Add --version flag to CLI",
+            body="## Description\nAdd a version flag.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+        ),
+        summary="Add --version flag to CLI",
+        problem_statement="Add a version flag.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    run_record = RunRecord(
+        run_id="run-123",
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        status="runnable",
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        run_dir=str(run_dir),
+    )
+    verdict = GovernanceVerdict(
+        status="approved",
+        summary="QA passed.",
+        reason_codes=(),
+    )
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed.",
+        detail_codes=("repair_stage_completed",),
+    )
+
+    with pytest.raises(
+        RequiredDecisionLogArtifactMissingError,
+        match="Missing required decision-log artifact",
+    ):
+        build_publish_plan(intake, run_record, verdict, repair_result)
 
 
 def test_build_publish_plan_embeds_blocker_fingerprint_for_follow_up_issue() -> None:

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -9,6 +9,8 @@ import pytest
 
 from precision_squad.models import (
     ApprovedPlan,
+    DecisionLogArtifact,
+    DesignDecision,
     EvaluationResult,
     ExecutionResult,
     GitHubIssue,
@@ -163,6 +165,82 @@ def test_write_qa_results_uses_phase_specific_filenames(tmp_path: Path) -> None:
 
     assert (run_dir / "qa-baseline-result.json").exists()
     assert (run_dir / "qa-result.json").exists()
+
+
+def test_write_and_load_decision_log_uses_attempt_scoped_filename(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    artifact = DecisionLogArtifact(
+        attempt=2,
+        entries=(
+            DesignDecision(
+                sequence=1,
+                summary="Keep decision-log persistence in coordinator",
+                rationale="Publishing must load persisted evidence rather than transient state.",
+                plan_steps=("Persist decision-log artifact before publish-plan construction",),
+                named_references=("src/precision_squad/coordinator.py",),
+                affected_targets=("src/precision_squad/coordinator.py",),
+            ),
+        ),
+    )
+
+    store.write_decision_log(run_dir, artifact)
+
+    saved_path = run_dir / "decision-log.attempt-2.json"
+    assert saved_path.exists()
+    loaded = store.load_decision_log(run_dir, attempt=2)
+    assert loaded == artifact
+
+
+def test_write_decision_log_preserves_prior_attempt_files(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    store.write_decision_log(
+        run_dir,
+        DecisionLogArtifact(
+            attempt=1,
+            entries=(
+                DesignDecision(
+                    sequence=1,
+                    summary="Attempt one choice",
+                    rationale="First attempt rationale.",
+                ),
+            ),
+        ),
+    )
+    first_payload = (run_dir / "decision-log.attempt-1.json").read_text(encoding="utf-8")
+
+    store.write_decision_log(
+        run_dir,
+        DecisionLogArtifact(
+            attempt=2,
+            entries=(
+                DesignDecision(
+                    sequence=1,
+                    summary="Attempt two choice",
+                    rationale="Second attempt rationale.",
+                ),
+            ),
+        ),
+    )
+
+    assert (run_dir / "decision-log.attempt-1.json").read_text(encoding="utf-8") == first_payload
+    assert (run_dir / "decision-log.attempt-2.json").exists()
+
+
+def test_write_decision_log_persists_explicit_empty_entries(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    store.write_decision_log(run_dir, DecisionLogArtifact(attempt=1, entries=()))
+
+    payload = json.loads((run_dir / "decision-log.attempt-1.json").read_text(encoding="utf-8"))
+    assert payload == {"attempt": 1, "entries": []}
 
 
 def test_load_approved_plan_rejects_unapproved_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #55

## Summary
- persist attempt-scoped decision-log artifacts before publish-plan construction
- extend repair output parsing to carry structured design decisions through the repair result
- derive the PR `## Design Decisions` section from the persisted artifact instead of transient in-memory state
- add focused regression coverage for persistence, projection, and adapter behavior

## Approved Plan
- `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-55.md`

## Notable implementation decisions
- keep decision-log persistence attempt-scoped in `run_store` and coordinator flow rather than introducing a new side channel
- project review-facing design decisions from the stored artifact in publishing so the PR body is derived evidence, not the source of truth
- preserve adapter/LLM adapter parity for `design_decisions` schema handling and validation

## Validation evidence
- implementation review passed for run `20260519-155817-887`
- controller supplied `next_stage=MERGE` for reviewed head `8cf9fb931d2d8badb2520fa3377e0319c2d82cde`
- focused pytest targets per approved plan were part of the reviewed implementation evidence