### PR TITLE
fix: align repair adapter seam

### DIFF
--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -57,6 +57,18 @@ _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
 _REPAIR_AGENT_CHOICES = ("none", "opencode", "vercel-ai")
 
 
+def _build_repair_adapter(*, repair_agent: str, repair_model: str | None) -> RepairAdapter | None:
+    """Construct a seam-compatible repair adapter for the configured agent."""
+    if repair_agent == "none":
+        return None
+
+    adapter_factories: dict[str, Callable[[str | None], RepairAdapter]] = {
+        "opencode": lambda model: OpenCodeRepairAdapter(model=model),
+        "vercel-ai": lambda model: VercelAIRepairAdapter(model=model),
+    }
+    return adapter_factories[repair_agent](repair_model)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
@@ -302,11 +314,7 @@ class _CliRepairDependencies:
     def create_repair_adapter(
         self, *, repair_agent: str, repair_model: str | None
     ) -> RepairAdapter | None:
-        if repair_agent == "opencode":
-            return OpenCodeRepairAdapter(model=repair_model)
-        if repair_agent == "vercel-ai":
-            return VercelAIRepairAdapter(model=repair_model)
-        return None
+        return _build_repair_adapter(repair_agent=repair_agent, repair_model=repair_model)
 
     def run_repair_qa_loop(
         self,

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -49,7 +49,9 @@ def build_publish_plan(
                 + context_note
                 + _render_design_decisions_section(
                     run_record,
-                    require_artifact=repair_result is not None and repair_result.status == "completed",
+                    require_artifact=(
+                        repair_result is not None and repair_result.status == "completed"
+                    ),
                 )
             ),
             reason_codes=verdict.reason_codes,

--- a/src/precision_squad/repair/__init__.py
+++ b/src/precision_squad/repair/__init__.py
@@ -1,9 +1,9 @@
-"""Agent-backed repair stage using a documented local execution contract."""
+"""Canonical repair seam exports and repair-stage orchestration."""
 
 import subprocess
 
 from ..github_client import GitHubWriteClient
-from .adapter import OpenCodeRepairAdapter, RepairAdapter
+from .adapter import RepairAdapter, OpenCodeRepairAdapter
 from .llm_adapter import VercelAIRepairAdapter
 from .orchestration import (
     RepairStage,
@@ -19,8 +19,8 @@ from .orchestration import (
 from .qa import WorkspaceQaVerifier, _failure_signature, _finalize_qa_result, build_qa_feedback
 
 __all__ = [
-    "OpenCodeRepairAdapter",
     "RepairAdapter",
+    "OpenCodeRepairAdapter",
     "RepairStage",
     "VercelAIRepairAdapter",
     "WorkspaceQaVerifier",

--- a/src/precision_squad/repair/__init__.py
+++ b/src/precision_squad/repair/__init__.py
@@ -3,7 +3,7 @@
 import subprocess
 
 from ..github_client import GitHubWriteClient
-from .adapter import RepairAdapter, OpenCodeRepairAdapter
+from .adapter import OpenCodeRepairAdapter, RepairAdapter
 from .llm_adapter import VercelAIRepairAdapter
 from .orchestration import (
     RepairStage,

--- a/src/precision_squad/repair/adapter.py
+++ b/src/precision_squad/repair/adapter.py
@@ -250,7 +250,11 @@ class OpenCodeRepairAdapter:
 
         repair_json = _parse_repair_json(command_result.stdout)
         last_event = json_events[-1] if json_events else None
-        if repair_json is None and isinstance(last_event, dict) and "design_decisions" in last_event:
+        if (
+            repair_json is None
+            and isinstance(last_event, dict)
+            and "design_decisions" in last_event
+        ):
             return RepairResult(
                 status="blocked",
                 summary="Repair agent produced malformed structured output for `design_decisions`.",

--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -1,4 +1,4 @@
-"""Direct LLM repair adapter using the OpenAI SDK."""
+"""Compatibility direct-LLM repair adapter behind the shared seam."""
 
 from __future__ import annotations
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -14,6 +14,7 @@ from precision_squad.models import (
     NamedReference,
     RunRecord,
 )
+from precision_squad.repair import OpenCodeRepairAdapter, RepairAdapter, VercelAIRepairAdapter
 from precision_squad.repair.adapter import (
     _build_repair_prompt,
     _extract_design_decisions,
@@ -50,6 +51,23 @@ def test_extract_json_events_empty_stdout() -> None:
 def test_extract_json_events_no_dicts() -> None:
     stdout = '"just a string"\n123\n[1, 2, 3]\n'
     assert _extract_json_events(stdout) == []
+
+
+def test_repair_package_exports_canonical_seam_first() -> None:
+    import precision_squad.repair as repair
+
+    assert repair.RepairAdapter is RepairAdapter
+    assert repair.__all__[:3] == ["RepairAdapter", "OpenCodeRepairAdapter", "RepairStage"]
+
+
+def test_repair_package_exports_opencode_before_compatibility_adapter() -> None:
+    import precision_squad.repair as repair
+
+    assert repair.OpenCodeRepairAdapter is OpenCodeRepairAdapter
+    assert repair.VercelAIRepairAdapter is VercelAIRepairAdapter
+    assert repair.__all__.index("OpenCodeRepairAdapter") < repair.__all__.index(
+        "VercelAIRepairAdapter"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,9 +10,9 @@ import pytest
 from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
 from precision_squad.cli import (
-    _CliRepairDependencies,
     _REPAIR_AGENT_CHOICES,
     _build_repair_adapter,
+    _CliRepairDependencies,
     _prompt_for_run_selection,
     _repair_issue_prompt_is_interactive,
     main,
@@ -33,8 +33,8 @@ from precision_squad.models import (
     RunRecord,
     RunRequest,
 )
-from precision_squad.run_store import RunStore
 from precision_squad.repair import OpenCodeRepairAdapter, RepairAdapter, VercelAIRepairAdapter
+from precision_squad.run_store import RunStore
 
 
 def test_main_without_args_shows_help(capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,14 @@ import pytest
 
 from precision_squad import __version__
 from precision_squad.bootstrap import main as bootstrap_main
-from precision_squad.cli import _prompt_for_run_selection, _repair_issue_prompt_is_interactive, main
+from precision_squad.cli import (
+    _CliRepairDependencies,
+    _REPAIR_AGENT_CHOICES,
+    _build_repair_adapter,
+    _prompt_for_run_selection,
+    _repair_issue_prompt_is_interactive,
+    main,
+)
 from precision_squad.coordinator import RepairIssueReport
 from precision_squad.models import (
     ApprovedPlan,
@@ -27,6 +34,7 @@ from precision_squad.models import (
     RunRequest,
 )
 from precision_squad.run_store import RunStore
+from precision_squad.repair import OpenCodeRepairAdapter, RepairAdapter, VercelAIRepairAdapter
 
 
 def test_main_without_args_shows_help(capsys) -> None:
@@ -36,6 +44,40 @@ def test_main_without_args_shows_help(capsys) -> None:
     assert status == 0
     assert "precision-squad" in captured.out
     assert "run" in captured.out
+
+
+def test_repair_agent_choices_remain_unchanged() -> None:
+    assert _REPAIR_AGENT_CHOICES == ("none", "opencode", "vercel-ai")
+
+
+def test_build_repair_adapter_returns_none_for_none_agent() -> None:
+    assert _build_repair_adapter(repair_agent="none", repair_model=None) is None
+
+
+def test_build_repair_adapter_returns_opencode_as_primary_concrete_implementation() -> None:
+    adapter = _build_repair_adapter(repair_agent="opencode", repair_model="test-model")
+
+    assert isinstance(adapter, RepairAdapter)
+    assert isinstance(adapter, OpenCodeRepairAdapter)
+    assert adapter.model == "test-model"
+
+
+def test_build_repair_adapter_returns_compatibility_vercel_ai_implementation() -> None:
+    adapter = _build_repair_adapter(repair_agent="vercel-ai", repair_model="test-model")
+
+    assert isinstance(adapter, RepairAdapter)
+    assert isinstance(adapter, VercelAIRepairAdapter)
+    assert adapter.model == "test-model"
+
+
+def test_cli_repair_dependencies_construct_seam_compatible_adapter() -> None:
+    adapter = _CliRepairDependencies().create_repair_adapter(
+        repair_agent="opencode",
+        repair_model=None,
+    )
+
+    assert isinstance(adapter, RepairAdapter)
+    assert isinstance(adapter, OpenCodeRepairAdapter)
 
 
 def test_version_flag_shows_package_version(capsys) -> None:


### PR DESCRIPTION
## Summary
- align the canonical internal repair-adapter seam around `RepairAdapter`
- keep `OpenCodeRepairAdapter` as the first concrete implementation behind the seam
- add focused seam-level CLI and adapter regression coverage for issue #58

## Plan
- Approved plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-58.md`
- Controller run: `20260519-155817-887`
- Reviewed artifact SHA: `e20679f25b4951ceab56a04977d37ca33e8907e3`

## Notable implementation decisions
- centralize CLI repair-adapter construction through a seam-compatible helper returning `RepairAdapter | None`
- export `RepairAdapter` first from `precision_squad.repair` and keep `OpenCodeRepairAdapter` ordered ahead of compatibility adapters
- retain `vercel-ai` as a compatibility implementation without changing operator-facing repair-agent choices

## Validation evidence
- fresh implementation review passed for commit `e20679f25b4951ceab56a04977d37ca33e8907e3`
- focused diff remains bounded to seam-level alignment and tests

Closes #58