### PR TITLE
fix: enforce honest completed repair results

### DIFF
--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -102,9 +102,17 @@ class VercelAIRepairAdapter:
             )
 
         return RepairResult(
-            status="completed",
-            summary=repair_json.get("summary", "Repair agent completed."),
-            detail_codes=("repair_stage_completed",),
+            status="blocked",
+            summary=(
+                f"{repair_json.get('summary', 'Repair agent returned structured output.')} "
+                "Direct LLM output was not applied to the workspace and did not persist "
+                "a patch artifact for this run."
+            ),
+            detail_codes=(
+                "repair_workspace_path_missing",
+                "repair_patch_path_missing",
+                "repair_output_not_applied",
+            ),
             stdout_path=str(stdout_path),
             side_issues=side_issues,
             design_decisions=design_decisions,

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import shutil
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 from ..docs_remediation import (
@@ -174,7 +175,143 @@ class RepairStage:
         parameters = inspect.signature(self.adapter.repair).parameters
         if "approved_plan" not in parameters:
             repair_kwargs.pop("approved_plan")
-        return self.adapter.repair(**repair_kwargs)
+        repair_result = self.adapter.repair(**repair_kwargs)
+        return _validate_completed_repair_result(repair_result, run_dir=run_dir)
+
+
+def _validate_completed_repair_result(
+    repair_result: RepairResult,
+    *,
+    run_dir: Path,
+) -> RepairResult:
+    """Validate the shared completed-result artifact invariant."""
+    if repair_result.status != "completed":
+        return repair_result
+
+    expected_workspace_path = (run_dir / "repair-workspace").resolve()
+    expected_repo_workspace = (expected_workspace_path / "repo").resolve()
+    expected_patch_path = (run_dir / "repair.patch").resolve()
+
+    if not repair_result.workspace_path:
+        return _reclassify_completed_result(
+            repair_result,
+            status="blocked",
+            summary=(
+                "Repair stage reported completed, but no applied workspace artifact "
+                "was recorded for this run."
+            ),
+            detail_codes=("repair_workspace_path_missing",),
+        )
+
+    resolved_workspace_path = _resolve_run_artifact_path(repair_result.workspace_path, run_dir=run_dir)
+    if resolved_workspace_path != expected_workspace_path:
+        return _reclassify_completed_result(
+            repair_result,
+            status="blocked",
+            summary=(
+                "Repair stage reported completed, but the workspace artifact does "
+                "not resolve to this run's repair workspace."
+            ),
+            detail_codes=("repair_workspace_path_invalid",),
+        )
+
+    if not repair_result.patch_path:
+        return _reclassify_completed_result(
+            repair_result,
+            status="blocked",
+            summary=(
+                "Repair stage reported completed, but no persisted patch artifact "
+                "was recorded for this run."
+            ),
+            detail_codes=("repair_patch_path_missing",),
+        )
+
+    resolved_patch_path = _resolve_run_artifact_path(repair_result.patch_path, run_dir=run_dir)
+    if resolved_patch_path != expected_patch_path:
+        return _reclassify_completed_result(
+            repair_result,
+            status="blocked",
+            summary=(
+                "Repair stage reported completed, but the patch artifact does not "
+                "resolve to this run's persisted patch path."
+            ),
+            detail_codes=("repair_patch_path_invalid",),
+        )
+
+    if not expected_workspace_path.is_dir():
+        return _reclassify_completed_result(
+            repair_result,
+            status="failed_infra",
+            summary=(
+                "Repair stage reported completed, but the recorded repair workspace "
+                "directory is missing."
+            ),
+            detail_codes=("repair_workspace_missing",),
+        )
+
+    if not expected_repo_workspace.is_dir():
+        return _reclassify_completed_result(
+            repair_result,
+            status="failed_infra",
+            summary=(
+                "Repair stage reported completed, but the recorded repo checkout is "
+                "missing from the repair workspace."
+            ),
+            detail_codes=("repair_workspace_repo_missing",),
+        )
+
+    if not expected_patch_path.is_file():
+        return _reclassify_completed_result(
+            repair_result,
+            status="failed_infra",
+            summary=(
+                "Repair stage reported completed, but the recorded patch artifact is "
+                "missing."
+            ),
+            detail_codes=("repair_patch_missing",),
+        )
+
+    if expected_patch_path.stat().st_size <= 0:
+        return _reclassify_completed_result(
+            repair_result,
+            status="failed_infra",
+            summary=(
+                "Repair stage reported completed, but the recorded patch artifact is "
+                "empty."
+            ),
+            detail_codes=("repair_patch_empty",),
+        )
+
+    return repair_result
+
+
+def _resolve_run_artifact_path(path_str: str, *, run_dir: Path) -> Path:
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = run_dir / path
+    return path.resolve()
+
+
+def _reclassify_completed_result(
+    repair_result: RepairResult,
+    *,
+    status: str,
+    summary: str,
+    detail_codes: tuple[str, ...],
+) -> RepairResult:
+    merged_detail_codes = tuple(
+        dict.fromkeys(
+            code
+            for code in (*repair_result.detail_codes, *detail_codes)
+            if code != "repair_stage_completed"
+        )
+    )
+    return replace(
+        repair_result,
+        status=status,
+        summary=summary,
+        detail_codes=merged_detail_codes,
+    )
 
 
 def run_repair_qa_loop(

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -203,7 +203,10 @@ def _validate_completed_repair_result(
             detail_codes=("repair_workspace_path_missing",),
         )
 
-    resolved_workspace_path = _resolve_run_artifact_path(repair_result.workspace_path, run_dir=run_dir)
+    resolved_workspace_path = _resolve_run_artifact_path(
+        repair_result.workspace_path,
+        run_dir=run_dir,
+    )
     if resolved_workspace_path != expected_workspace_path:
         return _reclassify_completed_result(
             repair_result,

--- a/src/precision_squad/repair/orchestration.py
+++ b/src/precision_squad/repair/orchestration.py
@@ -282,7 +282,11 @@ def _validate_completed_repair_result(
             detail_codes=("repair_patch_empty",),
         )
 
-    return repair_result
+    return replace(
+        repair_result,
+        workspace_path=str(expected_workspace_path),
+        patch_path=str(expected_patch_path),
+    )
 
 
 def _resolve_run_artifact_path(path_str: str, *, run_dir: Path) -> Path:

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -404,13 +404,14 @@ class _QaFailedTestDependencies:
     ):
         from precision_squad.models import QaResult
 
-        del adapter, contract_artifact_dir, intake, run_dir, run_record
+        del adapter, contract_artifact_dir, intake, run_record
 
         repair_result = RepairResult(
             status="completed",
             summary="Stub repair completed.",
             detail_codes=("repair_stage_completed",),
             workspace_path=str(repo_path.parent),
+            patch_path=str(run_dir / "repair.patch"),
         )
         baseline_result = QaResult(
             status="passed",
@@ -485,13 +486,14 @@ class _StubRepairAdapter:
         repo_workspace: Path,
         developer_contract: object | None = None,
     ) -> RepairResult:
-        del approved_plan, contract_artifact_dir, developer_contract, intake, run_dir, run_record
+        del approved_plan, contract_artifact_dir, developer_contract, intake, run_record
 
         return RepairResult(
             status="completed",
             summary="Stub repair completed.",
             detail_codes=("repair_stage_completed",),
             workspace_path=str(repo_workspace.parent),
+            patch_path=str(run_dir / "repair.patch"),
         )
 
     def with_qa_feedback(self, feedback: str) -> _StubRepairAdapter:

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -404,13 +404,17 @@ class _QaFailedTestDependencies:
     ):
         from precision_squad.models import QaResult
 
-        del adapter, contract_artifact_dir, intake, run_record
+        del adapter, contract_artifact_dir, intake, repo_path, run_record
+
+        repair_workspace = run_dir / "repair-workspace"
+        (repair_workspace / "repo").mkdir(parents=True, exist_ok=True)
+        (run_dir / "repair.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
 
         repair_result = RepairResult(
             status="completed",
             summary="Stub repair completed.",
             detail_codes=("repair_stage_completed",),
-            workspace_path=str(repo_path.parent),
+            workspace_path=str(repair_workspace),
             patch_path=str(run_dir / "repair.patch"),
         )
         baseline_result = QaResult(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -74,6 +74,8 @@ def test_repair_issue_persists_empty_decision_log_before_publish(tmp_path: Path,
         status="completed",
         summary="Repair completed.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(tmp_path / "repair-workspace"),
+        patch_path=str(tmp_path / "repair.patch"),
         design_decisions=(),
     )
     baseline = QaResult(status="passed", summary="Baseline passed.", detail_codes=(), phase="baseline")
@@ -133,6 +135,8 @@ def test_repair_issue_marks_missing_decision_log_artifact_as_failed_infra(
         status="completed",
         summary="Repair completed.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(tmp_path / "repair-workspace"),
+        patch_path=str(tmp_path / "repair.patch"),
     )
     baseline = QaResult(status="passed", summary="Baseline passed.", detail_codes=(), phase="baseline")
     final = QaResult(status="passed", summary="Final passed.", detail_codes=(), phase="final")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -16,6 +16,7 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    QaResult,
     RepairResult,
     RunRecord,
 )
@@ -447,6 +448,7 @@ def test_repair_stage_clears_existing_workspace_before_clone(
     class DummyAdapter:
         def repair(self, **kwargs):
             del kwargs
+            (run_dir / "repair.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
             return RepairResult(
                 status="completed",
                 summary="Repair stage completed and produced source changes.",
@@ -468,6 +470,78 @@ def test_repair_stage_clears_existing_workspace_before_clone(
     )
 
     assert result.status == "completed"
+
+
+def test_repair_stage_reclassifies_completed_result_without_patch_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(command, cwd, capture_output, text):
+        del cwd, capture_output, text
+
+        class _Completed:
+            def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "abc123\n")
+        if command[:2] == ["git", "clone"]:
+            Path(command[-1]).mkdir(parents=True, exist_ok=True)
+            return _Completed(0)
+        if command[:3] == ["git", "reset", "--hard"]:
+            return _Completed(0)
+        raise AssertionError(f"Unexpected command: {command}")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path=str(run_dir / "repair-workspace"),
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(
+        _intake(),
+        _record(run_dir),
+        run_dir,
+        contract_dir,
+    )
+
+    assert result.status == "blocked"
+    assert result.detail_codes == ("repair_patch_path_missing",)
 
 
 def test_repair_stage_fails_before_workspace_side_effects_when_approved_plan_missing(
@@ -912,10 +986,9 @@ def test_merge_execution_result_promotes_completed_repair(tmp_path: Path) -> Non
         status="completed",
         summary="Repair stage completed and produced source changes.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(tmp_path / "repair-workspace"),
         patch_path=str(tmp_path / "repair.patch"),
     )
-    from precision_squad.models import QaResult
-
     qa_result = QaResult(
         status="passed",
         summary="Documented QA command passed in the repair workspace.",
@@ -944,6 +1017,7 @@ def test_merge_docs_remediation_execution_result_promotes_completed_repair(
         status="completed",
         summary="Repair stage completed and produced source changes.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(tmp_path / "repair-workspace"),
         patch_path=str(tmp_path / "repair.patch"),
     )
     validation_result = ExecutionResult(
@@ -984,6 +1058,7 @@ def test_merge_docs_remediation_execution_result_blocks_when_revalidation_still_
         status="completed",
         summary="Repair stage completed and produced source changes.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(tmp_path / "repair-workspace"),
         patch_path=str(tmp_path / "repair.patch"),
     )
     validation_result = ExecutionResult(
@@ -1156,6 +1231,208 @@ def test_workspace_qa_verifier_runs_documented_setup_and_qa_commands(
     assert result.command == "python -m pytest tests/test_cli.py"
     assert commands[0][4] == "python -m pip install -e .[dev]"
     assert commands[1][4] == "python -m pytest tests/test_cli.py"
+
+
+def test_run_repair_qa_loop_short_circuits_qa_when_completed_contract_is_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(command, cwd, capture_output, text):
+        del cwd, capture_output, text
+
+        class _Completed:
+            def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "abc123\n")
+        if command[:2] == ["git", "clone"]:
+            Path(command[-1]).mkdir(parents=True, exist_ok=True)
+            return _Completed(0)
+        if command[:3] == ["git", "reset", "--hard"]:
+            return _Completed(0)
+        raise AssertionError(f"Unexpected command: {command}")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path=str(run_dir / "repair-workspace"),
+            )
+
+        def with_qa_feedback(self, feedback: str):
+            del feedback
+            return self
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.repair.orchestration._run_baseline_qa",
+        lambda **kwargs: QaResult(
+            status="passed",
+            summary="Baseline passed.",
+            detail_codes=("qa_passed",),
+            phase="baseline",
+            quality="green",
+        ),
+    )
+
+    def fail_verify(*args, **kwargs):
+        raise AssertionError("repair QA should not run when completed artifacts are incomplete")
+
+    monkeypatch.setattr("precision_squad.repair.orchestration.WorkspaceQaVerifier.verify", fail_verify)
+
+    repair_result, baseline_result, qa_result = __import__(
+        "precision_squad.repair.orchestration", fromlist=["run_repair_qa_loop"]
+    ).run_repair_qa_loop(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+        intake=_intake(),
+        run_record=_record(run_dir),
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        max_iterations=1,
+    )
+
+    assert repair_result.status == "blocked"
+    assert baseline_result.status == "passed"
+    assert qa_result.status == "not_run"
+
+
+def test_run_repair_qa_loop_runs_qa_for_valid_completed_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(command, cwd, capture_output, text):
+        del cwd, capture_output, text
+
+        class _Completed:
+            def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "abc123\n")
+        if command[:2] == ["git", "clone"]:
+            Path(command[-1]).mkdir(parents=True, exist_ok=True)
+            return _Completed(0)
+        if command[:3] == ["git", "reset", "--hard"]:
+            return _Completed(0)
+        raise AssertionError(f"Unexpected command: {command}")
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            (run_dir / "repair.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path=str(run_dir / "repair-workspace"),
+                patch_path=str(run_dir / "repair.patch"),
+            )
+
+        def with_qa_feedback(self, feedback: str):
+            del feedback
+            return self
+
+    seen_repo_workspace: dict[str, str] = {}
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "precision_squad.repair.orchestration._run_baseline_qa",
+        lambda **kwargs: QaResult(
+            status="passed",
+            summary="Baseline passed.",
+            detail_codes=("qa_passed",),
+            phase="baseline",
+            quality="green",
+        ),
+    )
+
+    def pass_verify(self, *, run_dir, contract_artifact_dir, repo_workspace, iteration):
+        del self, run_dir, contract_artifact_dir, iteration
+        seen_repo_workspace["value"] = str(repo_workspace)
+        return QaResult(
+            status="passed",
+            summary="Final passed.",
+            detail_codes=("qa_passed",),
+        )
+
+    monkeypatch.setattr(
+        "precision_squad.repair.orchestration.WorkspaceQaVerifier.verify",
+        pass_verify,
+    )
+
+    repair_result, baseline_result, qa_result = __import__(
+        "precision_squad.repair.orchestration", fromlist=["run_repair_qa_loop"]
+    ).run_repair_qa_loop(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+        intake=_intake(),
+        run_record=_record(run_dir),
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        max_iterations=1,
+    )
+
+    assert repair_result.status == "completed"
+    assert baseline_result.status == "passed"
+    assert qa_result.status == "passed"
+    assert seen_repo_workspace["value"] == str(run_dir / "repair-workspace" / "repo")
 
 
 def test_workspace_qa_verifier_bootstraps_whitelisted_uv(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -650,6 +650,39 @@ def test_repair_stage_reclassifies_completed_result_with_patch_path_outside_run_
     assert result.detail_codes == ("repair_patch_path_invalid",)
 
 
+def test_repair_stage_reclassifies_completed_result_when_repo_workspace_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = _prepare_repair_stage_run(run_dir)
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            repo_workspace = kwargs["repo_workspace"]
+            (run_dir / "repair.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
+            repo_workspace.rmdir()
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path="repair-workspace",
+                patch_path="repair.patch",
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", _fake_repair_stage_git_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert result.detail_codes == ("repair_workspace_repo_missing",)
+
+
 def test_repair_stage_reclassifies_completed_result_when_patch_artifact_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -81,6 +81,49 @@ def _write_contract(contract_dir: Path, setup_commands: list[str], qa_command: s
     )
 
 
+def _prepare_repair_stage_run(run_dir: Path) -> Path:
+    contract_dir = run_dir / "execution-contract"
+    contract_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "issue.md").write_text("# Issue\n", encoding="utf-8")
+    (run_dir / "executor.stdout.log").write_text("stdout\n", encoding="utf-8")
+    (run_dir / "executor.stderr.log").write_text("stderr\n", encoding="utf-8")
+    (contract_dir / "contract.json").write_text("{}\n", encoding="utf-8")
+    (contract_dir / "README.snapshot.md").write_text("# Source: README.md\n", encoding="utf-8")
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/markdown-pdf-renderer#9",
+                "plan_summary": "Repair the issue.",
+                "implementation_steps": ["Apply minimal change"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return contract_dir
+
+
+def _fake_repair_stage_git_run(command, cwd, capture_output, text):
+    del cwd, capture_output, text
+
+    class _Completed:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    if command[:3] == ["git", "rev-parse", "HEAD"]:
+        return _Completed(0, "abc123\n")
+    if command[:2] == ["git", "clone"]:
+        Path(command[-1]).mkdir(parents=True, exist_ok=True)
+        return _Completed(0)
+    if command[:3] == ["git", "reset", "--hard"]:
+        return _Completed(0)
+    raise AssertionError(f"Unexpected command: {command}")
+
+
 def test_executor_requires_existing_repo_path(tmp_path: Path) -> None:
     executor = DocsFirstExecutor(repo_path=tmp_path / "missing-repo")
 
@@ -542,6 +585,132 @@ def test_repair_stage_reclassifies_completed_result_without_patch_artifact(
 
     assert result.status == "blocked"
     assert result.detail_codes == ("repair_patch_path_missing",)
+
+
+def test_repair_stage_reclassifies_completed_result_with_workspace_path_outside_run_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = _prepare_repair_stage_run(run_dir)
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            (run_dir / "repair.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path="..",
+                patch_path="repair.patch",
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", _fake_repair_stage_git_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "blocked"
+    assert result.detail_codes == ("repair_workspace_path_invalid",)
+
+
+def test_repair_stage_reclassifies_completed_result_with_patch_path_outside_run_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = _prepare_repair_stage_run(run_dir)
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path="repair-workspace",
+                patch_path="..\\repair.patch",
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", _fake_repair_stage_git_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "blocked"
+    assert result.detail_codes == ("repair_patch_path_invalid",)
+
+
+def test_repair_stage_reclassifies_completed_result_when_patch_artifact_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = _prepare_repair_stage_run(run_dir)
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path="repair-workspace",
+                patch_path="repair.patch",
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", _fake_repair_stage_git_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert result.detail_codes == ("repair_patch_missing",)
+
+
+def test_repair_stage_reclassifies_completed_result_when_patch_artifact_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    contract_dir = _prepare_repair_stage_run(run_dir)
+
+    class DummyAdapter:
+        def repair(self, **kwargs):
+            del kwargs
+            (run_dir / "repair.patch").write_text("", encoding="utf-8")
+            return RepairResult(
+                status="completed",
+                summary="Repair stage completed and produced source changes.",
+                detail_codes=("repair_stage_completed",),
+                workspace_path="repair-workspace",
+                patch_path="repair.patch",
+            )
+
+    monkeypatch.setattr("precision_squad.repair.subprocess.run", _fake_repair_stage_git_run)
+
+    result = RepairStage(
+        repo_path=repo_path,
+        adapter=cast(OpenCodeRepairAdapter, DummyAdapter()),
+    ).execute(_intake(), _record(run_dir), run_dir, contract_dir)
+
+    assert result.status == "failed_infra"
+    assert result.detail_codes == ("repair_patch_empty",)
 
 
 def test_repair_stage_fails_before_workspace_side_effects_when_approved_plan_missing(
@@ -1381,8 +1550,8 @@ def test_run_repair_qa_loop_runs_qa_for_valid_completed_artifacts(
                 status="completed",
                 summary="Repair stage completed and produced source changes.",
                 detail_codes=("repair_stage_completed",),
-                workspace_path=str(run_dir / "repair-workspace"),
-                patch_path=str(run_dir / "repair.patch"),
+                workspace_path="repair-workspace",
+                patch_path="repair.patch",
             )
 
         def with_qa_feedback(self, feedback: str):
@@ -1432,6 +1601,8 @@ def test_run_repair_qa_loop_runs_qa_for_valid_completed_artifacts(
     assert repair_result.status == "completed"
     assert baseline_result.status == "passed"
     assert qa_result.status == "passed"
+    assert repair_result.workspace_path == str((run_dir / "repair-workspace").resolve())
+    assert repair_result.patch_path == str((run_dir / "repair.patch").resolve())
     assert seen_repo_workspace["value"] == str(run_dir / "repair-workspace" / "repo")
 
 

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -171,7 +171,7 @@ def _approved_plan() -> ApprovedPlan:
     )
 
 
-def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
+def test_repair_adapter_blocks_json_only_output_without_artifacts(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
     contract_dir = tmp_path / "contract"
@@ -200,12 +200,17 @@ def test_repair_adapter_completed_with_changes(tmp_path: Path) -> None:
             repo_workspace=repo_workspace,
         )
 
-    assert result.status == "completed"
-    assert result.summary == "Fixed the bug."
+    assert result.status == "blocked"
+    assert "Fixed the bug." in result.summary
+    assert result.detail_codes == (
+        "repair_workspace_path_missing",
+        "repair_patch_path_missing",
+        "repair_output_not_applied",
+    )
     assert result.stdout_path is not None
 
 
-def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
+def test_repair_adapter_blocks_schema_valid_json_even_without_side_effects(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
     contract_dir = tmp_path / "contract"
@@ -234,11 +239,11 @@ def test_repair_adapter_completed_no_changes(tmp_path: Path) -> None:
             repo_workspace=repo_workspace,
         )
 
-    assert result.status == "completed"
-    assert result.summary == "Fixed the bug."
+    assert result.status == "blocked"
+    assert "did not persist a patch artifact" in result.summary
 
 
-def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
+def test_repair_adapter_keeps_valid_json_output_blocked_when_not_applied(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
     contract_dir = tmp_path / "contract"
@@ -267,7 +272,7 @@ def test_repair_adapter_diff_failed(tmp_path: Path) -> None:
             repo_workspace=repo_workspace,
         )
 
-    assert result.status == "completed"
+    assert result.status == "blocked"
 
 
 def test_repair_adapter_api_failure(tmp_path: Path) -> None:
@@ -372,7 +377,7 @@ def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
             repo_workspace=repo_workspace,
         )
 
-    assert result.status == "completed"
+    assert result.status == "blocked"
     assert len(result.side_issues) == 1
     assert result.side_issues[0].title == "Other bug"
 
@@ -417,7 +422,7 @@ def test_repair_adapter_with_design_decisions(tmp_path: Path) -> None:
             repo_workspace=repo_workspace,
         )
 
-    assert result.status == "completed"
+    assert result.status == "blocked"
     assert len(result.design_decisions) == 1
     assert result.design_decisions[0].summary == "Persist in coordinator"
 

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -184,6 +184,8 @@ def test_build_publish_plan_fails_when_completed_repair_missing_decision_log_art
         status="completed",
         summary="Repair completed.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(run_dir / "repair-workspace"),
+        patch_path=str(run_dir / "repair.patch"),
     )
 
     with pytest.raises(
@@ -358,6 +360,7 @@ def test_build_publish_plan_creates_follow_up_issue_for_side_issues() -> None:
         updated_at="2026-04-28T00:00:00Z",
         run_dir=".precision-squad/runs/run-123",
     )
+    run_dir = Path(run_record.run_dir)
     verdict = GovernanceVerdict(
         status="blocked",
         summary="QA failed.",
@@ -367,6 +370,8 @@ def test_build_publish_plan_creates_follow_up_issue_for_side_issues() -> None:
         status="completed",
         summary="Repair completed with side issues.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(run_dir / "repair-workspace"),
+        patch_path=str(run_dir / "repair.patch"),
         side_issues=(
             SideIssue(
                 title="Missing version pin",
@@ -415,6 +420,7 @@ def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
         updated_at="2026-04-28T00:00:00Z",
         run_dir=".precision-squad/runs/run-123",
     )
+    run_dir = Path(run_record.run_dir)
     verdict = GovernanceVerdict(
         status="blocked",
         summary="QA failed.",
@@ -424,6 +430,8 @@ def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
         status="completed",
         summary="Repair completed.",
         detail_codes=("repair_stage_completed",),
+        workspace_path=str(run_dir / "repair-workspace"),
+        patch_path=str(run_dir / "repair.patch"),
         side_issues=(),
     )
 


### PR DESCRIPTION
Closes #47

## Plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-47.md`
- Controller run: `20260519-155817-887`
- Reviewed head: `d4a0be4b2fd48da10c8055886912976b6c3ffc63`

## Implementation decisions
- enforce the completed-result contract at the shared `RepairStage.execute()` validation seam
- prevent JSON-only direct-LLM output from projecting as `completed`
- correct affected dishonest completed-result fixtures and downstream QA assumptions

## Validation evidence
- stage F already passed on reviewed head `d4a0be4b2fd48da10c8055886912976b6c3ffc63`
- merge-stage reconciliation pushed the reviewed branch head to the PR branch before completion handling