### PR TITLE
feat: add plan approved-plan ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Bounded pre-planning review command:
 python -m precision_squad.cli review issue <run-id>
 ```
 
+Canonical planning ingress for an existing reviewed run:
+
+```bash
+python -m precision_squad.cli plan <run-id> --approved-plan-path <path>
+```
+
 Optional project config:
 
 - locations, in search order: `./.precision-squad.toml` and `./.precision-squad/precision-squad.toml`
@@ -94,6 +100,7 @@ Optional project config:
 - schema: command-shaped TOML tables only; top-level scalar keys are invalid
 - discovery root:
   - `repair issue`: `--repo-path` when provided, otherwise the current working directory
+  - `plan`: the current working directory
   - `publish run`: the current working directory
   - `install-skill`: `--project-root` when provided, otherwise the current working directory
 - relative path values from config are resolved relative to the config file that supplied them
@@ -114,6 +121,9 @@ approved_plan_path = "approved-plan.json"
 runs_dir = ".precision-squad/runs"
 
 [review.issue]
+runs_dir = ".precision-squad/runs"
+
+[plan]
 runs_dir = ".precision-squad/runs"
 
 [publish.run]
@@ -140,6 +150,10 @@ Supported keys for `create issue`:
 - `runs_dir`
 
 Supported keys for `review issue`:
+
+- `runs_dir`
+
+Supported keys for `plan`:
 
 - `runs_dir`
 
@@ -194,6 +208,12 @@ python -m precision_squad.cli run issue owner/repo#number --repo-path <local-rep
 `review issue` stops after reading the same run's `issue-draft.json` and writing the bounded review artifact:
 
 - `issue-review.json`
+
+`plan` stops after validating the operator-supplied approved plan and writing the same run's canonical planning artifact, gated by `issue-review.json` approval:
+
+- `approved-plan.json`
+
+`plan <run-id> --approved-plan-path <path>` is the canonical planning ingress. `repair issue --approved-plan-path` remains supported as a compatibility ingress for repair-oriented flows.
 
 Publish a stored run without rerunning repair:
 

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -19,6 +19,7 @@ from .config import (
 )
 from .coordinator import (
     CreateIssueParams,
+    PersistApprovedPlanParams,
     PublishRunParams,
     RepairIssueParams,
     ReviewIssueParams,
@@ -195,6 +196,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory where run artifacts are stored.",
     )
     review_issue_parser.set_defaults(handler=_review_issue)
+
+    plan_parser = subparsers.add_parser(
+        "plan",
+        help="Persist a canonical approved plan for an existing reviewed run.",
+    )
+    plan_parser.add_argument("run_id", help="Existing run ID to attach the approved plan to.")
+    plan_parser.add_argument(
+        "--approved-plan-path",
+        required=True,
+        help="Path to the approved-plan.json artifact to validate and persist for this run.",
+    )
+    plan_parser.add_argument(
+        "--runs-dir",
+        default=argparse.SUPPRESS,
+        help="Directory where run artifacts are stored.",
+    )
+    plan_parser.set_defaults(handler=_plan_run)
 
     publish_parser = subparsers.add_parser(
         "publish",
@@ -401,6 +419,26 @@ def _review_issue(args: argparse.Namespace) -> int:
             field_suffix = f" ({item.field})" if item.field else ""
             print(f"- {item.code}: {item.message} [{item.artifact}{field_suffix}]")
     return report.exit_code
+
+
+def _plan_run(args: argparse.Namespace) -> int:
+    store = RunStore(Path(args.runs_dir))
+    record = store.load_run(args.run_id)
+    approved_plan = _load_approved_plan(Path(args.approved_plan_path), record.issue_ref)
+    artifact_path = RunCoordinator().persist_approved_plan_for_planning(
+        params=PersistApprovedPlanParams(
+            run_id=args.run_id,
+            runs_dir=Path(args.runs_dir),
+            approved_plan=approved_plan,
+        )
+    )
+
+    print(f"Run ID: {record.run_id}")
+    print(f"Run Dir: {record.run_dir}")
+    print(f"Issue: {record.issue_ref}")
+    print(f"Approved Plan: {artifact_path}")
+    print("Artifacts: approved-plan.json")
+    return 0
 
 
 class _CliRepairDependencies:
@@ -921,6 +959,10 @@ def _validate_review_issue_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
 
+def _validate_plan_run_args(args: dict[str, Any]) -> None:
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+
+
 def _validate_create_issue_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
@@ -948,6 +990,11 @@ def _review_issue_config_root(args: argparse.Namespace) -> Path:
 
 
 def _create_issue_config_root(args: argparse.Namespace) -> Path:
+    del args
+    return Path.cwd()
+
+
+def _plan_run_config_root(args: argparse.Namespace) -> Path:
     del args
     return Path.cwd()
 
@@ -1006,6 +1053,13 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
         defaults={"runs_dir": ".precision-squad/runs"},
         validate=_validate_review_issue_args,
         discovery_root=_review_issue_config_root,
+    ),
+    _plan_run: _CommandConfigSpec(
+        table=("plan",),
+        supported_keys=frozenset({"runs_dir"}),
+        defaults={"runs_dir": ".precision-squad/runs"},
+        validate=_validate_plan_run_args,
+        discovery_root=_plan_run_config_root,
     ),
     _install_skill: _CommandConfigSpec(
         table=("install-skill",),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -391,6 +391,202 @@ def test_review_issue_end_to_end_persists_blocked_when_issue_draft_missing(
     assert "Review Status: blocked" in captured.out
 
 
+def test_plan_run_prints_persisted_artifact_output(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.persist_approved_plan_for_planning",
+        lambda self, *, params: run_dir / "approved-plan.json",
+    )
+
+    status = main(
+        [
+            "plan",
+            "run-123",
+            "--runs-dir",
+            str(runs_dir),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Run ID: run-123" in captured.out
+    assert "Issue: owner/repo#1" in captured.out
+    assert "Artifacts: approved-plan.json" in captured.out
+
+
+def test_plan_run_persists_approved_plan_for_reviewed_run(capsys, tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "issue-review.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "review_status": "approved",
+                "summary": "Planning may proceed because issue-draft.json passed the local planner-safety review.",
+                "feedback": [],
+                "provenance": {
+                    "source_artifact": "issue-draft.json",
+                    "run_id": "run-123",
+                    "issue_ref": "owner/repo#1",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    status = main(
+        [
+            "plan",
+            "run-123",
+            "--runs-dir",
+            str(runs_dir),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads((run_dir / "approved-plan.json").read_text(encoding="utf-8"))
+    assert status == 0
+    assert payload["issue_ref"] == "owner/repo#1"
+    assert payload["approved"] is True
+    assert "Approved Plan:" in captured.out
+
+
+def test_plan_run_rejects_missing_issue_review_artifact(capsys, tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    status = main(
+        [
+            "plan",
+            "run-123",
+            "--runs-dir",
+            str(runs_dir),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "requires issue-review.json" in captured.err
+    assert not (run_dir / "approved-plan.json").exists()
+
+
+@pytest.mark.parametrize("review_status", ["changes_requested", "blocked"])
+def test_plan_run_rejects_non_approved_issue_review(
+    capsys, tmp_path: Path, review_status: str
+) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "issue-review.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "review_status": review_status,
+                "summary": "Planning must stop.",
+                "feedback": [],
+                "provenance": {
+                    "source_artifact": "issue-draft.json",
+                    "run_id": "run-123",
+                    "issue_ref": "owner/repo#1",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    status = main(
+        [
+            "plan",
+            "run-123",
+            "--runs-dir",
+            str(runs_dir),
+            "--approved-plan-path",
+            str(plan_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "review_status" in captured.err
+    assert review_status in captured.err
+    assert not (run_dir / "approved-plan.json").exists()
+
+
 def test_repair_agent_choices_include_legacy_compatibility_input() -> None:
     assert _REPAIR_AGENT_CHOICES == ("opencode", "none", "vercel-ai")
 
@@ -2113,6 +2309,43 @@ def test_publish_run_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
     monkeypatch.setattr("precision_squad.cli._run_post_publish_review_if_needed", lambda **kwargs: None)
 
     status = main(["publish", "run", "run-123"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Run ID: run-123" in captured.out
+
+
+def test_plan_run_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    runs_dir = tmp_path / "runs-from-config"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (tmp_path / ".precision-squad.toml").write_text(
+        f'[plan]\nruns_dir = "{runs_dir.as_posix()}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "owner/repo#1",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_path = _write_valid_plan(tmp_path, issue_ref="owner/repo#1")
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.persist_approved_plan_for_planning",
+        lambda self, *, params: run_dir / "approved-plan.json",
+    )
+
+    status = main(["plan", "run-123", "--approved-plan-path", str(plan_path)])
 
     captured = capsys.readouterr()
     assert status == 0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,11 +1,17 @@
-"""Focused tests for decision-log persistence in RunCoordinator."""
+"""Focused tests for RunCoordinator bounded workflows."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from precision_squad.coordinator import RepairIssueParams, RunCoordinator
+import pytest
+
+from precision_squad.coordinator import (
+    PersistApprovedPlanParams,
+    RepairIssueParams,
+    RunCoordinator,
+)
 from precision_squad.models import (
     ApprovedPlan,
     ExecutionResult,
@@ -13,10 +19,13 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    IssueReview,
+    IssueReviewProvenance,
     PublishPlan,
     PublishResult,
     QaResult,
     RepairResult,
+    RunRequest,
 )
 from precision_squad.run_store import RunStore
 
@@ -175,3 +184,68 @@ def test_repair_issue_marks_missing_decision_log_artifact_as_failed_infra(
     assert report.governance_verdict.status == "blocked"
     assert report.publish_plan is not None
     assert report.publish_plan.status == "issue_comment"
+
+
+def test_persist_approved_plan_for_planning_writes_same_run_artifact(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+
+    path = RunCoordinator().persist_approved_plan_for_planning(
+        params=PersistApprovedPlanParams(
+            run_id=record.run_id,
+            runs_dir=runs_dir,
+            approved_plan=_approved_plan(),
+        )
+    )
+
+    assert path == run_dir / "approved-plan.json"
+    assert path.exists()
+
+
+def test_persist_approved_plan_for_planning_rejects_issue_mismatch(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#2", runs_dir=str(runs_dir)),
+        IssueIntake(
+            issue=GitHubIssue(
+                reference=IssueReference("owner", "repo", 2),
+                title="Test issue two",
+                body="Fix the other bug.",
+                labels=(),
+                html_url="https://github.com/owner/repo/issues/2",
+            ),
+            summary="Test issue two",
+            problem_statement="Fix the other bug.",
+            assessment=IssueAssessment(status="runnable", reason_codes=()),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not match the stored run issue_ref"):
+        RunCoordinator().persist_approved_plan_for_planning(
+            params=PersistApprovedPlanParams(
+                run_id=record.run_id,
+                runs_dir=runs_dir,
+                approved_plan=_approved_plan(),
+            )
+        )


### PR DESCRIPTION
Closes #69

## Summary
- add `precision-squad plan <run-id> --approved-plan-path <path>` as the canonical planning ingress
- enforce the inherited same-run `issue-review.json` approval gate before persisting `approved-plan.json`
- preserve the `repair issue --approved-plan-path` compatibility boundary while documenting `plan` as canonical

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-69.md`
- Approved implementation head: `cd15d493a9e0a296b90b2b09bc4efd0dfa7c4ab7`

## Notable implementation decisions
- keep the change bounded to CLI/docs/tests for the new operator-facing planning ingress
- persist the same run's canonical `approved-plan.json` only after same-run issue review is stage-approved
- avoid broad stage-chain or repair-flow redesign in this slice

## Validation evidence
- implementation review approved for head `cd15d493a9e0a296b90b2b09bc4efd0dfa7c4ab7`
- branch scope vs `origin/master`: README, `src/precision_squad/cli.py`, `tests/test_cli.py`, `tests/test_coordinator.py`
