### PR TITLE
docs: resolve review impl semantics in ADR-008

### DIFF
--- a/docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md
+++ b/docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md
@@ -1,0 +1,114 @@
+# ADR-008: Resolve `implement` and `review impl` Stage Semantics
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-22
+
+## Context
+
+The workflow vocabulary around `implement`, `publish`, and `review impl` needs an explicit contract.
+
+Without that contract, downstream work can drift into conflicting interpretations such as:
+
+- treating `implement` as the stage that creates a branch or PR
+- treating `review impl` as review of unpublished local workspace state
+- collapsing `publish` into `implement`
+
+Those interpretations would conflict with the already accepted governance rule in [CONTEXT.md](../../CONTEXT.md) and [ADR-001](./adr-001-governance-two-verdicts.md):
+
+- `approved` means governance says yes
+- `approved` creates `draft_pr` automatically
+- that draft PR creation belongs to `publish`
+
+Issue #66 is a decision-and-documentation slice only. It does not change CLI behavior, publish automation, or issue-state automation.
+
+## Decision
+
+Define the stage sequence as:
+
+1. `implement`
+2. `publish`
+3. `review impl`
+
+### `implement`
+
+`implement` is the local, issue-scoped implementation stage.
+
+It consumes:
+
+- the approved issue-scoped planning or decision input for the run
+- the local repository workspace for the single issue being executed
+
+It produces:
+
+- the local implementation diff for that issue
+- persisted run artifacts needed for governance and later publish steps
+- no PR and no branch as a direct stage output
+
+### `publish`
+
+`publish` is the boundary between local implementation and PR-based review.
+
+It consumes:
+
+- the stored implementation result from `implement`
+- the governance verdict
+
+It produces:
+
+- a generated branch and draft PR when the verdict is `approved`
+- persisted publish artifacts such as `publish-plan` and `publish-result`
+
+`publish` occurs only after `implement` completes and governance returns `approved`.
+
+### `review impl`
+
+`review impl` is review of the published draft PR for the same issue.
+
+It consumes:
+
+- the published draft PR for the same issue, including URL or number and head SHA
+- persisted run context needed to review that PR
+- the PR diff and PR body, not an unpublished local-only implementation artifact
+
+It produces:
+
+- the post-publish implementation review result
+- structured feedback back to the source issue when review rejects
+- issue reopen or keep-open behavior on rejection
+- no second PR and no broadened multi-issue output
+
+### Timing Constraints
+
+The workflow timing is locked down as follows:
+
+- PR creation occurs during `publish`
+- `publish` occurs after `implement` completes and after governance returns `approved`
+- `review impl` occurs only after a draft PR already exists
+- draft PR creation does not itself close the issue
+- issue closure is outside the `implement` / `publish` / `review impl` contract for this slice
+
+## Rationale
+
+1. **Preserve accepted governance semantics.** This ADR keeps the accepted `approved -> draft_pr` rule intact instead of redefining governance.
+2. **Keep stage responsibilities clear.** Local implementation, PR publication, and post-publish review are separate responsibilities with separate artifacts.
+3. **Avoid local-only review ambiguity.** `review impl` should evaluate the published draft PR that other participants can inspect, not a transient unpublished workspace.
+4. **Keep issue scope bounded.** This decision resolves terminology and artifact boundaries without expanding into execution changes.
+
+## Consequences
+
+- `implement` must be described as a local stage that does not directly create or update a PR.
+- `publish` must be described as the step that creates the branch and draft PR after an `approved` governance verdict.
+- `review impl` must be described as post-publish review of that draft PR.
+- Documentation and future implementation work should treat persisted implementation artifacts and persisted publish artifacts as distinct handoff points.
+- Issue closure remains governed elsewhere and is not implied by `implement`, `publish`, or draft PR creation.
+
+## References
+
+- [CONTEXT.md](../../CONTEXT.md) — Governance Verdicts
+- [ADR-001: Governance Two-Verdict Model](./adr-001-governance-two-verdicts.md)
+- [architecture.md](../architecture.md) — Publishing And Review

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,16 +244,26 @@ The active fingerprint is no longer based only on a human-facing summary. It is 
 
 ## Publishing And Review
 
-Publishing uses the stored repair workspace rather than rerunning repair.
+Per [ADR-008](./adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md), `publish` sits between local `implement` work and `review impl`.
 
-The publish executor:
+Publishing uses the stored implementation result rather than rerunning repair.
+
+The publish executor consumes:
+
+- the stored implementation result from `implement`
+- an `approved` governance verdict
+
+It then:
 
 - copies `repair-workspace/repo` into `publish-workspace`
 - strips transient artifacts such as cache directories and `.pyc` files
 - commits the repaired state on a generated branch
 - creates a draft PR
+- persists publish artifacts such as `publish-plan.json` and `publish-result.json`
 
-After publish, local review agents can inspect the PR as:
+`review impl` happens only after that draft PR exists. Post-publish review consumes the published PR context and diff rather than an unpublished local-only workspace artifact.
+
+After publish, local review agents can inspect the draft PR as:
 
 - `reviewer`
 - `architect`
@@ -261,8 +271,10 @@ After publish, local review agents can inspect the PR as:
 If either rejects the PR, `precision-squad`:
 
 - posts structured feedback back to the GitHub issue
-- reopens the issue
+- reopens or keeps open the issue
 - persists a `post-publish-review-result.json`
+
+Draft PR creation does not itself close the issue.
 
 ## Persistence Model
 


### PR DESCRIPTION
## Summary
- create ADR-008 as the authoritative decision artifact for `implement`, `publish`, and `review impl`
- align the narrow `Publishing And Review` section in `docs/architecture.md` with the ADR-008 sequence
- preserve the accepted `approved -> draft_pr` governance rule from `CONTEXT.md` and ADR-001

## Issue
- Closes #66

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-66.md`

## Notable implementation decisions
- keep scope bounded to `docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md` and the narrow `docs/architecture.md` publishing/review section
- define `implement` as local issue-scoped work that does not directly create or update a PR
- define `publish` as the stage between `implement` and `review impl` that creates the draft PR after an `approved` governance verdict
- define `review impl` as review of the published draft PR, not unpublished local workspace state

## Validation evidence
- approved implementation head: `4038c7eb2d84e204c970b2dc6990cd66c79e7d2b`
- diff scope versus `master`: only `docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md` and `docs/architecture.md`
- local branch HEAD matches approved implementation head
