### PR TITLE
test: align improved quality assertion for #93

### DIFF
--- a/tests/integration/test_pipeline_quality_tag.py
+++ b/tests/integration/test_pipeline_quality_tag.py
@@ -158,7 +158,7 @@ def test_broken_baseline_improved_to_approved(
     assert report.qa_result.status == "passed", (
         f"final QA should be passed: {report.qa_result.status}"
     )
-    assert report.qa_result.quality == "green"
+    assert report.qa_result.quality == "improved"
 
     assert report.governance_verdict is not None
     assert report.publish_plan is not None


### PR DESCRIPTION
Closes #93

## Summary
- align the remaining final QA quality assertion in `tests/integration/test_pipeline_quality_tag.py`
- keep the PR scoped to the single residual test assertion covered by issue #93
- preserve traceability to #52 and #65

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-93.md`

## Implementation decisions
- change only `tests/integration/test_pipeline_quality_tag.py`
- update the known residual assertion target from `"green"` to `"improved"`
- no production code or wider terminology cleanup included

## Validation evidence
- approved implementation head: `35bb96a7df5b34604dfacd3364fbf28fc484c95d`
- targeted validation reference from plan: `pytest tests/integration/test_pipeline_quality_tag.py::test_broken_baseline_improved_to_approved`