### PR TITLE
fix: ignore local workflow artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 build/
 *.egg-info/
 .precision-squad/
+.worktrees/
+logs/
+tests/.test-repos/

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,4 +1,4 @@
-runs/
-node_modules/
-package.json
-package-lock.json
+/runs/
+/node_modules/
+/package.json
+/package-lock.json

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,1 +1,4 @@
 runs/
+node_modules/
+package.json
+package-lock.json


### PR DESCRIPTION
## Summary
- ignore local nested worktree state
- ignore local logs and fixture repos
- ignore local Opencode npm install artifacts

- ## Testing
- git check-ignore -v -- .opencode/node_modules .opencode/package.json .opencode/package-lock.json .worktrees/split-pivot logs/security/.security-key tests/.test-repos/clean-python-project

Closes #91