### PR TITLE
fix: retire direct llm runtime path

### DIFF
--- a/src/precision_squad/repair/llm_adapter.py
+++ b/src/precision_squad/repair/llm_adapter.py
@@ -2,35 +2,16 @@
 
 from __future__ import annotations
 
-import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
-import openai
-from jsonschema import ValidationError, validate
-
-from ..models import ApprovedPlan, DesignDecision, IssueIntake, RepairResult, RunRecord, SideIssue
+from ..models import ApprovedPlan, IssueIntake, RepairResult, RunRecord
 from ..stage_contracts import DeveloperStageContract
-from .adapter import (
-    REPAIR_RESULT_SCHEMA,
-    _build_repair_prompt,
-    _extract_design_decisions,
-    _extract_side_issues,
-)
-
-_SYSTEM_PROMPT = (
-    "You are a precise code repair assistant. "
-    "You will receive an issue description and context files. "
-    "Make the minimal source changes needed to resolve the issue. "
-    "Output a single JSON object matching the schema provided in the user prompt. "
-    "Do not output any text outside the JSON object."
-)
 
 
 @dataclass(frozen=True, slots=True)
 class VercelAIRepairAdapter:
-    """Repair adapter that calls an OpenAI-compatible LLM API directly."""
+    """Compatibility adapter for the retired direct-LLM repair path."""
 
     model: str | None = None
     qa_feedback: str | None = None
@@ -50,85 +31,17 @@ class VercelAIRepairAdapter:
         repo_workspace: Path,
         developer_contract: DeveloperStageContract | None = None,
     ) -> RepairResult:
-        stdout_path = run_dir / "repair.stdout.log"
-
-        prompt = _build_repair_prompt(
-            approved_plan=approved_plan,
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_artifact_dir,
-            repo_workspace=repo_workspace,
-            qa_feedback=self.qa_feedback,
-            developer_contract=developer_contract,
-        )
-
-        resolved_model = self.model or os.environ.get("OPENAI_MODEL", "gpt-4o")
-
-        try:
-            client = openai.OpenAI()
-            response = client.chat.completions.create(
-                model=resolved_model,
-                response_format={"type": "json_object"},
-                messages=[
-                    {"role": "system", "content": _SYSTEM_PROMPT},
-                    {"role": "user", "content": prompt},
-                ],
-            )
-            raw_content = response.choices[0].message.content or "{}"
-        except Exception as exc:
-            return RepairResult(
-                status="failed_infra",
-                summary=f"LLM API call failed: {exc}",
-                detail_codes=("llm_api_failed",),
-                stdout_path=str(stdout_path),
-            )
-
-        stdout_path.write_text(raw_content, encoding="utf-8")
-
-        repair_json = _parse_llm_response(raw_content)
-        side_issues: tuple[SideIssue, ...] = ()
-        design_decisions: tuple[DesignDecision, ...] = ()
-        if repair_json is not None:
-            side_issues = _extract_side_issues(repair_json)
-            design_decisions = _extract_design_decisions(repair_json)
-
-        if repair_json is None:
-            return RepairResult(
-                status="blocked",
-                summary="LLM response did not match the expected repair result schema.",
-                detail_codes=("llm_response_invalid",),
-                stdout_path=str(stdout_path),
-            )
-
         return RepairResult(
             status="blocked",
             summary=(
-                f"{repair_json.get('summary', 'Repair agent returned structured output.')} "
-                "Direct LLM output was not applied to the workspace and did not persist "
-                "a patch artifact for this run."
+                "Direct LLM compatibility path is retired on the current baseline. "
+                "No repair output was applied to the workspace and no patch artifact "
+                "was persisted for this path."
             ),
             detail_codes=(
+                "direct_llm_runtime_retired",
                 "repair_workspace_path_missing",
                 "repair_patch_path_missing",
                 "repair_output_not_applied",
             ),
-            stdout_path=str(stdout_path),
-            side_issues=side_issues,
-            design_decisions=design_decisions,
         )
-
-
-def _parse_llm_response(raw_content: str) -> dict | None:
-    """Parse and validate a single JSON response from an LLM."""
-    try:
-        payload = json.loads(raw_content)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(payload, dict):
-        return None
-    try:
-        validate(instance=payload, schema=REPAIR_RESULT_SCHEMA)
-    except ValidationError:
-        return None
-    return payload

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+import precision_squad.repair.llm_adapter as llm_adapter_module
 from precision_squad.models import (
     ApprovedPlan,
     GitHubIssue,
@@ -55,6 +59,41 @@ def _approved_plan() -> ApprovedPlan:
         retrieval_surface_summary="src/",
         approved=True,
     )
+
+
+def test_repair_adapter_never_constructs_openai_compatible_client(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = _make_intake()
+    run_record = _make_run_record()
+    contract_dir = tmp_path / "contract"
+    contract_dir.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    repo_workspace = tmp_path / "repo"
+    repo_workspace.mkdir()
+
+    def fail_if_openai_client_constructed(*args: object, **kwargs: object) -> object:
+        pytest.fail("repair() must not construct an OpenAI-compatible client")
+
+    monkeypatch.setattr(
+        llm_adapter_module,
+        "openai",
+        SimpleNamespace(OpenAI=fail_if_openai_client_constructed),
+        raising=False,
+    )
+
+    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    result = adapter.repair(
+        approved_plan=_approved_plan(),
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=repo_workspace,
+    )
+
+    assert result.status == "blocked"
 
 
 def test_repair_adapter_returns_retired_blocked_result_without_openai_client(tmp_path: Path) -> None:

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from precision_squad.models import (
     ApprovedPlan,
@@ -16,117 +12,7 @@ from precision_squad.models import (
     IssueReference,
     RunRecord,
 )
-from precision_squad.repair.llm_adapter import (
-    VercelAIRepairAdapter,
-    _parse_llm_response,
-)
-
-# ---------------------------------------------------------------------------
-# _parse_llm_response
-# ---------------------------------------------------------------------------
-
-
-def test_parse_llm_response_valid_summary_only() -> None:
-    payload = json.dumps({"summary": "Fixed the bug."})
-    result = _parse_llm_response(payload)
-    assert result is not None
-    assert result["summary"] == "Fixed the bug."
-
-
-def test_parse_llm_response_valid_with_side_issues() -> None:
-    payload = {
-        "summary": "Fixed the bug.",
-        "side_issues": [
-            {
-                "title": "Other bug",
-                "summary": "Found another bug",
-                "body": "Details here",
-                "labels": ["bug"],
-            }
-        ],
-    }
-    result = _parse_llm_response(json.dumps(payload))
-    assert result is not None
-    assert len(result["side_issues"]) == 1
-
-
-def test_parse_llm_response_valid_with_design_decisions() -> None:
-    payload = {
-        "summary": "Fixed the bug.",
-        "design_decisions": [
-            {
-                "sequence": 1,
-                "summary": "Persist in coordinator",
-                "rationale": "Publish plan must read persisted evidence.",
-            }
-        ],
-    }
-    result = _parse_llm_response(json.dumps(payload))
-    assert result is not None
-    assert len(result["design_decisions"]) == 1
-
-
-def test_parse_llm_response_empty_string() -> None:
-    assert _parse_llm_response("") is None
-
-
-def test_parse_llm_response_not_json() -> None:
-    assert _parse_llm_response("not json") is None
-
-
-def test_parse_llm_response_not_dict() -> None:
-    assert _parse_llm_response('"just a string"') is None
-
-
-def test_parse_llm_response_missing_summary() -> None:
-    assert _parse_llm_response(json.dumps({"side_issues": []})) is None
-
-
-def test_parse_llm_response_summary_wrong_type() -> None:
-    assert _parse_llm_response(json.dumps({"summary": 123})) is None
-
-
-def test_parse_llm_response_side_issues_wrong_type() -> None:
-    assert _parse_llm_response(json.dumps({"summary": "done", "side_issues": "bad"})) is None
-
-
-def test_parse_llm_response_side_issue_missing_required() -> None:
-    payload = json.dumps({"summary": "done", "side_issues": [{"title": "Only title"}]})
-    assert _parse_llm_response(payload) is None
-
-
-def test_parse_llm_response_design_decision_missing_required() -> None:
-    payload = json.dumps(
-        {"summary": "done", "design_decisions": [{"sequence": 1, "summary": "Only summary"}]}
-    )
-    assert _parse_llm_response(payload) is None
-
-
-def test_parse_llm_response_design_decision_rejects_whitespace_summary() -> None:
-    payload = json.dumps(
-        {
-            "summary": "done",
-            "design_decisions": [{"sequence": 1, "summary": "   ", "rationale": "Valid rationale"}],
-        }
-    )
-    assert _parse_llm_response(payload) is None
-
-
-def test_parse_llm_response_design_decision_rejects_whitespace_rationale() -> None:
-    payload = json.dumps(
-        {
-            "summary": "done",
-            "design_decisions": [{"sequence": 1, "summary": "Valid summary", "rationale": "\n\t "}],
-        }
-    )
-    assert _parse_llm_response(payload) is None
-
-
-def test_parse_llm_response_pretty_printed_json() -> None:
-    payload = json.dumps({"summary": "Fixed the bug."}, indent=2)
-    result = _parse_llm_response(payload)
-    assert result is not None
-    assert result["summary"] == "Fixed the bug."
+from precision_squad.repair.llm_adapter import VercelAIRepairAdapter
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +57,7 @@ def _approved_plan() -> ApprovedPlan:
     )
 
 
-def test_repair_adapter_blocks_json_only_output_without_artifacts(tmp_path: Path) -> None:
+def test_repair_adapter_returns_retired_blocked_result_without_openai_client(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
     contract_dir = tmp_path / "contract"
@@ -181,36 +67,32 @@ def test_repair_adapter_blocks_json_only_output_without_artifacts(tmp_path: Path
     repo_workspace = tmp_path / "repo"
     repo_workspace.mkdir()
 
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
+    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    result = adapter.repair(
+        approved_plan=_approved_plan(),
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=repo_workspace,
+    )
 
     assert result.status == "blocked"
-    assert "Fixed the bug." in result.summary
+    assert "Direct LLM compatibility path is retired on the current baseline." in result.summary
     assert result.detail_codes == (
+        "direct_llm_runtime_retired",
         "repair_workspace_path_missing",
         "repair_patch_path_missing",
         "repair_output_not_applied",
     )
-    assert result.stdout_path is not None
+    assert result.patch_path is None
+    assert result.workspace_path is None
+    assert result.stdout_path is None
+    assert not (run_dir / "repair.patch").exists()
+    assert not any(run_dir.iterdir())
 
 
-def test_repair_adapter_blocks_schema_valid_json_even_without_side_effects(tmp_path: Path) -> None:
+def test_repair_adapter_retirement_result_does_not_claim_applied_workspace_or_patch(tmp_path: Path) -> None:
     intake = _make_intake()
     run_record = _make_run_record()
     contract_dir = tmp_path / "contract"
@@ -220,247 +102,22 @@ def test_repair_adapter_blocks_schema_valid_json_even_without_side_effects(tmp_p
     repo_workspace = tmp_path / "repo"
     repo_workspace.mkdir()
 
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
+    adapter = VercelAIRepairAdapter(model="gpt-4o")
+    result = adapter.repair(
+        approved_plan=_approved_plan(),
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        contract_artifact_dir=contract_dir,
+        repo_workspace=repo_workspace,
+    )
 
     assert result.status == "blocked"
-    assert "did not persist a patch artifact" in result.summary
-
-
-def test_repair_adapter_keeps_valid_json_output_blocked_when_not_applied(tmp_path: Path) -> None:
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps({"summary": "Fixed the bug."})
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
-
-    assert result.status == "blocked"
-
-
-def test_repair_adapter_api_failure(tmp_path: Path) -> None:
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.side_effect = Exception("API error")
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
-
-    assert result.status == "failed_infra"
-    assert "LLM API call failed" in result.summary
-
-
-def test_repair_adapter_invalid_response(tmp_path: Path) -> None:
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = '{"not_summary": "bad"}'
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
-
-    assert result.status == "blocked"
-    assert "did not match" in result.summary
-
-
-def test_repair_adapter_with_side_issues(tmp_path: Path) -> None:
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    payload = {
-        "summary": "Fixed the bug.",
-        "side_issues": [
-            {
-                "title": "Other bug",
-                "summary": "Found another bug",
-                "body": "Details here",
-                "labels": ["bug"],
-            }
-        ],
-    }
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps(payload)
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
-
-    assert result.status == "blocked"
-    assert len(result.side_issues) == 1
-    assert result.side_issues[0].title == "Other bug"
-
-
-def test_repair_adapter_with_design_decisions(tmp_path: Path) -> None:
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    payload = {
-        "summary": "Fixed the bug.",
-        "design_decisions": [
-            {
-                "sequence": 1,
-                "summary": "Persist in coordinator",
-                "rationale": "Publish plan must load stored evidence.",
-                "plan_steps": ["Persist artifact before publish-plan construction"],
-            }
-        ],
-    }
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps(payload)
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter(model="gpt-4o")
-        result = adapter.repair(
-            approved_plan=_approved_plan(),
-            intake=intake,
-            run_record=run_record,
-            run_dir=run_dir,
-            contract_artifact_dir=contract_dir,
-            repo_workspace=repo_workspace,
-        )
-
-    assert result.status == "blocked"
-    assert len(result.design_decisions) == 1
-    assert result.design_decisions[0].summary == "Persist in coordinator"
-
-
-def test_repair_adapter_model_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_MODEL", "gpt-4-turbo")
-
-    intake = _make_intake()
-    run_record = _make_run_record()
-    contract_dir = tmp_path / "contract"
-    contract_dir.mkdir()
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    repo_workspace = tmp_path / "repo"
-    repo_workspace.mkdir()
-
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = json.dumps({"summary": "done"})
-
-    with patch("precision_squad.repair.llm_adapter.openai.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai.return_value = mock_client
-
-        adapter = VercelAIRepairAdapter()
-        adapter.repair(
-                approved_plan=_approved_plan(),
-                intake=intake,
-                run_record=run_record,
-                run_dir=run_dir,
-                contract_artifact_dir=contract_dir,
-                repo_workspace=repo_workspace,
-            )
-
-    mock_client.chat.completions.create.assert_called_once()
-    call_args = mock_client.chat.completions.create.call_args
-    assert call_args.kwargs["model"] == "gpt-4-turbo"
+    assert "no patch artifact was persisted" in result.summary
+    assert result.patch_path is None
+    assert result.workspace_path is None
+    assert result.side_issues == ()
+    assert result.design_decisions == ()
 
 
 def test_repair_adapter_with_qa_feedback(tmp_path: Path) -> None:

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -18,7 +18,6 @@ from precision_squad.models import (
 )
 from precision_squad.repair.llm_adapter import VercelAIRepairAdapter
 
-
 # ---------------------------------------------------------------------------
 # VercelAIRepairAdapter.repair
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #57

## Summary
- retire the direct LLM repair runtime path in `src/precision_squad/repair/llm_adapter.py`
- keep the compatibility path inert and deterministic instead of performing live repair work
- replace the old live-call expectations in `tests/test_llm_adapter.py` with focused retirement coverage

## Approved plan
- `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-57.md`

## Notable implementation decisions
- preserve the existing compatibility surface for the retired adapter path
- stop the retired path from instantiating or calling the OpenAI-compatible client
- keep the active repair implementation on the OpenCode-backed path

## Validation evidence
- controller run: `20260519-155817-887`
- stage F implementation review verdict: `pass`
- evidence commit: `4122e9f8ec8442b46714ddffcf3ba9d90d85fcae`
- progress log: `.opencode/runs/canonical-issue-resolver-parallel/20260519-155817-887/issue-57.md`

## Scope
This PR is scoped to issue #57 only and follows the approved bounded runtime-retirement plan.