### PR TITLE
test: refresh quality tag terminology

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -160,9 +160,9 @@ def make_ambiguous_repo(tmp_path: Path) -> Path:
 def make_repo_with_failing_tests(tmp_path: Path) -> Path:
     """Create a git repository with one passing and one failing test.
 
-    This is used to test the baseline-tolerance (provisional) path:
+    This is used to test the baseline-tolerant quality-tag path:
     baseline QA fails, repair improves (failing test is removed), final QA
-    passes, governance marks as provisional.
+    passes, governance marks the run approved with quality=improved.
     """
     repo_root = tmp_path / "failing-repo"
     repo_root.mkdir()

--- a/tests/integration/test_pipeline_quality_tag.py
+++ b/tests/integration/test_pipeline_quality_tag.py
@@ -138,7 +138,7 @@ def test_broken_baseline_improved_to_approved(
         approved_plan=approved_plan_for(),
     )
 
-    deps = _ProvisionalTestDependencies()
+    deps = _BaselineTolerantTestDependencies()
 
     report = RunCoordinator().repair_issue(
         params=params,
@@ -190,7 +190,7 @@ def test_approved_publish_plan_contains_governance_verdict(
         approved_plan=approved_plan_for(),
     )
 
-    deps = _ProvisionalTestDependencies()
+    deps = _BaselineTolerantTestDependencies()
 
     report = RunCoordinator().repair_issue(
         params=params,
@@ -204,8 +204,8 @@ def test_approved_publish_plan_contains_governance_verdict(
     assert "approved" in plan.body.lower()
 
 
-class _ProvisionalTestDependencies(_ApprovedTestDependencies):
-    """Dependencies for the provisional path that use the failing-test repair adapter."""
+class _BaselineTolerantTestDependencies(_ApprovedTestDependencies):
+    """Dependencies for the baseline-tolerant path using the failing-test repair adapter."""
 
     def __init__(self) -> None:
         self._adapter = _RepairAdapterThatFixesFailingTest()


### PR DESCRIPTION
Closes #52

## Summary
- remove active `provisional` wording from the baseline-tolerant integration-test fixture description
- rename the local test dependency helper to baseline-tolerant terminology
- keep the change scoped to the two files allowed by the canonical plan

## Plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-52.md`

## Implementation decisions
- preserved scenario behavior and assertions
- used current vocabulary from `CONTEXT.md`: approved/blocked as verdicts, improved as a quality tag
- limited changes to `tests/integration/conftest.py` and `tests/integration/test_pipeline_quality_tag.py`

## Validation evidence
- Approved implementation head: `6c6aaf1259bd60f02fff91f7d0d851e2e4c5d256`
- Scope check: diff versus `master` touches only the two planned files
- Validation references were not provided in the task beyond the approved implementation head