### PR TITLE
fix: restore issue 82 baseline health

### DIFF
--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -29,7 +29,6 @@ from .models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
-    NamedReference,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -179,10 +178,10 @@ def _repair_issue(args: argparse.Namespace) -> int:
             "when carrying forward the prior approved-plan.json."
         )
 
-    intake = load_issue_intake(args.issue_ref)
     approved_plan: ApprovedPlan | None = None
     if args.approved_plan_path:
         approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
+    intake = load_issue_intake(args.issue_ref)
     report = RunCoordinator().repair_issue(
         params=RepairIssueParams(
             issue_ref=args.issue_ref,

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -216,7 +216,8 @@ class RunCoordinator:
                 )
             except ApprovedPlanNotFoundError:
                 raise ValueError(
-                    "Retry requires a prior approved-plan.json when --approved-plan-path is omitted; "
+                    "Retry requires a prior approved-plan.json when "
+                    "--approved-plan-path is omitted; "
                     f"missing prior approved-plan.json in {previous_run_dir}."
                 )
             except ApprovedPlanValidationError as exc:

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -97,7 +97,11 @@ def build_publish_plan(
         if side_issues:
             side_issues_lines = []
             for si in side_issues:
-                labels_str = ", ".join(f"`{l}`" for l in si.labels) if si.labels else "no labels"
+                labels_str = (
+                    ", ".join(f"`{label}`" for label in si.labels)
+                    if si.labels
+                    else "no labels"
+                )
                 side_issues_lines.append(
                     f"### {si.title}\n"
                     f"**Labels:** {labels_str}\n\n"

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -18,6 +18,12 @@ from ..opencode_model import resolve_opencode_model
 from ..stage_contracts import DeveloperStageContract, render_developer_approved_plan_context
 
 
+def _extract_json_events(stdout: str) -> list[dict]:
+    """Backward-compatible alias for JSON event extraction."""
+
+    return extract_json_events(stdout)
+
+
 @runtime_checkable
 class RepairAdapter(Protocol):
     """Common interface for repair adapters."""
@@ -250,12 +256,14 @@ def _extract_side_issues(repair_json: dict) -> tuple[SideIssue, ...]:
             labels = tuple(str(label) for label in labels_raw if isinstance(label, str))
         else:
             labels = ()
-        side_issues.append(SideIssue(
-            title=title,
-            summary=summary,
-            body=body,
-            labels=labels,
-        ))
+        side_issues.append(
+            SideIssue(
+                title=title,
+                summary=summary,
+                body=body,
+                labels=labels,
+            )
+        )
     return tuple(side_issues)
 
 

--- a/src/precision_squad/repair/qa.py
+++ b/src/precision_squad/repair/qa.py
@@ -259,9 +259,9 @@ def _finalize_qa_result(
     )
     if baseline_result.status not in {"failed", "failed_infra"}:
         if qa_result.status == "passed":
-            quality: Literal["green", "degraded"] = "green"
+            baseline_quality: Literal["green", "degraded"] = "green"
         else:
-            quality = "degraded"
+            baseline_quality = "degraded"
         return QaResult(
             status=final_result.status,
             summary=final_result.summary,
@@ -270,15 +270,15 @@ def _finalize_qa_result(
             stdout_path=final_result.stdout_path,
             stderr_path=final_result.stderr_path,
             phase="final",
-            quality=quality,
+            quality=baseline_quality,
         )
 
     repaired_failure_signature = _failure_signature(qa_result)
     if repaired_failure_signature < baseline_failure_signature:
         if qa_result.status == "passed":
-            quality: Literal["green", "improved", "degraded"] = "green"
+            improved_quality: Literal["green", "improved", "degraded"] = "green"
         else:
-            quality = "improved"
+            improved_quality = "improved"
         return QaResult(
             status=final_result.status,
             summary=final_result.summary,
@@ -287,13 +287,13 @@ def _finalize_qa_result(
             stdout_path=final_result.stdout_path,
             stderr_path=final_result.stderr_path,
             phase="final",
-            quality=quality,
+            quality=improved_quality,
         )
 
     if qa_result.status == "passed":
-        quality = "green"
+        final_quality: Literal["green", "degraded"] = "green"
     else:
-        quality = "degraded"
+        final_quality = "degraded"
     return QaResult(
         status=final_result.status,
         summary=final_result.summary,
@@ -302,7 +302,7 @@ def _finalize_qa_result(
         stdout_path=final_result.stdout_path,
         stderr_path=final_result.stderr_path,
         phase="final",
-        quality=quality,
+        quality=final_quality,
     )
 
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-from json import JSONDecodeError
 from dataclasses import asdict
 from datetime import UTC, datetime
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Literal, cast
 from uuid import uuid4
@@ -239,7 +239,8 @@ def _parse_approved_plan_payload(
     plan_issue_ref = _require_non_empty_str_field(payload, field_name="issue_ref")
     if plan_issue_ref != issue_ref:
         raise ApprovedPlanValidationError(
-            f"Approved plan issue_ref '{plan_issue_ref}' does not match expected issue_ref '{issue_ref}'"
+            "Approved plan issue_ref "
+            f"'{plan_issue_ref}' does not match expected issue_ref '{issue_ref}'"
         )
 
     return ApprovedPlan(
@@ -333,7 +334,10 @@ def _read_named_references(payload: dict[str, object]) -> tuple[NamedReference, 
         name = _require_non_empty_str(ref["name"], field_name=f"named_references[{index}].name")
 
         reference_type = ref.get("reference_type", "file")
-        if not isinstance(reference_type, str) or reference_type not in _ALLOWED_NAMED_REFERENCE_TYPES:
+        if (
+            not isinstance(reference_type, str)
+            or reference_type not in _ALLOWED_NAMED_REFERENCE_TYPES
+        ):
             raise ApprovedPlanValidationError(
                 "Approved plan named_references[{}].reference_type must be one of {}".format(
                     index,
@@ -350,7 +354,10 @@ def _read_named_references(payload: dict[str, object]) -> tuple[NamedReference, 
         named_refs.append(
             NamedReference(
                 name=name,
-                reference_type=cast(Literal["file", "interface", "symbol", "example"], reference_type),
+                reference_type=cast(
+                    Literal["file", "interface", "symbol", "example"],
+                    reference_type,
+                ),
                 description=description,
             )
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from precision_squad.models import (
     RepairResult,
     RunRecord,
 )
+from tests.integration.support import configure_git_identity
 
 # ---------------------------------------------------------------------------
 # GitHub token
@@ -238,12 +239,15 @@ class StubRepairAdapter:
     def repair(
         self,
         *,
+        approved_plan: object | None = None,
         intake: IssueIntake,
         run_record: RunRecord,
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
+        developer_contract: object | None = None,
     ) -> RepairResult:
+        del approved_plan, developer_contract
         repo_workspace.resolve()
 
         init_file = self._find_init(repo_workspace)
@@ -253,6 +257,7 @@ class StubRepairAdapter:
                 encoding="utf-8",
             )
 
+        configure_git_identity(repo_workspace)
         subprocess.run(
             ["git", "add", "-A"],
             cwd=repo_workspace,

--- a/tests/integration/support.py
+++ b/tests/integration/support.py
@@ -1,0 +1,152 @@
+"""Shared helpers for integration pipeline tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from precision_squad.models import (
+    ApprovedPlan,
+    IssueIntake,
+    PublishResult,
+    QaResult,
+    RepairResult,
+    RunRecord,
+)
+from precision_squad.repair import RepairAdapter
+
+
+def approved_plan_for(issue_ref: str = "cracklings3d/markdown-pdf-renderer#9") -> ApprovedPlan:
+    """Return a minimal approved plan fixture for integration runs."""
+
+    return ApprovedPlan(
+        issue_ref=issue_ref,
+        plan_summary="Repair the issue with a minimal bounded change.",
+        implementation_steps=("Apply the smallest coherent fix.",),
+        named_references=(),
+        retrieval_surface_summary="src/ tests/",
+        approved=True,
+    )
+
+
+def configure_git_identity(repo_workspace: Path) -> None:
+    """Configure a local git identity for test commits."""
+
+    for key, value in (("user.email", "test@test.local"), ("user.name", "Test")):
+        subprocess.run(
+            ["git", "config", key, value],
+            cwd=repo_workspace,
+            check=True,
+            capture_output=True,
+        )
+
+
+class _ApprovedTestDependencies:
+    """Dependency wiring for the approved pipeline path."""
+
+    def __init__(self, adapter: RepairAdapter) -> None:
+        self._adapter = adapter
+
+    def create_repair_adapter(
+        self, *, repair_agent: str, repair_model: str | None
+    ) -> RepairAdapter | None:
+        del repair_model
+        if repair_agent == "none":
+            return None
+        return self._adapter
+
+    def run_repair_qa_loop(
+        self,
+        *,
+        repo_path: Path,
+        adapter: RepairAdapter | None,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+    ) -> tuple[RepairResult, QaResult, QaResult]:
+        from precision_squad.repair.orchestration import (
+            RepairStage,
+            _failure_signature,
+            _finalize_qa_result,
+            _run_baseline_qa,
+        )
+        from precision_squad.repair.qa import WorkspaceQaVerifier
+
+        verifier = WorkspaceQaVerifier()
+        qa_result = _run_baseline_qa(
+            repo_path=repo_path,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_artifact_dir,
+            verifier=verifier,
+        )
+        baseline_result = qa_result
+        baseline_failure_signature = (
+            _failure_signature(baseline_result)
+            if baseline_result.status in {"failed", "failed_infra"}
+            else frozenset()
+        )
+
+        repair_result = RepairStage(
+            repo_path=repo_path,
+            adapter=adapter,
+        ).execute(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            contract_artifact_dir=contract_artifact_dir,
+        )
+
+        if repair_result.status != "completed":
+            return repair_result, baseline_result, qa_result
+
+        workspace_path = Path(repair_result.workspace_path or "")
+        repo_workspace = workspace_path / "repo"
+        final_qa = verifier.verify(
+            run_dir=run_dir,
+            contract_artifact_dir=contract_artifact_dir,
+            repo_workspace=repo_workspace,
+            iteration=1,
+        )
+        qa_result = _finalize_qa_result(
+            qa_result=final_qa,
+            baseline_result=baseline_result,
+            baseline_failure_signature=baseline_failure_signature,
+        )
+
+        return repair_result, baseline_result, qa_result
+
+    def run_docs_remediation_repair(self, **kwargs):
+        del kwargs
+        raise AssertionError("docs remediation should not run for non-docs-remediation issue")
+
+    def evaluate_docs_remediation_validation(self, **kwargs):
+        del kwargs
+        raise AssertionError("validation should not run for non-docs-remediation issue")
+
+    def merge_docs_remediation_execution_result(self, *args, **kwargs):
+        del args, kwargs
+        raise AssertionError("docs remediation merge should not run")
+
+    def merge_execution_result(self, synthesis_result, repair_result, qa_result=None):
+        from precision_squad.repair.orchestration import merge_execution_result as _real
+
+        return _real(synthesis_result, repair_result, qa_result)
+
+    def synthesis_artifacts_ready(self, execution_result):
+        from precision_squad.repair.orchestration import synthesis_artifacts_ready as _real
+
+        return _real(execution_result)
+
+    def execute_publish_plan(self, intake, plan, *, publish, run_dir=None) -> PublishResult:
+        del intake, publish, run_dir
+        return PublishResult(
+            status="dry_run",
+            target=plan.status,
+            summary="dry_run (integration test)",
+            url=None,
+        )
+
+    def run_post_publish_review_if_needed(self, **kwargs):
+        del kwargs
+        return None

--- a/tests/integration/test_github_publishing.py
+++ b/tests/integration/test_github_publishing.py
@@ -16,13 +16,20 @@ import pytest
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
+    ApprovedPlan,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
     IssueReference,
     PublishResult,
+    RepairResult,
+    RunRecord,
 )
-from tests.integration.test_pipeline_approved import _ApprovedTestDependencies
+from tests.integration.support import (
+    _ApprovedTestDependencies,
+    approved_plan_for,
+    configure_git_identity,
+)
 
 
 def _runnable_intake() -> IssueIntake:
@@ -52,12 +59,15 @@ class _StubRepairAdapterForGithub:
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
-        run_record,
+        run_record: RunRecord,
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
-    ):
+        developer_contract: object | None = None,
+    ) -> RepairResult:
+        del approved_plan, contract_artifact_dir, developer_contract, intake, run_record
         import subprocess
 
         init_file = repo_workspace / "src" / "clean_pkg" / "__init__.py"
@@ -65,6 +75,7 @@ class _StubRepairAdapterForGithub:
             original = init_file.read_text(encoding="utf-8")
             init_file.write_text(original + "# precision-squad: repaired\n", encoding="utf-8")
 
+        configure_git_identity(repo_workspace)
         subprocess.run(
             ["git", "add", "-A"],
             cwd=repo_workspace,
@@ -87,8 +98,6 @@ class _StubRepairAdapterForGithub:
         patch_path = run_dir / "repair.patch"
         patch_path.write_text(patch_proc.stdout or "", encoding="utf-8")
 
-        from precision_squad.models import RepairResult
-
         return RepairResult(
             status="completed",
             summary="Trivial repair: appended comment to __init__.py",
@@ -96,6 +105,10 @@ class _StubRepairAdapterForGithub:
             workspace_path=str(repo_workspace.parent),
             patch_path=str(patch_path),
         )
+
+    def with_qa_feedback(self, feedback: str) -> _StubRepairAdapterForGithub:
+        self.qa_feedback = feedback
+        return self
 
 
 class _GithubPublishTestDependencies(_ApprovedTestDependencies):
@@ -131,6 +144,7 @@ def test_publish_dry_run_returns_dry_run_status(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     adapter = _StubRepairAdapterForGithub()
@@ -143,6 +157,7 @@ def test_publish_dry_run_returns_dry_run_status(
     )
 
     assert report.publish_result is not None
+    assert report.publish_plan is not None
     assert report.publish_result.status == "dry_run", (
         f"Expected dry_run, got {report.publish_result.status}: "
         f"{report.publish_result.summary}"
@@ -169,6 +184,7 @@ def test_publish_plan_contains_issue_reference_and_verdict(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     adapter = _StubRepairAdapterForGithub()
@@ -181,6 +197,7 @@ def test_publish_plan_contains_issue_reference_and_verdict(
     )
 
     plan = report.publish_plan
+    assert plan is not None
     assert "cracklings3d/markdown-pdf-renderer#9" in plan.body
     assert report.run_record.run_id in plan.body
     assert "approved" in plan.body.lower()
@@ -208,6 +225,7 @@ def test_publish_true_calls_execute_publish_plan_with_publish_true(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     adapter = _StubRepairAdapterForGithub()
@@ -256,6 +274,7 @@ def test_publish_result_persisted_in_run_store(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     adapter = _StubRepairAdapterForGithub()

--- a/tests/integration/test_pipeline_approved.py
+++ b/tests/integration/test_pipeline_approved.py
@@ -22,6 +22,7 @@ from precision_squad.models import (
     IssueIntake,
     IssueReference,
 )
+from tests.integration.support import _ApprovedTestDependencies, approved_plan_for
 
 
 def _runnable_intake() -> IssueIntake:
@@ -61,6 +62,7 @@ def test_approved_happy_path(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -80,6 +82,9 @@ def test_approved_happy_path(
     assert report.qa_result.status == "passed"
     assert report.qa_result.quality == "green"
     assert report.baseline_qa_result is not None
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
+    assert report.publish_result is not None
     assert report.governance_verdict.status == "approved"
     assert report.publish_plan.status == "draft_pr"
     assert report.publish_result.status == "dry_run"
@@ -104,6 +109,7 @@ def test_approved_persists_all_artifacts(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -158,6 +164,7 @@ def test_approved_qa_result_has_correct_phase(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -193,6 +200,7 @@ def test_approved_publish_plan_has_required_fields(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -204,6 +212,7 @@ def test_approved_publish_plan_has_required_fields(
     )
 
     plan = report.publish_plan
+    assert plan is not None
     assert plan.status == "draft_pr"
     assert plan.title
     assert plan.body
@@ -228,6 +237,7 @@ def test_approved_exit_code_is_zero(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -241,122 +251,3 @@ def test_approved_exit_code_is_zero(
     assert report.exit_code == 0
 
 
-# ---------------------------------------------------------------------------
-# Test dependencies (wires real components except GitHub writes)
-# ---------------------------------------------------------------------------
-
-class _ApprovedTestDependencies:
-    """Dependency wiring for the approved pipeline path.
-
-    Uses real:
-    - DocsFirstExecutor (via RunCoordinator's internal wiring)
-    - run_repair_qa_loop (real implementation)
-    - synthesis_artifacts_ready (real implementation)
-
-    Mocks:
-    - GitHub write operations (returns dry_run PublishResult)
-    - post-publish review (returns None)
-    """
-
-    def __init__(self, adapter) -> None:
-        self._adapter = adapter
-
-    def create_repair_adapter(
-        self, *, repair_agent: str, repair_model: str | None
-    ):
-        if repair_agent == "none":
-            return None
-        return self._adapter
-
-    def run_repair_qa_loop(
-        self,
-        *,
-        repo_path: Path,
-        adapter,
-        intake: IssueIntake,
-        run_record,
-        run_dir: Path,
-        contract_artifact_dir: Path,
-    ):
-        from precision_squad.repair.orchestration import (
-            RepairStage,
-            _failure_signature,
-            _finalize_qa_result,
-            _run_baseline_qa,
-        )
-        from precision_squad.repair.qa import WorkspaceQaVerifier
-
-        verifier = WorkspaceQaVerifier()
-        qa_result = _run_baseline_qa(
-            repo_path=repo_path,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
-            verifier=verifier,
-        )
-        baseline_result = qa_result
-        baseline_failure_signature = (
-            _failure_signature(baseline_result)
-            if baseline_result.status in {"failed", "failed_infra"}
-            else frozenset()
-        )
-
-        repair_result = RepairStage(
-            repo_path=repo_path,
-            adapter=adapter,
-        ).execute(
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
-        )
-
-        if repair_result.status != "completed":
-            return repair_result, baseline_result, qa_result
-
-
-        workspace_path = Path(repair_result.workspace_path or "")
-        repo_workspace = workspace_path / "repo"
-        final_qa = verifier.verify(
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
-            repo_workspace=repo_workspace,
-            iteration=1,
-        )
-        qa_result = _finalize_qa_result(
-            qa_result=final_qa,
-            baseline_result=baseline_result,
-            baseline_failure_signature=baseline_failure_signature,
-        )
-
-        return repair_result, baseline_result, qa_result
-
-    def run_docs_remediation_repair(self, **kwargs):
-        raise AssertionError("docs remediation should not run for non-docs-remediation issue")
-
-    def evaluate_docs_remediation_validation(self, **kwargs):
-        raise AssertionError("validation should not run for non-docs-remediation issue")
-
-    def merge_docs_remediation_execution_result(self, *args, **kwargs):
-        raise AssertionError("docs remediation merge should not run")
-
-    def merge_execution_result(self, synthesis_result, repair_result, qa_result=None):
-        from precision_squad.repair.orchestration import merge_execution_result as _real
-
-        return _real(synthesis_result, repair_result, qa_result)
-
-    def synthesis_artifacts_ready(self, execution_result):
-        from precision_squad.repair.orchestration import synthesis_artifacts_ready as _real
-
-        return _real(execution_result)
-
-    def execute_publish_plan(self, intake, plan, *, publish, run_dir=None):
-        from precision_squad.models import PublishResult
-        return PublishResult(
-            status="dry_run",
-            target=plan.status,
-            summary="dry_run (integration test)",
-            url=None,
-        )
-
-    def run_post_publish_review_if_needed(self, **kwargs):
-        return None

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -13,10 +13,14 @@ import pytest
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
+    ApprovedPlan,
     ExecutionResult,
     IssueIntake,
     PublishResult,
+    RepairResult,
+    RunRecord,
 )
+from precision_squad.repair import RepairAdapter
 
 # ---------------------------------------------------------------------------
 # Blocked intake: plan issue skips the executor entirely
@@ -113,6 +117,9 @@ def test_missing_docs_blocks_pipeline(
 
     assert report.execution_result is not None
     assert report.execution_result.status == "missing_docs"
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
+    assert report.publish_result is not None
     assert report.governance_verdict.status == "blocked"
     assert report.publish_plan.status == "follow_up_issue"
     assert report.publish_result.status == "dry_run"
@@ -214,6 +221,8 @@ def test_ambiguous_docs_blocks_pipeline(
 
     assert report.execution_result is not None
     assert report.execution_result.status == "ambiguous_docs"
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
     assert report.governance_verdict.status == "blocked"
     assert report.publish_plan.status == "follow_up_issue"
     assert report.exit_code == 4
@@ -320,6 +329,7 @@ def test_qa_failed_blocks_pipeline(
     assert report.repair_result is not None
     assert report.repair_result.status == "completed"
     assert report.qa_result is not None
+    assert report.governance_verdict is not None
     assert report.qa_result.status == "failed"
     assert report.qa_result.quality == "degraded"
     assert report.governance_verdict.status == "blocked"
@@ -335,7 +345,8 @@ class _BlockedTestDependencies:
 
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ):
+    ) -> RepairAdapter | None:
+        del repair_agent, repair_model
         return None
 
     def run_repair_qa_loop(self, **kwargs):
@@ -382,13 +393,18 @@ class _QaFailedTestDependencies:
 
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
-    ):
+    ) -> RepairAdapter | None:
+        del repair_model
         if repair_agent == "none":
             return None
         return self._adapter
 
-    def run_repair_qa_loop(self, *, repo_path, adapter, intake, run_record, run_dir, contract_artifact_dir):
-        from precision_squad.models import QaResult, RepairResult
+    def run_repair_qa_loop(
+        self, *, repo_path, adapter, intake, run_record, run_dir, contract_artifact_dir
+    ):
+        from precision_squad.models import QaResult
+
+        del adapter, contract_artifact_dir, intake, run_dir, run_record
 
         repair_result = RepairResult(
             status="completed",
@@ -458,8 +474,18 @@ class _StubRepairAdapter:
         self.model: str | None = None
         self.qa_feedback: str | None = None
 
-    def repair(self, *, intake, run_record, run_dir, contract_artifact_dir, repo_workspace):
-        from precision_squad.models import RepairResult
+    def repair(
+        self,
+        *,
+        approved_plan: ApprovedPlan | None = None,
+        intake,
+        run_record: RunRecord,
+        run_dir: Path,
+        contract_artifact_dir: Path,
+        repo_workspace: Path,
+        developer_contract: object | None = None,
+    ) -> RepairResult:
+        del approved_plan, contract_artifact_dir, developer_contract, intake, run_dir, run_record
 
         return RepairResult(
             status="completed",
@@ -468,5 +494,6 @@ class _StubRepairAdapter:
             workspace_path=str(repo_workspace.parent),
         )
 
-    def with_qa_feedback(self, feedback: str):
+    def with_qa_feedback(self, feedback: str) -> _StubRepairAdapter:
+        self.qa_feedback = feedback
         return self

--- a/tests/integration/test_pipeline_docs_remediation.py
+++ b/tests/integration/test_pipeline_docs_remediation.py
@@ -15,7 +15,9 @@ from pathlib import Path
 import pytest
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
-from precision_squad.models import IssueIntake
+from precision_squad.models import ApprovedPlan, IssueIntake, RepairResult, RunRecord
+from precision_squad.repair import RepairAdapter
+from tests.integration.support import approved_plan_for, configure_git_identity
 
 # ---------------------------------------------------------------------------
 # Tailored repair adapters for docs-remediation scenarios
@@ -38,12 +40,15 @@ class _DocsFixRepairAdapter:
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
-        run_record,
+        run_record: RunRecord,
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
-    ):
+        developer_contract: object | None = None,
+    ) -> RepairResult:
+        del approved_plan, contract_artifact_dir, developer_contract, intake, run_record
         import subprocess
 
         readme = repo_workspace / "README.md"
@@ -74,6 +79,7 @@ class _DocsFixRepairAdapter:
             )
             readme.write_text(fixed, encoding="utf-8")
 
+        configure_git_identity(repo_workspace)
         subprocess.run(
             ["git", "add", "-A"],
             cwd=repo_workspace,
@@ -96,8 +102,6 @@ class _DocsFixRepairAdapter:
         patch_path = run_dir / "repair.patch"
         patch_path.write_text(patch_proc.stdout or "", encoding="utf-8")
 
-        from precision_squad.models import RepairResult
-
         return RepairResult(
             status="completed",
             summary="Docs-remediation repair: fixed GTK3 section in README.md.",
@@ -105,6 +109,10 @@ class _DocsFixRepairAdapter:
             workspace_path=str(repo_workspace.parent),
             patch_path=str(patch_path),
         )
+
+    def with_qa_feedback(self, feedback: str) -> _DocsFixRepairAdapter:
+        self.qa_feedback = feedback
+        return self
 
 
 class _NoOpRepairAdapter:
@@ -116,24 +124,30 @@ class _NoOpRepairAdapter:
         self.model: str | None = None
         self.qa_feedback: str | None = None
 
-    def repair(self, **kwargs):
+    def repair(self, **kwargs) -> RepairResult:
         import subprocess
 
-        from precision_squad.models import RepairResult
-
-        kwargs = kwargs
-        subprocess.run(["git", "add", "-A"], capture_output=True)
+        approved_plan = kwargs.pop("approved_plan", None)
+        del approved_plan
+        repo_workspace = kwargs["repo_workspace"]
+        configure_git_identity(repo_workspace)
+        subprocess.run(["git", "add", "-A"], cwd=repo_workspace, capture_output=True)
         subprocess.run(
             ["git", "commit", "-m", "noop repair"],
+            cwd=repo_workspace,
             capture_output=True,
         )
         return RepairResult(
             status="completed",
             summary="Repair stage ran but made no changes.",
             detail_codes=("repair_produced_no_changes",),
-            workspace_path=str(kwargs["repo_workspace"].parent),
+            workspace_path=str(repo_workspace.parent),
             patch_path="",
         )
+
+    def with_qa_feedback(self, feedback: str) -> _NoOpRepairAdapter:
+        self.qa_feedback = feedback
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -143,10 +157,13 @@ class _NoOpRepairAdapter:
 class _DocsRemediationDependencies:
     """Wires the docs-remediation repair path through RunCoordinator."""
 
-    def __init__(self, adapter) -> None:
+    def __init__(self, adapter: RepairAdapter) -> None:
         self._adapter = adapter
 
-    def create_repair_adapter(self, *, repair_agent: str, repair_model: str | None):
+    def create_repair_adapter(
+        self, *, repair_agent: str, repair_model: str | None
+    ) -> RepairAdapter | None:
+        del repair_model
         if repair_agent == "none":
             return None
         return self._adapter
@@ -231,6 +248,7 @@ def test_docs_remediation_succeeds_after_fix(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for("cracklings3d/markdown-pdf-renderer#16"),
     )
 
     deps = _DocsRemediationDependencies(_DocsFixRepairAdapter())
@@ -242,6 +260,8 @@ def test_docs_remediation_succeeds_after_fix(
     )
 
     assert report.execution_result is not None
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
     assert report.execution_result.status == "completed", (
         f"Expected completed, got {report.execution_result.status}: "
         f"{report.execution_result.summary}"
@@ -274,6 +294,7 @@ def test_docs_remediation_stays_blocked_without_fix(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for("cracklings3d/markdown-pdf-renderer#16"),
     )
 
     deps = _DocsRemediationDependencies(_NoOpRepairAdapter())
@@ -285,6 +306,8 @@ def test_docs_remediation_stays_blocked_without_fix(
     )
 
     assert report.execution_result is not None
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
     assert report.execution_result.status in {"missing_docs", "blocked"}, (
         f"Expected missing_docs or blocked, got {report.execution_result.status}: "
         f"{report.execution_result.summary}"
@@ -315,6 +338,7 @@ def test_docs_remediation_persists_repair_artifacts(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for("cracklings3d/markdown-pdf-renderer#16"),
     )
 
     deps = _DocsRemediationDependencies(_DocsFixRepairAdapter())

--- a/tests/integration/test_pipeline_quality_tag.py
+++ b/tests/integration/test_pipeline_quality_tag.py
@@ -13,12 +13,19 @@ import pytest
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
+    ApprovedPlan,
     GitHubIssue,
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    RepairResult,
+    RunRecord,
 )
-from tests.integration.test_pipeline_approved import _ApprovedTestDependencies
+from tests.integration.support import (
+    _ApprovedTestDependencies,
+    approved_plan_for,
+    configure_git_identity,
+)
 
 
 def _runnable_intake() -> IssueIntake:
@@ -59,12 +66,15 @@ class _RepairAdapterThatFixesFailingTest:
     def repair(
         self,
         *,
+        approved_plan: ApprovedPlan | None = None,
         intake: IssueIntake,
-        run_record,
+        run_record: RunRecord,
         run_dir: Path,
         contract_artifact_dir: Path,
         repo_workspace: Path,
-    ):
+        developer_contract: object | None = None,
+    ) -> RepairResult:
+        del approved_plan, contract_artifact_dir, developer_contract, intake, run_record
         import subprocess
 
         test_file = repo_workspace / "tests" / "test_core.py"
@@ -76,6 +86,7 @@ class _RepairAdapterThatFixesFailingTest:
             )
             test_file.write_text(fixed, encoding="utf-8")
 
+        configure_git_identity(repo_workspace)
         subprocess.run(
             ["git", "add", "-A"],
             cwd=repo_workspace,
@@ -97,8 +108,6 @@ class _RepairAdapterThatFixesFailingTest:
         )
         patch_path = run_dir / "repair.patch"
         patch_path.write_text(patch_proc.stdout or "", encoding="utf-8")
-
-        from precision_squad.models import RepairResult
 
         return RepairResult(
             status="completed",
@@ -126,6 +135,7 @@ def test_broken_baseline_improved_to_approved(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ProvisionalTestDependencies()
@@ -150,6 +160,8 @@ def test_broken_baseline_improved_to_approved(
     )
     assert report.qa_result.quality == "green"
 
+    assert report.governance_verdict is not None
+    assert report.publish_plan is not None
     assert report.governance_verdict.status == "approved", (
         f"Expected approved, got {report.governance_verdict.status}: "
         f"{report.governance_verdict.summary}"
@@ -175,6 +187,7 @@ def test_approved_publish_plan_contains_governance_verdict(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     deps = _ProvisionalTestDependencies()
@@ -186,6 +199,7 @@ def test_approved_publish_plan_contains_governance_verdict(
     )
 
     plan = report.publish_plan
+    assert plan is not None
     assert plan.status == "draft_pr"
     assert "approved" in plan.body.lower()
 
@@ -199,6 +213,7 @@ class _ProvisionalTestDependencies(_ApprovedTestDependencies):
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
     ):
+        del repair_model
         if repair_agent == "none":
             return None
         return self._adapter

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1293,6 +1293,20 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
     """Config file values are used when CLI args are not provided."""
     repo_path = tmp_path / "repo-from-config"
     runs_dir = tmp_path / "runs-from-config"
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     config_file = tmp_path / ".precision-squad.toml"
     config_file.write_text(
         (
@@ -1300,6 +1314,7 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
             f'repo_path = "{repo_path.as_posix()}"\n'
             f'runs_dir = "{runs_dir.as_posix()}"\n'
             'repair_agent = "none"\n'
+            f'approved_plan_path = "{plan_path.as_posix()}"\n'
         ),
         encoding="utf-8",
     )
@@ -1373,7 +1388,15 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
 
     monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
 
-    status = main(["repair", "issue", "owner/repo#1"])
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
 
     assert status == 0
     assert captured_params["repo_path"] == repo_path
@@ -1382,6 +1405,20 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
 
 
 def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     config_file = tmp_path / ".precision-squad.toml"
     config_file.write_text(
         (
@@ -1389,6 +1426,7 @@ def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytes
             'repo_path = "/from/config"\n'
             'runs_dir = "/config/runs"\n'
             'repair_agent = "none"\n'
+            f'approved_plan_path = "{plan_path.as_posix()}"\n'
         ),
         encoding="utf-8",
     )
@@ -1473,6 +1511,8 @@ def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytes
             str(tmp_path / "runs-from-cli"),
             "--repair-agent",
             "opencode",
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 
@@ -1645,6 +1685,20 @@ def test_repair_issue_no_publish_cli_overrides_true_config(
 ) -> None:
     repo_path = tmp_path / "repo-from-config"
     runs_dir = tmp_path / "runs-from-config"
+    plan_path = tmp_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     (tmp_path / ".precision-squad.toml").write_text(
         (
             "[repair.issue]\n"
@@ -1652,6 +1706,7 @@ def test_repair_issue_no_publish_cli_overrides_true_config(
             f'runs_dir = "{runs_dir.as_posix()}"\n'
             "publish = true\n"
             'repair_agent = "none"\n'
+            f'approved_plan_path = "{plan_path.as_posix()}"\n'
         ),
         encoding="utf-8",
     )
@@ -1723,7 +1778,16 @@ def test_repair_issue_no_publish_cli_overrides_true_config(
 
     monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
 
-    status = main(["repair", "issue", "owner/repo#1", "--no-publish"])
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--no-publish",
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
 
     assert status == 0
     assert captured_params["publish"] is False
@@ -1736,6 +1800,20 @@ def test_repair_issue_uses_explicit_repo_path_as_config_discovery_root(
     workspace.mkdir()
     repo_path = tmp_path / "target-repo"
     repo_path.mkdir()
+    plan_path = repo_path / "approved-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
     (workspace / ".precision-squad.toml").write_text(
         (
             "[repair.issue]\n"
@@ -1749,6 +1827,7 @@ def test_repair_issue_uses_explicit_repo_path_as_config_discovery_root(
             "[repair.issue]\n"
             f'runs_dir = "{(repo_path / "runs-from-repo").as_posix()}"\n'
             'repair_agent = "none"\n'
+            f'approved_plan_path = "{plan_path.as_posix()}"\n'
         ),
         encoding="utf-8",
     )
@@ -1828,6 +1907,8 @@ def test_repair_issue_uses_explicit_repo_path_as_config_discovery_root(
             "owner/repo#1",
             "--repo-path",
             str(repo_path),
+            "--approved-plan-path",
+            str(plan_path),
         ]
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,6 @@ from precision_squad.config import (
     merge_config_into_args,
 )
 
-
 SUPPORTED_TABLES = {
     ("repair", "issue"): frozenset(
         {

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -17,9 +17,7 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
-    PublishPlan,
     PublishResult,
-    RepairResult,
     RunRecord,
     RunRequest,
 )


### PR DESCRIPTION
Closes #82

## Summary
Restore the merge-gating baseline for issue #82 so the existing required lint, pytest, and pyright checks can pass without folding unrelated cleanup into other issue PRs.

## Approved plan
- Plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-82.md`

## Completion trace
- Run id: `20260519-155817-887`
- Reviewed head SHA: `640bbad156f1b641ab452a65ccf261328a1c7305`
- Implementation review: passed, next stage `MERGE`

## Notable implementation decisions
- Extract a dedicated integration-test support seam in `tests/integration/support.py` instead of relying on brittle cross-test imports.
- Keep baseline-health fixes scoped to the current lint, pytest collection/import, and pyright failures.
- Repair the `repair/qa.py` typing seam and directly affected tests without changing CI workflow definitions.

## Validation evidence
Implementation review passed for the reviewed head above. Merge readiness still depends on live GitHub required checks and branch protection state at completion time.