### PR TITLE
fix: persist post-publish review evidence

### DIFF
--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -226,6 +226,30 @@ class ReviewAgentResult:
     stdout_path: str | None = None
     stderr_path: str | None = None
     transcript_path: str | None = None
+    plan_alignment: Literal[
+        "aligned", "justified_deviation", "unjustified_deviation", "non_material_detail"
+    ] | None = None
+    plan_alignment_findings: tuple[str, ...] = ()
+    justification_findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AggregatedPlanAlignment:
+    """Aggregated cross-agent plan-alignment evidence for post-publish review."""
+
+    classification: Literal[
+        "aligned", "justified_deviation", "unjustified_deviation", "non_material_detail"
+    ] | None = None
+    plan_alignment_findings: tuple[str, ...] = ()
+    justification_findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PerAgentEvidence:
+    """Unambiguous reviewer/architect evidence mirror for persisted review results."""
+
+    reviewer: ReviewAgentResult
+    architect: ReviewAgentResult
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,5 +288,7 @@ class PostPublishReviewResult:
     architect_status: Literal["approved", "rejected", "failed_infra", "not_run"] = "not_run"
     architect_summary: str = "Architect review did not run."
     architect_feedback: tuple[str, ...] = ()
+    per_agent_evidence: PerAgentEvidence | None = None
+    aggregated_plan_alignment: AggregatedPlanAlignment = AggregatedPlanAlignment()
     issue_comment_url: str | None = None
     issue_reopened: bool = False

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -11,11 +11,24 @@ from typing import Any, Literal, Protocol
 
 from .github_client import GitHubWriteClient
 from .json_events import extract_json_events
-from .models import IssueIntake, PostPublishReviewResult, ReviewAgentResult, RunRecord
+from .models import (
+    AggregatedPlanAlignment,
+    IssueIntake,
+    PerAgentEvidence,
+    PostPublishReviewResult,
+    ReviewAgentResult,
+    RunRecord,
+)
 from .opencode_model import resolve_opencode_model
 from .stage_contracts import ReviewStageContract, load_review_stage_contract, render_review_prompt
 
 PULL_NUMBER_PATTERN = re.compile(r"/pull/(?P<number>[0-9]+)$")
+_PLAN_ALIGNMENT_VALUES = {
+    "aligned",
+    "justified_deviation",
+    "unjustified_deviation",
+    "non_material_detail",
+}
 
 
 class ReviewRunner(Protocol):
@@ -116,6 +129,9 @@ class OpenCodePrReviewAgent:
             stdout_path=str(stdout_path),
             stderr_path=str(stderr_path),
             transcript_path=str(transcript_path),
+            plan_alignment=parsed["plan_alignment"],
+            plan_alignment_findings=tuple(parsed["plan_alignment_findings"]),
+            justification_findings=tuple(parsed["justification_findings"]),
         )
 
 
@@ -142,16 +158,28 @@ def run_post_publish_review(
             pull_head_sha = None
 
     if reviewer is None or architect is None:
+        reviewer_result = _result_stub(
+            role="reviewer",
+            status="not_run",
+            summary="Reviewer did not run.",
+        )
+        architect_result = _result_stub(
+            role="architect",
+            status="not_run",
+            summary="Architect did not run.",
+        )
         return PostPublishReviewResult(
             status="not_run",
             summary="Post-publish review agents were not configured.",
             pull_request_url=pull_request_url,
             pull_number=pull_number,
             pull_head_sha=pull_head_sha,
-            reviewer_status="not_run",
-            reviewer_summary="Reviewer did not run.",
-            architect_status="not_run",
-            architect_summary="Architect did not run.",
+            reviewer_status=reviewer_result.status,
+            reviewer_summary=reviewer_result.summary,
+            architect_status=architect_result.status,
+            architect_summary=architect_result.summary,
+            per_agent_evidence=_build_per_agent_evidence(reviewer_result, architect_result),
+            aggregated_plan_alignment=_aggregate_plan_alignment(reviewer_result, architect_result),
         )
 
     try:
@@ -163,18 +191,31 @@ def run_post_publish_review(
             pull_number=pull_number,
             pull_head_sha=pull_head_sha,
             diff_loader=_fetch_pr_diff,
+            pr_body_loader=_fetch_pr_body,
         )
     except ValueError as exc:
+        reviewer_result = _result_stub(
+            role="reviewer",
+            status="failed_infra",
+            summary=str(exc),
+        )
+        architect_result = _result_stub(
+            role="architect",
+            status="failed_infra",
+            summary=str(exc),
+        )
         return PostPublishReviewResult(
             status="failed_infra",
             summary=str(exc),
             pull_request_url=pull_request_url,
             pull_number=pull_number,
             pull_head_sha=pull_head_sha,
-            reviewer_status="failed_infra",
-            reviewer_summary=str(exc),
-            architect_status="failed_infra",
-            architect_summary=str(exc),
+            reviewer_status=reviewer_result.status,
+            reviewer_summary=reviewer_result.summary,
+            architect_status=architect_result.status,
+            architect_summary=architect_result.summary,
+            per_agent_evidence=_build_per_agent_evidence(reviewer_result, architect_result),
+            aggregated_plan_alignment=_aggregate_plan_alignment(reviewer_result, architect_result),
         )
 
     reviewer_result = reviewer.review(
@@ -191,6 +232,8 @@ def run_post_publish_review(
         pull_request_url=pull_request_url,
         review_contract=review_contract,
     )
+    per_agent_evidence = _build_per_agent_evidence(reviewer_result, architect_result)
+    aggregated_plan_alignment = _aggregate_plan_alignment(reviewer_result, architect_result)
     if reviewer_result.status == "approved" and architect_result.status == "approved":
         return PostPublishReviewResult(
             status="approved",
@@ -204,6 +247,8 @@ def run_post_publish_review(
             architect_status=architect_result.status,
             architect_summary=architect_result.summary,
             architect_feedback=architect_result.feedback,
+            per_agent_evidence=per_agent_evidence,
+            aggregated_plan_alignment=aggregated_plan_alignment,
         )
 
     if "failed_infra" in {reviewer_result.status, architect_result.status}:
@@ -219,6 +264,8 @@ def run_post_publish_review(
             architect_status=architect_result.status,
             architect_summary=architect_result.summary,
             architect_feedback=architect_result.feedback,
+            per_agent_evidence=per_agent_evidence,
+            aggregated_plan_alignment=aggregated_plan_alignment,
         )
 
     client = GitHubWriteClient.from_env(token_env)
@@ -243,6 +290,8 @@ def run_post_publish_review(
         architect_status=architect_result.status,
         architect_summary=architect_result.summary,
         architect_feedback=architect_result.feedback,
+        per_agent_evidence=per_agent_evidence,
+        aggregated_plan_alignment=aggregated_plan_alignment,
         issue_comment_url=issue_comment_url,
         issue_reopened=True,
     )
@@ -266,6 +315,7 @@ def _build_review_prompt(
             pull_number=_extract_pull_number(pull_request_url),
             pull_head_sha=None,
             diff_loader=_fetch_pr_diff,
+            pr_body_loader=_fetch_pr_body,
         )
     return render_review_prompt(role, review_contract)
 
@@ -290,6 +340,16 @@ def _fetch_pr_diff(owner: str, repo: str, pull_request_url: str) -> str:
     return completed.stdout
 
 
+def _fetch_pr_body(owner: str, repo: str, pull_request_url: str) -> str | None:
+    match = PULL_NUMBER_PATTERN.search(pull_request_url.strip())
+    if match is None:
+        return None
+    pull_number = int(match.group("number"))
+    payload = GitHubWriteClient.from_env().get_pull_request(owner, repo, pull_number)
+    body = payload.get("body")
+    return body if isinstance(body, str) else None
+
+
 def _parse_review_output(events: list[dict]) -> dict[str, Any] | None:
     for event in reversed(events):
         if event.get("type") != "text":
@@ -306,16 +366,32 @@ def _parse_review_output(events: list[dict]) -> dict[str, Any] | None:
         status = payload.get("status")
         summary = payload.get("summary")
         feedback = payload.get("feedback")
+        plan_alignment = payload.get("plan_alignment")
+        plan_alignment_findings = payload.get("plan_alignment_findings")
+        justification_findings = payload.get("justification_findings")
         if status not in {"approved", "rejected"}:
             continue
         if not isinstance(summary, str):
             continue
         if not isinstance(feedback, list) or not all(isinstance(item, str) for item in feedback):
             continue
+        if plan_alignment not in _PLAN_ALIGNMENT_VALUES:
+            continue
+        if not isinstance(plan_alignment_findings, list) or not all(
+            isinstance(item, str) for item in plan_alignment_findings
+        ):
+            continue
+        if not isinstance(justification_findings, list) or not all(
+            isinstance(item, str) for item in justification_findings
+        ):
+            continue
         return {
             "status": _as_review_status(status),
             "summary": summary,
             "feedback": tuple(feedback),
+            "plan_alignment": _as_plan_alignment(plan_alignment),
+            "plan_alignment_findings": tuple(plan_alignment_findings),
+            "justification_findings": tuple(justification_findings),
         }
     return None
 
@@ -348,6 +424,20 @@ def _as_review_status(value: object) -> Literal["approved", "rejected"]:
     raise ValueError("Expected review status")
 
 
+def _as_plan_alignment(
+    value: object,
+) -> Literal["aligned", "justified_deviation", "unjustified_deviation", "non_material_detail"]:
+    if value == "aligned":
+        return "aligned"
+    if value == "justified_deviation":
+        return "justified_deviation"
+    if value == "unjustified_deviation":
+        return "unjustified_deviation"
+    if value == "non_material_detail":
+        return "non_material_detail"
+    raise ValueError("Expected plan alignment")
+
+
 def _build_issue_feedback_comment(
     *,
     intake: IssueIntake,
@@ -356,8 +446,7 @@ def _build_issue_feedback_comment(
     reviewer_result: ReviewAgentResult,
     architect_result: ReviewAgentResult,
 ) -> str:
-    reviewer_feedback = "\n".join(f"- {item}" for item in reviewer_result.feedback) or "- none"
-    architect_feedback = "\n".join(f"- {item}" for item in architect_result.feedback) or "- none"
+    rejection_sections = _build_rejection_sections(reviewer_result, architect_result)
     return (
         "## Precision Squad Review Feedback\n"
         f"- Run ID: `{run_record.run_id}`\n"
@@ -365,10 +454,7 @@ def _build_issue_feedback_comment(
         f"- PR: {pull_request_url}\n"
         f"- Reviewer verdict: `{reviewer_result.status}`\n"
         f"- Architect verdict: `{architect_result.status}`\n\n"
-        "### Reviewer Findings\n"
-        f"{reviewer_feedback}\n\n"
-        "### Architect Findings\n"
-        f"{architect_feedback}\n"
+        f"{rejection_sections}\n"
     )
 
 
@@ -377,3 +463,86 @@ def _extract_pull_number(pull_request_url: str) -> int | None:
     if match is None:
         return None
     return int(match.group("number"))
+
+
+def _result_stub(
+    *,
+    role: Literal["reviewer", "architect"],
+    status: Literal["failed_infra", "not_run"],
+    summary: str,
+) -> ReviewAgentResult:
+    return ReviewAgentResult(role=role, status=status, summary=summary)
+
+
+def _build_per_agent_evidence(
+    reviewer_result: ReviewAgentResult,
+    architect_result: ReviewAgentResult,
+) -> PerAgentEvidence:
+    return PerAgentEvidence(reviewer=reviewer_result, architect=architect_result)
+
+
+def _aggregate_plan_alignment(
+    reviewer_result: ReviewAgentResult,
+    architect_result: ReviewAgentResult,
+) -> AggregatedPlanAlignment:
+    ordered_results = (reviewer_result, architect_result)
+    statuses = {result.status for result in ordered_results}
+    if "failed_infra" in statuses or "not_run" in statuses:
+        classification = None
+    else:
+        classifications = {result.plan_alignment for result in ordered_results}
+        if "unjustified_deviation" in classifications:
+            classification = "unjustified_deviation"
+        elif "justified_deviation" in classifications:
+            classification = "justified_deviation"
+        elif "non_material_detail" in classifications:
+            classification = "non_material_detail"
+        else:
+            classification = "aligned"
+
+    return AggregatedPlanAlignment(
+        classification=classification,
+        plan_alignment_findings=_dedupe_preserving_order(
+            item for result in ordered_results for item in result.plan_alignment_findings
+        ),
+        justification_findings=_dedupe_preserving_order(
+            item for result in ordered_results for item in result.justification_findings
+        ),
+    )
+
+
+def _dedupe_preserving_order(items: Any) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        ordered.append(item)
+    return tuple(ordered)
+
+
+def _build_rejection_sections(
+    reviewer_result: ReviewAgentResult,
+    architect_result: ReviewAgentResult,
+) -> str:
+    sections: list[str] = []
+    for result in (reviewer_result, architect_result):
+        if result.status != "rejected":
+            continue
+        sections.append(f"### {result.role.title()} Rejection")
+        sections.append(f"- Plan alignment: `{result.plan_alignment}`")
+        sections.extend(f"- {bullet}" for bullet in _comment_bullets_for_rejection(result))
+        sections.append("")
+    return "\n".join(sections).strip()
+
+
+def _comment_bullets_for_rejection(result: ReviewAgentResult) -> tuple[str, ...]:
+    concrete: list[str] = []
+    concrete.extend(item for item in result.plan_alignment_findings if item.strip())
+    concrete.extend(item for item in result.justification_findings if item.strip())
+    if not concrete:
+        concrete.extend(item for item in result.feedback if item.strip())
+    if not concrete:
+        concrete.append("Concrete rejection details were not provided by the review agent.")
+    return tuple(dict.fromkeys(concrete[:3]))

--- a/src/precision_squad/stage_contracts.py
+++ b/src/precision_squad/stage_contracts.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from .docs_policy import load_review_checklist_rules
 from .models import ApprovedPlan, IssueIntake, RunRecord
 from .run_store import RunStore
 
 DOCS_CHECKLIST_SOURCE = "src/precision_squad/data/docs_checklist.json"
-_SURFACED_DESIGN_DECISIONS_EMPTY = (
-    "none (reserved for issue #55; intentionally empty for issue #54)"
+_SURFACED_DESIGN_DECISIONS_EMPTY = "No surfaced design decisions were present in the PR body."
+_SURFACED_DESIGN_DECISIONS_UNUSABLE = (
+    "Surfaced design decisions were present in the PR body but unusable; expected the "
+    "existing ```json fenced block emitted by publishing.py."
 )
+_DESIGN_DECISIONS_SECTION_PATTERN = re.compile(
+    r"(?ims)^## Design Decisions\s*\n(?P<body>.*?)(?=^##\s|\Z)"
+)
+_JSON_FENCE_PATTERN = re.compile(r"(?is)^\s*```json\s*\n(?P<payload>.*?)\n```\s*$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +53,7 @@ class ReviewStageContract:
     pull_request_url: str
     pull_number: int | None
     pull_head_sha: str | None
+    surfaced_justification_status: Literal["present", "absent", "unusable"] = "absent"
     surfaced_design_decisions: str = _SURFACED_DESIGN_DECISIONS_EMPTY
 
 
@@ -108,6 +117,7 @@ def load_review_stage_contract(
     pull_number: int | None,
     pull_head_sha: str | None,
     diff_loader: Callable[[str, str, str], str],
+    pr_body_loader: Callable[[str, str, str], str | None] | None = None,
 ) -> ReviewStageContract:
     """Load and validate the explicit review-stage contract inputs."""
     approved_plan_text = RunStore.load_approved_plan_text(
@@ -130,6 +140,18 @@ def load_review_stage_contract(
     if not checklist_rules:
         raise ValueError("Review context pack is missing required checklist material")
 
+    surfaced_justification_status = "absent"
+    surfaced_design_decisions = _SURFACED_DESIGN_DECISIONS_EMPTY
+    if pr_body_loader is not None:
+        pr_body = pr_body_loader(
+            intake.issue.reference.owner,
+            intake.issue.reference.repo,
+            pull_request_url,
+        )
+        surfaced_justification_status, surfaced_design_decisions = _extract_surfaced_design_decisions(
+            pr_body
+        )
+
     return ReviewStageContract(
         approved_plan_text=approved_plan_text,
         pr_diff=pr_diff,
@@ -139,6 +161,10 @@ def load_review_stage_contract(
         pull_request_url=pull_request_url,
         pull_number=pull_number,
         pull_head_sha=pull_head_sha,
+        surfaced_justification_status=cast_review_justification_status(
+            surfaced_justification_status
+        ),
+        surfaced_design_decisions=surfaced_design_decisions,
     )
 
 
@@ -181,6 +207,7 @@ def render_review_prompt(role: str, contract: ReviewStageContract) -> str:
         "PR Number: "
         f"{contract.pull_number if contract.pull_number is not None else '(unavailable)'}",
         f"PR Head SHA: {contract.pull_head_sha or '(unavailable)'}",
+        f"Surfaced Justification Status: {contract.surfaced_justification_status}",
     ]
     return "\n".join(
         [
@@ -193,17 +220,62 @@ def render_review_prompt(role: str, contract: ReviewStageContract) -> str:
             *checklist_lines,
             "",
             "## Surfaced Design Decisions",
-            f"- {contract.surfaced_design_decisions}",
+            contract.surfaced_design_decisions,
             "",
             "## PR Diff",
             contract.pr_diff,
             "",
             "Review the published PR and respond with exactly one JSON object.",
-            'Use the shape: {"status":"approved|rejected","summary":"...","feedback":["..."]}',
+            "Judge implementation alignment against the approved plan.",
+            "Use only the surfaced PR-body ## Design Decisions section as justification evidence.",
+            "If surfaced design decisions are absent or unusable, treat them as no valid justification.",
+            (
+                'Use the shape: {"status":"approved|rejected","summary":"...",'
+                '"feedback":["..."],"plan_alignment":"aligned|justified_deviation|'
+                'unjustified_deviation|non_material_detail",'
+                '"plan_alignment_findings":["..."],"justification_findings":["..."]}'
+            ),
+            "For approved or rejected verdicts, all JSON fields are required.",
             "If you reject, feedback must contain concrete required changes.",
             "Do not include markdown fences.",
         ]
     )
+
+
+def _extract_surfaced_design_decisions(
+    pr_body: str | None,
+) -> tuple[Literal["present", "absent", "unusable"], str]:
+    if not isinstance(pr_body, str) or not pr_body.strip():
+        return "absent", _SURFACED_DESIGN_DECISIONS_EMPTY
+
+    section_match = _DESIGN_DECISIONS_SECTION_PATTERN.search(pr_body)
+    if section_match is None:
+        return "absent", _SURFACED_DESIGN_DECISIONS_EMPTY
+
+    section_body = section_match.group("body").strip()
+    fence_match = _JSON_FENCE_PATTERN.match(section_body)
+    if fence_match is None:
+        return "unusable", _SURFACED_DESIGN_DECISIONS_UNUSABLE
+
+    payload_text = fence_match.group("payload").strip()
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        return "unusable", _SURFACED_DESIGN_DECISIONS_UNUSABLE
+
+    return "present", "```json\n" + json.dumps(payload, indent=2) + "\n```"
+
+
+def cast_review_justification_status(
+    value: str,
+) -> Literal["present", "absent", "unusable"]:
+    if value == "present":
+        return "present"
+    if value == "absent":
+        return "absent"
+    if value == "unusable":
+        return "unusable"
+    raise ValueError("Expected surfaced justification status")
 
 
 def _require_file(path: Path, label: str) -> Path:

--- a/src/precision_squad/stage_contracts.py
+++ b/src/precision_squad/stage_contracts.py
@@ -148,9 +148,10 @@ def load_review_stage_contract(
             intake.issue.reference.repo,
             pull_request_url,
         )
-        surfaced_justification_status, surfaced_design_decisions = _extract_surfaced_design_decisions(
-            pr_body
-        )
+        (
+            surfaced_justification_status,
+            surfaced_design_decisions,
+        ) = _extract_surfaced_design_decisions(pr_body)
 
     return ReviewStageContract(
         approved_plan_text=approved_plan_text,
@@ -228,7 +229,10 @@ def render_review_prompt(role: str, contract: ReviewStageContract) -> str:
             "Review the published PR and respond with exactly one JSON object.",
             "Judge implementation alignment against the approved plan.",
             "Use only the surfaced PR-body ## Design Decisions section as justification evidence.",
-            "If surfaced design decisions are absent or unusable, treat them as no valid justification.",
+            (
+                "If surfaced design decisions are absent or unusable, "
+                "treat them as no valid justification."
+            ),
             (
                 'Use the shape: {"status":"approved|rejected","summary":"...",'
                 '"feedback":["..."],"plan_alignment":"aligned|justified_deviation|'

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 
@@ -13,16 +13,17 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    ReviewAgentResult,
     RunRecord,
 )
 from precision_squad.post_publish_review import (
     OpenCodePrReviewAgent,
-    ReviewAgentResult,
     ReviewRunner,
     _build_review_prompt,
     _parse_review_output,
     run_post_publish_review,
 )
+from precision_squad.run_store import RunStore
 
 
 def _intake() -> IssueIntake:
@@ -67,28 +68,166 @@ def _write_approved_plan(run_dir: Path) -> None:
     )
 
 
-def _write_invalid_approved_plan(run_dir: Path, payload: dict[str, object]) -> None:
-    (run_dir / "approved-plan.json").write_text(json.dumps(payload), encoding="utf-8")
+def _review_result(
+    *,
+    role: Literal["reviewer", "architect"],
+    status: Literal["approved", "rejected", "failed_infra", "not_run"],
+    summary: str,
+    feedback: tuple[str, ...] = (),
+    plan_alignment: Literal[
+        "aligned", "justified_deviation", "unjustified_deviation", "non_material_detail"
+    ] | None = "aligned",
+    plan_alignment_findings: tuple[str, ...] = (),
+    justification_findings: tuple[str, ...] = (),
+) -> ReviewAgentResult:
+    return ReviewAgentResult(
+        role=role,
+        status=status,
+        summary=summary,
+        feedback=feedback,
+        plan_alignment=plan_alignment,
+        plan_alignment_findings=plan_alignment_findings,
+        justification_findings=justification_findings,
+    )
 
 
-def _write_raw_approved_plan(run_dir: Path, raw_payload: str) -> None:
-    (run_dir / "approved-plan.json").write_text(raw_payload, encoding="utf-8")
+def _stub_agent(result: ReviewAgentResult) -> ReviewRunner:
+    class StubAgent:
+        def review(self, **kwargs) -> ReviewAgentResult:
+            del kwargs
+            return result
+
+    return cast(ReviewRunner, StubAgent())
 
 
-def test_run_post_publish_review_reopens_issue_on_rejection(
+def _valid_agent_payload(status: str = "approved") -> str:
+    return json.dumps(
+        {
+            "status": status,
+            "summary": "ok",
+            "feedback": [],
+            "plan_alignment": "aligned",
+            "plan_alignment_findings": [],
+            "justification_findings": [],
+        }
+    )
+
+
+def test_parse_review_output_requires_expanded_plan_alignment_fields() -> None:
+    assert (
+        _parse_review_output(
+            [
+                {
+                    "type": "text",
+                    "part": {
+                        "text": json.dumps(
+                            {
+                                "status": "approved",
+                                "summary": "ok",
+                                "feedback": [],
+                            }
+                        )
+                    },
+                }
+            ]
+        )
+        is None
+    )
+
+
+def test_parse_review_output_accepts_expanded_payload_with_prose_prefix() -> None:
+    payload = _parse_review_output(
+        [
+            {
+                "type": "text",
+                "part": {
+                    "text": (
+                        "The implementation is solid.\n\n"
+                        '{"status":"rejected","summary":"needs fixes",'
+                        '"feedback":["adjust review contract"],'
+                        '"plan_alignment":"unjustified_deviation",'
+                        '"plan_alignment_findings":["Changed behavior outside approved plan"],'
+                        '"justification_findings":["No surfaced justification for the change"]}'
+                    )
+                },
+            }
+        ]
+    )
+
+    assert payload is not None
+    assert payload["status"] == "rejected"
+    assert payload["plan_alignment"] == "unjustified_deviation"
+    assert payload["plan_alignment_findings"] == ("Changed behavior outside approved plan",)
+    assert payload["justification_findings"] == ("No surfaced justification for the change",)
+
+
+def test_opencode_pr_review_agent_reads_expanded_json_payload(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _write_approved_plan(tmp_path)
 
-    class StubAgent:
-        def __init__(self, result: ReviewAgentResult) -> None:
-            self._result = result
+    def fake_run(command, cwd, capture_output, text):
+        del command, cwd, capture_output, text
 
-        def review(self, **kwargs) -> ReviewAgentResult:
-            del kwargs
-            return self._result
+        class _Completed:
+            returncode = 0
+            stdout = '{"type":"text","part":{"text":' + json.dumps(_valid_agent_payload()) + "}}\n"
+            stderr = ""
 
-    actions: list[str] = []
+        return _Completed()
+
+    monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
+
+    result = OpenCodePrReviewAgent(role="reviewer").review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+    )
+
+    assert result.status == "approved"
+    assert result.plan_alignment == "aligned"
+    assert result.plan_alignment_findings == ()
+    assert result.justification_findings == ()
+
+
+def test_build_review_prompt_describes_expanded_review_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
+
+    prompt = _build_review_prompt(
+        role="reviewer",
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+    )
+
+    assert '"plan_alignment"' in prompt
+    assert '"plan_alignment_findings"' in prompt
+    assert '"justification_findings"' in prompt
+    assert "Use only the surfaced PR-body ## Design Decisions section as justification evidence." in prompt
+
+
+def test_run_post_publish_review_preserves_two_agent_approval_rule(tmp_path: Path) -> None:
+    _write_approved_plan(tmp_path)
 
     class StubWriter:
         def get_pull_request_head_sha(self, owner: str, repo: str, pull_number: int):
@@ -96,14 +235,13 @@ def test_run_post_publish_review_reopens_issue_on_rejection(
             return "head-sha"
 
         def create_issue_comment(self, reference, body):
-            del reference
-            actions.append(body)
-            return "https://github.com/cracklings3d/markdown-pdf-renderer/issues/9#issuecomment-2"
+            del reference, body
+            return "comment-url"
 
         def reopen_issue(self, reference):
             del reference
-            actions.append("reopened")
 
+    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
         "precision_squad.post_publish_review.GitHubWriteClient.from_env",
         lambda token_env="GITHUB_TOKEN": StubWriter(),
@@ -112,53 +250,167 @@ def test_run_post_publish_review_reopens_issue_on_rejection(
         "precision_squad.post_publish_review._fetch_pr_diff",
         lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
     )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
+    try:
+        approved = run_post_publish_review(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            reviewer=_stub_agent(
+                _review_result(role="reviewer", status="approved", summary="Reviewer approves.")
+            ),
+            architect=_stub_agent(
+                _review_result(role="architect", status="approved", summary="Architect approves.")
+            ),
+        )
+        rejected = run_post_publish_review(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            reviewer=_stub_agent(
+                _review_result(role="reviewer", status="approved", summary="Reviewer approves.")
+            ),
+            architect=_stub_agent(
+                _review_result(
+                    role="architect",
+                    status="rejected",
+                    summary="Architect rejects.",
+                    plan_alignment="unjustified_deviation",
+                    plan_alignment_findings=("Architect found scope drift.",),
+                )
+            ),
+        )
+        failed_infra = run_post_publish_review(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            reviewer=_stub_agent(
+                _review_result(role="reviewer", status="approved", summary="Reviewer approves.")
+            ),
+            architect=_stub_agent(
+                _review_result(
+                    role="architect",
+                    status="failed_infra",
+                    summary="Architect crashed.",
+                    plan_alignment=None,
+                )
+            ),
+        )
+    finally:
+        monkeypatch.undo()
 
-    result = run_post_publish_review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        reviewer=cast(
-            ReviewRunner,
-            StubAgent(
-            ReviewAgentResult(
-                role="reviewer",
-                status="rejected",
-                summary="Reviewer found an issue.",
-                feedback=("Fix the CLI import behavior.",),
-            )
+    assert approved.status == "approved"
+    assert rejected.status == "rejected"
+    assert failed_infra.status == "failed_infra"
+
+
+def test_run_post_publish_review_persists_per_agent_and_aggregated_evidence(tmp_path: Path) -> None:
+    _write_approved_plan(tmp_path)
+    comments: list[str] = []
+
+    class StubWriter:
+        def get_pull_request_head_sha(self, owner: str, repo: str, pull_number: int):
+            del owner, repo, pull_number
+            return "head-sha"
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return "comment-url"
+
+        def reopen_issue(self, reference):
+            del reference
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
+    try:
+        result = run_post_publish_review(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            reviewer=_stub_agent(
+                _review_result(
+                    role="reviewer",
+                    status="rejected",
+                    summary="Reviewer found an issue.",
+                    feedback=("Fix review handling.",),
+                    plan_alignment="unjustified_deviation",
+                    plan_alignment_findings=("Changed review output contract.",),
+                    justification_findings=("No surfaced justification for contract change.",),
+                )
             ),
-        ),
-        architect=cast(
-            ReviewRunner,
-            StubAgent(
-            ReviewAgentResult(
-                role="architect",
-                status="approved",
-                summary="Structure looks fine.",
-            )
+            architect=_stub_agent(
+                _review_result(
+                    role="architect",
+                    status="approved",
+                    summary="Structure looks fine.",
+                    plan_alignment="aligned",
+                    plan_alignment_findings=("Matches approved structure.",),
+                    justification_findings=("Surfaced design decisions are consistent.",),
+                )
             ),
-        ),
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert result.per_agent_evidence is not None
+    assert result.per_agent_evidence.reviewer.role == "reviewer"
+    assert result.per_agent_evidence.reviewer.plan_alignment == "unjustified_deviation"
+    assert result.per_agent_evidence.architect.role == "architect"
+    assert result.aggregated_plan_alignment.classification == "unjustified_deviation"
+    assert result.aggregated_plan_alignment.plan_alignment_findings == (
+        "Changed review output contract.",
+        "Matches approved structure.",
+    )
+    assert result.aggregated_plan_alignment.justification_findings == (
+        "No surfaced justification for contract change.",
+        "Surfaced design decisions are consistent.",
     )
 
-    assert result.status == "rejected"
-    assert result.issue_reopened is True
-    assert result.issue_comment_url is not None
-    assert result.pull_head_sha == "head-sha"
-    assert any("Precision Squad Review Feedback" in action for action in actions)
-    assert "reopened" in actions
+    store = RunStore(tmp_path)
+    store.write_post_publish_review_result(tmp_path, result)
+    payload = json.loads((tmp_path / "post-publish-review-result.json").read_text(encoding="utf-8"))
+    assert payload["reviewer_status"] == "rejected"
+    assert payload["architect_status"] == "approved"
+    assert payload["per_agent_evidence"]["reviewer"]["plan_alignment"] == "unjustified_deviation"
+    assert payload["per_agent_evidence"]["architect"]["plan_alignment"] == "aligned"
+    assert payload["aggregated_plan_alignment"]["classification"] == "unjustified_deviation"
 
 
-def test_run_post_publish_review_approves_when_both_agents_pass(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("reviewer_alignment", "architect_alignment", "expected"),
+    [
+        ("aligned", "aligned", "aligned"),
+        ("non_material_detail", "aligned", "non_material_detail"),
+        ("aligned", "justified_deviation", "justified_deviation"),
+        ("justified_deviation", "unjustified_deviation", "unjustified_deviation"),
+    ],
+)
+def test_run_post_publish_review_aggregates_plan_alignment_by_precedence(
+    tmp_path: Path,
+    reviewer_alignment: str,
+    architect_alignment: str,
+    expected: str,
+) -> None:
     _write_approved_plan(tmp_path)
-
-    class StubAgent:
-        def __init__(self, result: ReviewAgentResult) -> None:
-            self._result = result
-
-        def review(self, **kwargs) -> ReviewAgentResult:
-            del kwargs
-            return self._result
 
     class StubWriter:
         def get_pull_request_head_sha(self, owner: str, repo: str, pull_number: int):
@@ -174,425 +426,73 @@ def test_run_post_publish_review_approves_when_both_agents_pass(tmp_path: Path) 
         "precision_squad.post_publish_review._fetch_pr_diff",
         lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
     )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
     try:
         result = run_post_publish_review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        reviewer=cast(
-            ReviewRunner,
-            StubAgent(
-            ReviewAgentResult(
-                role="reviewer",
-                status="approved",
-                summary="Reviewer approves.",
-            )
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            reviewer=_stub_agent(
+                _review_result(
+                    role="reviewer",
+                    status="approved",
+                    summary="Reviewer approves.",
+                    plan_alignment=cast(
+                        Literal[
+                            "aligned",
+                            "justified_deviation",
+                            "unjustified_deviation",
+                            "non_material_detail",
+                        ],
+                        reviewer_alignment,
+                    ),
+                )
             ),
-        ),
-        architect=cast(
-            ReviewRunner,
-            StubAgent(
-            ReviewAgentResult(
-                role="architect",
-                status="approved",
-                summary="Architect approves.",
-            )
+            architect=_stub_agent(
+                _review_result(
+                    role="architect",
+                    status="approved",
+                    summary="Architect approves.",
+                    plan_alignment=cast(
+                        Literal[
+                            "aligned",
+                            "justified_deviation",
+                            "unjustified_deviation",
+                            "non_material_detail",
+                        ],
+                        architect_alignment,
+                    ),
+                )
             ),
-        ),
         )
     finally:
         monkeypatch.undo()
 
-    assert result.status == "approved"
-    assert result.pull_number == 13
-    assert result.pull_head_sha == "head-sha"
+    assert result.aggregated_plan_alignment.classification == expected
 
 
-def test_opencode_pr_review_agent_resolves_custom_provider_model(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "MiniMax-M2.7-highspeed")
-    commands: list[list[str]] = []
-    _write_approved_plan(tmp_path)
-
-    def fake_run(command, cwd, capture_output, text):
-        del cwd, capture_output, text
-        commands.append(command)
-
-        class _Completed:
-            returncode = 0
-            stdout = (
-                '{"type":"text","part":{"text":"{\\"status\\":\\"approved\\",'
-                '\\"summary\\":\\"ok\\",\\"feedback\\":[]}"}}\n'
-            )
-            stderr = ""
-
-        return _Completed()
-
-    monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-
-    result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-    )
-
-    assert result.status == "approved"
-    assert commands[0][8:10] == ["--model", "custom-openai-model/MiniMax-M2.7-highspeed"]
-
-
-def test_opencode_pr_review_agent_uses_full_configured_model_id(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("CUSTOM_OPENAI_MODEL_NAME", "minimax-cn-coding-plan/MiniMax-M2.7-highspeed")
-    commands: list[list[str]] = []
-    _write_approved_plan(tmp_path)
-
-    def fake_run(command, cwd, capture_output, text):
-        del cwd, capture_output, text
-        commands.append(command)
-
-        class _Completed:
-            returncode = 0
-            stdout = (
-                '{"type":"text","part":{"text":"{\\"status\\":\\"approved\\",'
-                '\\"summary\\":\\"ok\\",\\"feedback\\":[]}"}}\n'
-            )
-            stderr = ""
-
-        return _Completed()
-
-    monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-
-    result = OpenCodePrReviewAgent(role="reviewer", model="custom-openai-model").review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-    )
-
-    assert result.status == "approved"
-    assert commands[0][8:10] == ["--model", "minimax-cn-coding-plan/MiniMax-M2.7-highspeed"]
-
-
-def test_opencode_pr_review_agent_accepts_structured_verdict_on_nonzero_exit(
+def test_run_post_publish_review_rejection_comment_stays_bounded_but_concrete(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _write_approved_plan(tmp_path)
-
-    def fake_run(command, cwd, capture_output, text):
-        del command, cwd, capture_output, text
-
-        class _Completed:
-            returncode = 1
-            stdout = (
-                '{"type":"text","part":{"text":"{\\"status\\":\\"rejected\\",'
-                '\\"summary\\":\\"needs follow-up\\",\\"feedback\\":[\\"fix review handling\\"]}"}}\n'
-            )
-            stderr = "tool exited non-zero"
-
-        return _Completed()
-
-    monkeypatch.setattr("precision_squad.post_publish_review.subprocess.run", fake_run)
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-
-    result = OpenCodePrReviewAgent(role="architect").review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-    )
-
-    assert result.status == "rejected"
-    assert result.summary == "needs follow-up"
-    assert result.feedback == ("fix review handling",)
-
-
-def test_opencode_pr_review_agent_fails_when_persisted_plan_is_unapproved(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    (tmp_path / "approved-plan.json").write_text(
-        json.dumps(
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Invalid plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": False,
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-
-    result = OpenCodePrReviewAgent(role="reviewer").review(
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-    )
-
-    assert result.status == "failed_infra"
-    assert "approved" in result.summary.lower()
-
-
-def test_build_review_prompt_fails_when_persisted_plan_is_missing(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="Approved plan artifact not found"):
-        _build_review_prompt(
-            role="reviewer",
-            intake=_intake(),
-            run_record=_record(tmp_path),
-            run_dir=tmp_path,
-            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        )
-
-
-def test_build_review_prompt_fails_when_persisted_plan_has_invalid_structure(tmp_path: Path) -> None:
-    _write_invalid_approved_plan(
-        tmp_path,
-        {
-            "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-            "plan_summary": "Valid summary",
-            "implementation_steps": ["Inspect the diff"],
-            "named_references": [],
-            "approved": True,
-        },
-    )
-
-    with pytest.raises(ValueError, match="retrieval_surface_summary"):
-        _build_review_prompt(
-            role="reviewer",
-            intake=_intake(),
-            run_record=_record(tmp_path),
-            run_dir=tmp_path,
-            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        )
-
-
-@pytest.mark.parametrize(
-    ("writer", "payload", "match"),
-    [
-        (_write_raw_approved_plan, "[]\n", "Expected JSON object"),
-        (_write_raw_approved_plan, "{", "not valid JSON"),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#999",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "does not match",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "   ",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "plan_summary",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "implementation_steps",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": [],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "implementation steps",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["   "],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "implementation_steps\\[1\\]",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": [1],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "implementation_steps\\[1\\]",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "named_references",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [42],
-                "retrieval_surface_summary": "src/",
-                "approved": True,
-            },
-            "named_references\\[1\\]",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "approved": True,
-            },
-            "retrieval_surface_summary",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "retrieval_surface_summary": None,
-                "approved": True,
-            },
-            "retrieval_surface_summary",
-        ),
-        (
-            _write_invalid_approved_plan,
-            {
-                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
-                "plan_summary": "Plan",
-                "implementation_steps": ["Inspect the diff"],
-                "named_references": [],
-                "retrieval_surface_summary": "src/",
-                "approved": False,
-            },
-            "approved.*true",
-        ),
-    ],
-)
-def test_build_review_prompt_rejects_canonical_invalid_approved_plan_cases(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    writer,
-    payload,
-    match: str,
-) -> None:
-    def fail_if_diff_is_fetched(*args, **kwargs):
-        raise AssertionError("PR diff should not be fetched before approved-plan validation")
-
-    monkeypatch.setattr("precision_squad.post_publish_review._fetch_pr_diff", fail_if_diff_is_fetched)
-    writer(tmp_path, payload)
-
-    with pytest.raises(ValueError, match=match):
-        _build_review_prompt(
-            role="reviewer",
-            intake=_intake(),
-            run_record=_record(tmp_path),
-            run_dir=tmp_path,
-            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        )
-
-
-def test_build_review_prompt_includes_checklist_source_and_empty_design_decisions(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_approved_plan(tmp_path)
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-
-    prompt = _build_review_prompt(
-        role="reviewer",
-        intake=_intake(),
-        run_record=_record(tmp_path),
-        run_dir=tmp_path,
-        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-    )
-
-    assert "## Deterministic Review Checklist (src/precision_squad/data/docs_checklist.json)" in prompt
-    assert "docs_entrypoint_present" in prompt
-    assert "## Surfaced Design Decisions" in prompt
-    assert "reserved for issue #55" in prompt
-    assert "PR Number: 13" in prompt
-    assert "PR Head SHA: (unavailable)" in prompt
-
-
-def test_run_post_publish_review_fails_fast_when_checklist_loading_fails(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_approved_plan(tmp_path)
-
-    def fail_if_agent_runs(**kwargs):
-        raise AssertionError("review agents should not run before checklist validation")
-
-    monkeypatch.setattr(
-        "precision_squad.post_publish_review._fetch_pr_diff",
-        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
-    )
-    monkeypatch.setattr(
-        "precision_squad.stage_contracts.load_review_checklist_rules",
-        lambda: (_ for _ in ()).throw(ValueError("docs checklist field 'rules' must be a list")),
-    )
+    comments: list[str] = []
 
     class StubWriter:
         def get_pull_request_head_sha(self, owner: str, repo: str, pull_number: int):
             del owner, repo, pull_number
             return "head-sha"
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return "https://github.com/cracklings3d/markdown-pdf-renderer/issues/9#issuecomment-2"
+
+        def reopen_issue(self, reference):
+            del reference
 
     monkeypatch.setattr(
         "precision_squad.post_publish_review.GitHubWriteClient.from_env",
@@ -602,38 +502,48 @@ def test_run_post_publish_review_fails_fast_when_checklist_loading_fails(
         "precision_squad.post_publish_review._fetch_pr_diff",
         lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
     )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "## Design Decisions\n```json\n[]\n```\n",
+    )
 
     result = run_post_publish_review(
         intake=_intake(),
         run_record=_record(tmp_path),
         run_dir=tmp_path,
         pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
-        reviewer=cast(ReviewRunner, type("StubReviewer", (), {"review": staticmethod(fail_if_agent_runs)})()),
-        architect=cast(ReviewRunner, type("StubArchitect", (), {"review": staticmethod(fail_if_agent_runs)})()),
+        reviewer=_stub_agent(
+            _review_result(
+                role="reviewer",
+                status="rejected",
+                summary="Reviewer found an issue.",
+                feedback=("Fix review handling.",),
+                plan_alignment="unjustified_deviation",
+                plan_alignment_findings=("Changed review output contract.",),
+                justification_findings=("No surfaced justification for contract change.",),
+            )
+        ),
+        architect=_stub_agent(
+            _review_result(
+                role="architect",
+                status="rejected",
+                summary="Architect found an issue.",
+                feedback=("Restore approved boundary.",),
+                plan_alignment="justified_deviation",
+                plan_alignment_findings=("Minor structural change observed.",),
+                justification_findings=("Surfaced justification conflicts with implementation.",),
+            )
+        ),
     )
 
-    assert result.status == "failed_infra"
-    assert "docs checklist field 'rules' must be a list" in result.summary
-    assert result.reviewer_status == "failed_infra"
-    assert result.architect_status == "failed_infra"
-
-
-def test_parse_review_output_accepts_prose_before_json() -> None:
-    payload = _parse_review_output(
-        [
-            {
-                "type": "text",
-                "part": {
-                    "text": (
-                        "The implementation is solid. One issue remains.\n\n"
-                        '{"status":"rejected","summary":"test is brittle",'
-                        '"feedback":["use __version__ in the assertion"]}'
-                    )
-                },
-            }
-        ]
-    )
-
-    assert payload is not None
-    assert payload["status"] == "rejected"
-    assert payload["summary"] == "test is brittle"
+    assert result.status == "rejected"
+    assert comments
+    comment = comments[0]
+    assert "Reviewer verdict: `rejected`" in comment
+    assert "Architect verdict: `rejected`" in comment
+    assert "Plan alignment: `unjustified_deviation`" in comment
+    assert "Plan alignment: `justified_deviation`" in comment
+    assert "Changed review output contract." in comment
+    assert "Surfaced justification conflicts with implementation." in comment
+    assert "aggregated_plan_alignment" not in comment
+    assert "stdout_path" not in comment

--- a/tests/test_stage_contracts.py
+++ b/tests/test_stage_contracts.py
@@ -100,6 +100,24 @@ def _write_developer_artifacts(run_dir: Path, contract_dir: Path) -> None:
     (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
 
 
+def _valid_pr_body() -> str:
+    return (
+        "## Summary\nBody\n\n"
+        "## Design Decisions\n"
+        "```json\n"
+        "[{\n"
+        '  "sequence": 1,\n'
+        '  "summary": "Keep existing path",\n'
+        '  "rationale": "Avoid new review stage",\n'
+        '  "plan_steps": ["Inspect the diff"],\n'
+        '  "named_references": ["src/precision_squad/post_publish_review.py"],\n'
+        '  "affected_targets": ["src/precision_squad/post_publish_review.py"]\n'
+        "}]\n"
+        "```\n\n"
+        "## Notes\nDone\n"
+    )
+
+
 def test_load_developer_stage_contract_requires_allowlisted_artifacts(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     contract_dir = run_dir / "execution-contract"
@@ -153,9 +171,7 @@ def test_render_developer_approved_plan_context_uses_canonical_fields_only() -> 
     ]
 
 
-def test_load_review_stage_contract_uses_deterministic_checklist_and_empty_decision_slot(
-    tmp_path: Path,
-) -> None:
+def test_load_review_stage_contract_loads_all_existing_review_inputs(tmp_path: Path) -> None:
     _write_approved_plan(tmp_path)
 
     contract = load_review_stage_contract(
@@ -166,15 +182,17 @@ def test_load_review_stage_contract_uses_deterministic_checklist_and_empty_decis
         pull_number=13,
         pull_head_sha="head-sha",
         diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+        pr_body_loader=lambda *args: _valid_pr_body(),
     )
 
-    assert contract.pull_number == 13
-    assert contract.pull_head_sha == "head-sha"
+    assert "Approved Plan" in contract.approved_plan_text
+    assert contract.pr_diff.startswith("--- a/file.py")
     assert contract.checklist_rules[0]["code"] == "docs_entrypoint_present"
-    assert contract.surfaced_design_decisions.startswith("none")
+    assert contract.surfaced_justification_status == "present"
+    assert '"summary": "Keep existing path"' in contract.surfaced_design_decisions
 
 
-def test_render_review_prompt_includes_only_required_review_inputs(tmp_path: Path) -> None:
+def test_render_review_prompt_uses_pr_body_design_decisions_not_placeholder(tmp_path: Path) -> None:
     _write_approved_plan(tmp_path)
     contract = load_review_stage_contract(
         intake=_intake(),
@@ -184,6 +202,7 @@ def test_render_review_prompt_includes_only_required_review_inputs(tmp_path: Pat
         pull_number=13,
         pull_head_sha="head-sha",
         diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+        pr_body_loader=lambda *args: _valid_pr_body(),
     )
 
     prompt = render_review_prompt("reviewer", contract)
@@ -191,9 +210,44 @@ def test_render_review_prompt_includes_only_required_review_inputs(tmp_path: Pat
     assert f"## Deterministic Review Checklist ({DOCS_CHECKLIST_SOURCE})" in prompt
     assert "docs_entrypoint_present" in prompt
     assert "## Surfaced Design Decisions" in prompt
-    assert "reserved for issue #55" in prompt
+    assert '"summary": "Keep existing path"' in prompt
+    assert "reserved for issue #55" not in prompt
     assert "PR Head SHA: head-sha" in prompt
+    assert "Surfaced Justification Status: present" in prompt
     assert "## PR Diff" in prompt
+
+
+def test_load_review_stage_contract_fails_before_diff_when_approved_plan_missing(tmp_path: Path) -> None:
+    def fail_if_diff_is_loaded(*args):
+        raise AssertionError("PR diff should not be fetched before approved-plan validation")
+
+    with pytest.raises(ValueError, match="Approved plan artifact not found"):
+        load_review_stage_contract(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            pull_number=13,
+            pull_head_sha="head-sha",
+            diff_loader=fail_if_diff_is_loaded,
+            pr_body_loader=lambda *args: _valid_pr_body(),
+        )
+
+
+def test_load_review_stage_contract_fails_when_pr_diff_missing(tmp_path: Path) -> None:
+    _write_approved_plan(tmp_path)
+
+    with pytest.raises(ValueError, match="missing required PR diff"):
+        load_review_stage_contract(
+            intake=_intake(),
+            run_record=_record(tmp_path),
+            run_dir=tmp_path,
+            pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+            pull_number=13,
+            pull_head_sha="head-sha",
+            diff_loader=lambda *args: "",
+            pr_body_loader=lambda *args: _valid_pr_body(),
+        )
 
 
 def test_load_review_stage_contract_fails_when_checklist_loader_fails(
@@ -215,4 +269,44 @@ def test_load_review_stage_contract_fails_when_checklist_loader_fails(
             pull_number=13,
             pull_head_sha="head-sha",
             diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+            pr_body_loader=lambda *args: _valid_pr_body(),
         )
+
+
+@pytest.mark.parametrize(
+    ("pr_body", "expected_status", "expected_text"),
+    [
+        ("## Summary\nNo decisions section\n", "absent", "No surfaced design decisions were present"),
+        (
+            "## Design Decisions\nNot fenced JSON\n",
+            "unusable",
+            "unusable; expected the existing ```json fenced block",
+        ),
+        (
+            "## Design Decisions\n```json\n{\n```\n",
+            "unusable",
+            "unusable; expected the existing ```json fenced block",
+        ),
+    ],
+)
+def test_load_review_stage_contract_treats_absent_or_malformed_design_decisions_as_not_valid_justification(
+    tmp_path: Path,
+    pr_body: str,
+    expected_status: str,
+    expected_text: str,
+) -> None:
+    _write_approved_plan(tmp_path)
+
+    contract = load_review_stage_contract(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        pull_number=13,
+        pull_head_sha="head-sha",
+        diff_loader=lambda *args: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n",
+        pr_body_loader=lambda *args: pr_body,
+    )
+
+    assert contract.surfaced_justification_status == expected_status
+    assert expected_text in contract.surfaced_design_decisions


### PR DESCRIPTION
## Linked Issue

Closes #53

## Summary

- persist explicit per-agent and aggregated plan-alignment evidence in the existing post-publish review result
- load surfaced `## Design Decisions` content from the published PR body on the current baseline review path
- preserve the current two-agent approval rule and keep rejection comments concrete without widening into ADR-008 review-impl work

## Approved Plan

- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-53.md`
- Reviewed commit: `07614c9`

## Design Decisions

- stayed on the existing post-publish review path only
- kept scope limited to `src/precision_squad/models.py`, `src/precision_squad/post_publish_review.py`, `src/precision_squad/stage_contracts.py`, `tests/test_post_publish_review.py`, and `tests/test_stage_contracts.py`
- did not add a new review stage, command, artifact, or CLI surface

## Validation

- `PYTHONPATH set to issue-53 src; python -m pytest tests/test_stage_contracts.py tests/test_post_publish_review.py` -> passed (22 passed)
- ambient run note: `python -m pytest tests/test_stage_contracts.py tests/test_post_publish_review.py` previously failed due to an import leak from another worktree, but the reviewed validation evidence for this issue passed in the issue workspace

## Scope Check

- This PR stays within issue #53 scope and the approved plan.
- Follow-up work remains separate from ADR-008 / issue #66 / issue #72.

## Risks / Follow-Ups

- ambient worktree import leakage remains outside this issue's scoped change

## Structural Continuity Notes

- Canonical path after change: existing post-publish review flow through `post_publish_review.py` and `stage_contracts.py`
- Does an old path remain alive? If yes, why? Yes; the legacy top-level status/summary fields remain for current-baseline compatibility while adding unambiguous evidence mirrors.
- Removal owner: future baseline cleanup outside issue #53 scope
- Removal trigger: explicit follow-on issue or ADR-backed contract change