### PR TITLE
feat: add create issue stage and issue-draft artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Primary repair command:
 python -m precision_squad.cli repair issue owner/repo#number --repo-path <local-repo>
 ```
 
+Bounded issue-preparation command:
+
+```bash
+python -m precision_squad.cli create issue owner/repo#number
+```
+
 Optional project config:
 
 - locations, in search order: `./.precision-squad.toml` and `./.precision-squad/precision-squad.toml`
@@ -98,6 +104,9 @@ repair_model = "model-name"
 review_model = "model-name"
 approved_plan_path = "approved-plan.json"
 
+[create.issue]
+runs_dir = ".precision-squad/runs"
+
 [publish.run]
 runs_dir = ".precision-squad/runs"
 review_model = "model-name"
@@ -116,6 +125,10 @@ Supported keys for `repair issue`:
 - `repair_model`
 - `review_model`
 - `approved_plan_path`
+
+Supported keys for `create issue`:
+
+- `runs_dir`
 
 Repair agent selection for `repair issue`:
 
@@ -156,6 +169,14 @@ Legacy alias still supported:
 ```bash
 python -m precision_squad.cli run issue owner/repo#number --repo-path <local-repo>
 ```
+
+`create issue` stops after writing the bounded issue-preparation artifacts:
+
+- `run-request.json`
+- `issue-intake.json`
+- `issue-draft.json`
+- `issue.md`
+- `run-record.json`
 
 Publish a stored run without rerunning repair:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -284,6 +284,7 @@ Important persisted artifacts include:
 
 - `run-request.json`
 - `issue-intake.json`
+- `issue-draft.json`
 - `run-record.json`
 - `execution-result.json`
 - `evaluation-result.json`
@@ -296,6 +297,8 @@ Important persisted artifacts include:
 - `post-publish-review-result.json`
 
 This is deliberate. The system prefers inspectability and replayability over hidden state.
+
+`issue-draft.json` is the derived normalized issue-stage handoff artifact for pre-implement issue preparation. It is created by `create issue` and persisted beside the raw request and intake artifacts so downstream issue-stage consumers do not depend on `issue-intake.json` internals.
 
 ## Design Choices
 

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -17,7 +17,7 @@ from .config import (
     load_command_config,
     merge_config_into_args,
 )
-from .coordinator import PublishRunParams, RepairIssueParams, RunCoordinator
+from .coordinator import CreateIssueParams, PublishRunParams, RepairIssueParams, RunCoordinator
 from .env import load_local_env
 from .executor import DocsFirstExecutor
 from .github_client import GitHubClientError, GitHubWriteClient
@@ -153,6 +153,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     issue_parser.set_defaults(handler=_repair_issue)
 
+    create_parser = subparsers.add_parser(
+        "create",
+        help="Create bounded issue-preparation artifacts for a GitHub issue.",
+    )
+    create_subparsers = create_parser.add_subparsers(dest="create_command")
+    create_issue_parser = create_subparsers.add_parser(
+        "issue",
+        help="Create the normalized issue handoff for a GitHub issue reference.",
+    )
+    create_issue_parser.add_argument(
+        "issue_ref",
+        help="GitHub issue reference in the form owner/repo#number.",
+    )
+    create_issue_parser.add_argument(
+        "--runs-dir",
+        default=argparse.SUPPRESS,
+        help="Directory where run artifacts will be stored.",
+    )
+    create_issue_parser.set_defaults(handler=_create_issue)
+
     publish_parser = subparsers.add_parser(
         "publish",
         help="Publish artifacts from an existing stored run without rerunning repair.",
@@ -279,6 +299,28 @@ def _repair_issue(args: argparse.Namespace) -> int:
         if post_publish_review_result.issue_comment_url:
             print(f"Review Feedback URL: {post_publish_review_result.issue_comment_url}")
     return report.exit_code
+
+
+def _create_issue(args: argparse.Namespace) -> int:
+    intake = load_issue_intake(args.issue_ref)
+    report = RunCoordinator().create_issue(
+        params=CreateIssueParams(
+            issue_ref=args.issue_ref,
+            runs_dir=Path(args.runs_dir),
+        ),
+        intake=intake,
+    )
+
+    print(f"Issue: {intake.issue.reference}")
+    print(f"Title: {intake.issue.title}")
+    print(f"Run ID: {report.run_record.run_id}")
+    print(f"Run Dir: {report.run_record.run_dir}")
+    print(f"Classification: {intake.assessment.status}")
+    print(
+        "Artifacts: run-request.json, issue-intake.json, issue-draft.json, issue.md, "
+        "run-record.json"
+    )
+    return 0
 
 
 def _publish_run(args: argparse.Namespace) -> int:
@@ -829,6 +871,10 @@ def _validate_publish_run_args(args: dict[str, Any]) -> None:
     _normalize_optional_str_arg(args, "review_model")
 
 
+def _validate_create_issue_args(args: dict[str, Any]) -> None:
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+
+
 def _validate_install_skill_args(args: dict[str, Any]) -> None:
     args["project_root"] = _config_str(args.get("project_root"), key="project_root")
     args["force"] = _coerce_bool(args.get("force"), key="force")
@@ -842,6 +888,11 @@ def _repair_issue_config_root(args: argparse.Namespace) -> Path:
 
 
 def _publish_run_config_root(args: argparse.Namespace) -> Path:
+    del args
+    return Path.cwd()
+
+
+def _create_issue_config_root(args: argparse.Namespace) -> Path:
     del args
     return Path.cwd()
 
@@ -879,6 +930,13 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
         },
         validate=_validate_repair_issue_args,
         discovery_root=_repair_issue_config_root,
+    ),
+    _create_issue: _CommandConfigSpec(
+        table=("create", "issue"),
+        supported_keys=frozenset({"runs_dir"}),
+        defaults={"runs_dir": ".precision-squad/runs"},
+        validate=_validate_create_issue_args,
+        discovery_root=_create_issue_config_root,
     ),
     _publish_run: _CommandConfigSpec(
         table=("publish", "run"),

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -173,8 +173,26 @@ class PublishRunReport:
     post_publish_review_result: PostPublishReviewResult | None
 
 
+@dataclass(frozen=True, slots=True)
+class CreateIssueParams:
+    issue_ref: str
+    runs_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class CreateIssueReport:
+    intake: IssueIntake
+    run_record: RunRecord
+
+
 class RunCoordinator:
     """Coordinates repair and publish workflows independent of CLI output."""
+
+    def create_issue(self, *, params: CreateIssueParams, intake: IssueIntake) -> CreateIssueReport:
+        store = RunStore(params.runs_dir)
+        request = RunRequest(issue_ref=params.issue_ref, runs_dir=str(params.runs_dir))
+        record = store.create_run(request, intake)
+        return CreateIssueReport(intake=intake, run_record=record)
 
     def repair_issue(
         self,

--- a/src/precision_squad/intake.py
+++ b/src/precision_squad/intake.py
@@ -6,7 +6,15 @@ import re
 
 from .docs_remediation import is_docs_remediation_title_or_body
 from .github_client import GitHubIssueClient
-from .models import GitHubIssue, IssueAssessment, IssueIntake, IssueReference
+from .models import (
+    GitHubIssue,
+    IssueAssessment,
+    IssueDraft,
+    IssueDraftProvenance,
+    IssueIntake,
+    IssueReference,
+    RunRequest,
+)
 
 ISSUE_REFERENCE_PATTERN = re.compile(
     r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)#(?P<number>[1-9][0-9]*)$"
@@ -96,6 +104,28 @@ def load_issue_intake(issue_ref: str, token_env: str = "GITHUB_TOKEN") -> IssueI
     client = GitHubIssueClient.from_env(token_env)
     issue = client.fetch_issue(reference)
     return build_issue_intake(issue)
+
+
+def derive_issue_draft(request: RunRequest, intake: IssueIntake) -> IssueDraft:
+    """Build the canonical normalized issue-stage handoff artifact."""
+    issue = intake.issue
+    return IssueDraft(
+        owner=issue.reference.owner,
+        repo=issue.reference.repo,
+        number=issue.reference.number,
+        issue_ref=str(issue.reference),
+        issue_url=issue.html_url,
+        title=issue.title,
+        summary=intake.summary,
+        problem_statement=intake.problem_statement,
+        labels=issue.labels,
+        intake_status=intake.assessment.status,
+        intake_reason_codes=intake.assessment.reason_codes,
+        provenance=IssueDraftProvenance(
+            source_artifacts=("run-request.json", "issue-intake.json"),
+            requested_issue_ref=request.issue_ref,
+        ),
+    )
 
 
 def is_docs_remediation_issue(issue: GitHubIssue | IssueIntake) -> bool:

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -49,6 +49,32 @@ class IssueIntake:
 
 
 @dataclass(frozen=True, slots=True)
+class IssueDraftProvenance:
+    """Explicit provenance for a normalized issue handoff artifact."""
+
+    source_artifacts: tuple[str, ...]
+    requested_issue_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class IssueDraft:
+    """Derived normalized issue handoff for downstream issue-stage consumers."""
+
+    owner: str
+    repo: str
+    number: int
+    issue_ref: str
+    issue_url: str
+    title: str
+    summary: str
+    problem_statement: str
+    labels: tuple[str, ...]
+    intake_status: Literal["runnable", "blocked"]
+    intake_reason_codes: tuple[str, ...]
+    provenance: IssueDraftProvenance
+
+
+@dataclass(frozen=True, slots=True)
 class RunRequest:
     """Operator request to run one issue through the control plane."""
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Literal, cast
 from uuid import uuid4
 
-from .intake import canonicalize_local_issue_ref
+from .intake import canonicalize_local_issue_ref, derive_issue_draft
 from .models import (
     ApprovedPlan,
     DecisionLogArtifact,
@@ -18,6 +18,8 @@ from .models import (
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
+    IssueDraft,
+    IssueDraftProvenance,
     IssueIntake,
     NamedReference,
     PostPublishReviewResult,
@@ -35,6 +37,7 @@ PersistedArtifact = (
     | EvaluationResult
     | ExecutionResult
     | GovernanceVerdict
+    | IssueDraft
     | IssueIntake
     | PostPublishReviewResult
     | PublishPlan
@@ -83,12 +86,27 @@ class RunStore:
             updated_at=created_at,
             run_dir=str(run_dir),
         )
+        issue_draft = derive_issue_draft(request, intake)
 
         self._write_json(run_dir / "run-request.json", request)
         self._write_json(run_dir / "issue-intake.json", intake)
+        self._write_json(run_dir / "issue-draft.json", issue_draft)
         self._write_issue_context(run_dir / "issue.md", intake)
         self._write_json(run_dir / "run-record.json", record)
         return record
+
+    def load_issue_draft(self, run_id: str) -> IssueDraft:
+        """Load the normalized issue handoff artifact for a run."""
+        run_dir = self.root / run_id
+        return self.load_issue_draft_from_dir(run_dir)
+
+    @staticmethod
+    def load_issue_draft_from_dir(run_dir: Path) -> IssueDraft:
+        """Load the normalized issue handoff artifact from a run directory."""
+        path = run_dir / "issue-draft.json"
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        return _parse_issue_draft_payload(payload)
 
     def load_run(self, run_id: str) -> RunRecord:
         """Load an existing run record by run ID."""
@@ -242,6 +260,82 @@ def _read_run_record(path: Path) -> RunRecord:
         updated_at=str(payload["updated_at"]),
         run_dir=str(payload["run_dir"]),
         attempt=int(payload.get("attempt", 1)),
+    )
+
+
+def _parse_issue_draft_payload(payload: object) -> IssueDraft:
+    if not isinstance(payload, dict):
+        raise ValueError("Issue draft payload must be a JSON object")
+
+    provenance_raw = payload.get("provenance")
+    if not isinstance(provenance_raw, dict):
+        raise ValueError("Issue draft field 'provenance' must be an object")
+
+    source_artifacts = provenance_raw.get("source_artifacts")
+    if not isinstance(source_artifacts, list) or not all(
+        isinstance(item, str) for item in source_artifacts
+    ):
+        raise ValueError("Issue draft provenance.source_artifacts must be a list of strings")
+
+    requested_issue_ref = provenance_raw.get("requested_issue_ref")
+    if not isinstance(requested_issue_ref, str):
+        raise ValueError("Issue draft provenance.requested_issue_ref must be a string")
+
+    intake_status = payload.get("intake_status")
+    if intake_status not in {"runnable", "blocked"}:
+        raise ValueError("Issue draft field 'intake_status' must be 'runnable' or 'blocked'")
+
+    intake_reason_codes = payload.get("intake_reason_codes")
+    if not isinstance(intake_reason_codes, list) or not all(
+        isinstance(item, str) for item in intake_reason_codes
+    ):
+        raise ValueError("Issue draft field 'intake_reason_codes' must be a list of strings")
+
+    labels = payload.get("labels")
+    if not isinstance(labels, list) or not all(isinstance(item, str) for item in labels):
+        raise ValueError("Issue draft field 'labels' must be a list of strings")
+
+    owner = payload.get("owner")
+    repo = payload.get("repo")
+    number = payload.get("number")
+    issue_ref = payload.get("issue_ref")
+    issue_url = payload.get("issue_url")
+    title = payload.get("title")
+    summary = payload.get("summary")
+    problem_statement = payload.get("problem_statement")
+    if not isinstance(owner, str):
+        raise ValueError("Issue draft field 'owner' must be a string")
+    if not isinstance(repo, str):
+        raise ValueError("Issue draft field 'repo' must be a string")
+    if not isinstance(number, int):
+        raise ValueError("Issue draft field 'number' must be an integer")
+    if not isinstance(issue_ref, str):
+        raise ValueError("Issue draft field 'issue_ref' must be a string")
+    if not isinstance(issue_url, str):
+        raise ValueError("Issue draft field 'issue_url' must be a string")
+    if not isinstance(title, str):
+        raise ValueError("Issue draft field 'title' must be a string")
+    if not isinstance(summary, str):
+        raise ValueError("Issue draft field 'summary' must be a string")
+    if not isinstance(problem_statement, str):
+        raise ValueError("Issue draft field 'problem_statement' must be a string")
+
+    return IssueDraft(
+        owner=owner,
+        repo=repo,
+        number=number,
+        issue_ref=issue_ref,
+        issue_url=issue_url,
+        title=title,
+        summary=summary,
+        problem_statement=problem_statement,
+        labels=tuple(labels),
+        intake_status=cast(Literal["runnable", "blocked"], intake_status),
+        intake_reason_codes=tuple(intake_reason_codes),
+        provenance=IssueDraftProvenance(
+            source_artifacts=tuple(source_artifacts),
+            requested_issue_ref=requested_issue_ref,
+        ),
     )
 
 

--- a/tests/integration/test_pipeline_approved.py
+++ b/tests/integration/test_pipeline_approved.py
@@ -124,6 +124,7 @@ def test_approved_persists_all_artifacts(
     expected = [
         "run-request.json",
         "issue-intake.json",
+        "issue-draft.json",
         "run-record.json",
         "execution-result.json",
         "repair-result.json",

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -65,6 +65,7 @@ def test_plan_issue_blocks_before_executor(
     run_dir = Path(report.run_record.run_dir)
     assert (run_dir / "run-request.json").exists()
     assert (run_dir / "issue-intake.json").exists()
+    assert (run_dir / "issue-draft.json").exists()
     assert (run_dir / "run-record.json").exists()
     assert (run_dir / "governance-verdict.json").exists()
     assert (run_dir / "publish-plan.json").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,84 @@ def test_main_without_args_shows_help(capsys) -> None:
     assert "run" in captured.out
 
 
+def test_create_issue_prints_bounded_issue_preparation_output(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "precision-squad", 67),
+            title="Add the create issue stage command",
+            body="## Description\nPersist normalized issue handoff artifacts.",
+            labels=("enhancement", "workflow"),
+            html_url="https://github.com/cracklings3d/precision-squad/issues/67",
+        ),
+        summary="Add the create issue stage command",
+        problem_statement="Persist normalized issue handoff artifacts.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    status = main(
+        [
+            "create",
+            "issue",
+            "cracklings3d/precision-squad#67",
+            "--runs-dir",
+            str(tmp_path / "runs"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Issue: cracklings3d/precision-squad#67" in captured.out
+    assert "Classification: runnable" in captured.out
+    assert "issue-draft.json" in captured.out
+
+
+def test_create_issue_persists_bounded_preparation_artifacts(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "precision-squad", 67),
+            title="Add the create issue stage command",
+            body="## Description\nPersist normalized issue handoff artifacts.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/precision-squad/issues/67",
+        ),
+        summary="Add the create issue stage command",
+        problem_statement="Persist normalized issue handoff artifacts.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", lambda _: intake)
+
+    status = main(
+        [
+            "create",
+            "issue",
+            "cracklings3d/precision-squad#67",
+            "--runs-dir",
+            str(tmp_path / "runs"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    run_dir_line = next(line for line in captured.out.splitlines() if line.startswith("Run Dir:"))
+    run_dir = Path(run_dir_line.removeprefix("Run Dir:").strip())
+    draft_payload = json.loads((run_dir / "issue-draft.json").read_text(encoding="utf-8"))
+
+    assert status == 0
+    assert (run_dir / "run-request.json").exists()
+    assert (run_dir / "issue-intake.json").exists()
+    assert (run_dir / "issue-draft.json").exists()
+    assert (run_dir / "issue.md").exists()
+    assert (run_dir / "run-record.json").exists()
+    assert not (run_dir / "execution-result.json").exists()
+    assert draft_payload["issue_ref"] == "cracklings3d/precision-squad#67"
+    assert draft_payload["summary"] == "Add the create issue stage command"
+    assert draft_payload["provenance"]["source_artifacts"] == ["run-request.json", "issue-intake.json"]
+
+
 def test_repair_agent_choices_include_legacy_compatibility_input() -> None:
     assert _REPAIR_AGENT_CHOICES == ("opencode", "none", "vercel-ai")
 

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -7,10 +7,11 @@ import pytest
 from precision_squad.intake import (
     build_issue_intake,
     canonicalize_local_issue_ref,
+    derive_issue_draft,
     is_docs_remediation_issue,
     parse_issue_reference,
 )
-from precision_squad.models import GitHubIssue, IssueReference
+from precision_squad.models import GitHubIssue, IssueReference, RunRequest
 
 PLAN_ISSUE = GitHubIssue(
     reference=IssueReference("cracklings3d", "markdown-pdf-renderer", 1),
@@ -149,3 +150,29 @@ def test_build_issue_intake_keeps_docs_remediation_issue_runnable_despite_long_b
 
     assert intake.assessment.status == "runnable"
     assert intake.assessment.reason_codes == ()
+
+
+def test_derive_issue_draft_builds_normalized_handoff_from_request_and_intake() -> None:
+    intake = build_issue_intake(BOUNDED_ISSUE)
+
+    draft = derive_issue_draft(
+        RunRequest(
+            issue_ref="cracklings3d/markdown-pdf-renderer#9",
+            runs_dir=".precision-squad/runs",
+        ),
+        intake,
+    )
+
+    assert draft.owner == "cracklings3d"
+    assert draft.repo == "markdown-pdf-renderer"
+    assert draft.number == 9
+    assert draft.issue_ref == "cracklings3d/markdown-pdf-renderer#9"
+    assert draft.issue_url == BOUNDED_ISSUE.html_url
+    assert draft.title == BOUNDED_ISSUE.title
+    assert draft.summary == intake.summary
+    assert draft.problem_statement == intake.problem_statement
+    assert draft.labels == ("enhancement",)
+    assert draft.intake_status == "runnable"
+    assert draft.intake_reason_codes == ()
+    assert draft.provenance.source_artifacts == ("run-request.json", "issue-intake.json")
+    assert draft.provenance.requested_issue_ref == "cracklings3d/markdown-pdf-renderer#9"

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -16,6 +16,7 @@ from precision_squad.models import (
     GitHubIssue,
     GovernanceVerdict,
     IssueAssessment,
+    IssueDraft,
     IssueIntake,
     IssueReference,
     PublishPlan,
@@ -68,6 +69,7 @@ def test_create_run_writes_expected_artifacts(tmp_path: Path) -> None:
     assert run_dir.exists()
     assert (run_dir / "run-request.json").exists()
     assert (run_dir / "issue-intake.json").exists()
+    assert (run_dir / "issue-draft.json").exists()
     assert (run_dir / "issue.md").exists()
     assert (run_dir / "run-record.json").exists()
 
@@ -77,6 +79,34 @@ def test_create_run_writes_expected_artifacts(tmp_path: Path) -> None:
     issue_context = (run_dir / "issue.md").read_text(encoding="utf-8")
     assert "## Issue Comments" in issue_context
     assert "Reviewer says use exact output." in issue_context
+
+
+def test_load_issue_draft_reads_normalized_handoff_artifact(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    request = RunRequest(issue_ref="owner/repo#1", runs_dir=str(tmp_path / "runs"))
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue title",
+            body="Issue body",
+            labels=("bug", "backend"),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue title",
+        problem_statement="Issue body",
+        assessment=IssueAssessment(status="blocked", reason_codes=("issue_marked_as_plan",)),
+    )
+
+    record = store.create_run(request, intake)
+
+    draft = store.load_issue_draft(record.run_id)
+
+    assert isinstance(draft, IssueDraft)
+    assert draft.issue_ref == "owner/repo#1"
+    assert draft.labels == ("bug", "backend")
+    assert draft.intake_status == "blocked"
+    assert draft.intake_reason_codes == ("issue_marked_as_plan",)
+    assert draft.provenance.source_artifacts == ("run-request.json", "issue-intake.json")
 
 
 def test_write_execution_result_persists_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #67

## Summary
- add a bounded `create issue` CLI flow for issue-preparation run creation
- persist normalized `issue-draft.json` alongside existing intake artifacts
- add focused tests and narrow docs updates for the create-issue slice

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-67.md`

## Notable implementation decisions
- keep `create issue` as a bounded pre-implement issue-preparation command
- model `issue-draft.json` as a derived normalized handoff artifact, not a raw intake duplicate
- keep later planning, publish, and review behavior out of this slice

## Validation evidence
- Approved implementation head: `2e2c38c972840f84750826f16096fb8fc0c9bb90`
- Implementation review already passed before completion handoff