### PR TITLE
Add review plan gate and plan-review artifact (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ python -m precision_squad.cli run issue owner/repo#number --repo-path <local-rep
 
 - `approved-plan.json`
 
+`review plan` stops after reading the same run's canonical `approved-plan.json` and writing the bounded pre-implementation review artifact:
+
+- `plan-review.json`
+
 `plan <run-id> --approved-plan-path <path>` is the canonical planning ingress. `repair issue --approved-plan-path` remains supported as a compatibility ingress for repair-oriented flows.
 
 Publish a stored run without rerunning repair:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,6 +286,8 @@ Important persisted artifacts include:
 - `issue-intake.json`
 - `issue-draft.json`
 - `issue-review.json`
+- `approved-plan.json`
+- `plan-review.json`
 - `run-record.json`
 - `execution-result.json`
 - `evaluation-result.json`
@@ -302,6 +304,8 @@ This is deliberate. The system prefers inspectability and replayability over hid
 `issue-draft.json` is the derived normalized issue-stage handoff artifact for pre-implement issue preparation. It is created by `create issue` and persisted beside the raw request and intake artifacts so downstream issue-stage consumers do not depend on `issue-intake.json` internals.
 
 `issue-review.json` is the same-run pre-planning review artifact for planner-safety gating. It is created by `review issue <run-id>` from the persisted `issue-draft.json` and must be stage-approved before the later planning ingress persists canonical `approved-plan.json` for that run.
+
+`plan-review.json` is the same-run pre-implementation review artifact for implement ingress gating. It is created by `review plan <run-id>` from the persisted canonical `approved-plan.json` and must be stage-approved before implement-stage code consumes that approved plan for the same run.
 
 ## Design Choices
 

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -23,6 +23,7 @@ from .coordinator import (
     PublishRunParams,
     RepairIssueParams,
     ReviewIssueParams,
+    ReviewPlanParams,
     RunCoordinator,
 )
 from .env import load_local_env
@@ -196,6 +197,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory where run artifacts are stored.",
     )
     review_issue_parser.set_defaults(handler=_review_issue)
+
+    review_plan_parser = review_subparsers.add_parser(
+        "plan",
+        help="Review the stored approved-plan.json artifact for a run ID.",
+    )
+    review_plan_parser.add_argument("run_id", help="Existing run ID to review.")
+    review_plan_parser.add_argument(
+        "--runs-dir",
+        default=argparse.SUPPRESS,
+        help="Directory where run artifacts are stored.",
+    )
+    review_plan_parser.set_defaults(handler=_review_plan)
 
     plan_parser = subparsers.add_parser(
         "plan",
@@ -413,6 +426,29 @@ def _review_issue(args: argparse.Namespace) -> int:
     print(f"Review Status: {review.review_status}")
     print(f"Review Summary: {review.summary}")
     print("Artifacts: issue-review.json")
+    if review.feedback:
+        print("Feedback:")
+        for item in review.feedback:
+            field_suffix = f" ({item.field})" if item.field else ""
+            print(f"- {item.code}: {item.message} [{item.artifact}{field_suffix}]")
+    return report.exit_code
+
+
+def _review_plan(args: argparse.Namespace) -> int:
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(
+            run_id=args.run_id,
+            runs_dir=Path(args.runs_dir),
+        )
+    )
+    review = report.plan_review
+
+    print(f"Run ID: {report.run_record.run_id}")
+    print(f"Run Dir: {report.run_record.run_dir}")
+    print(f"Issue: {report.run_record.issue_ref}")
+    print(f"Review Status: {review.review_status}")
+    print(f"Review Summary: {review.summary}")
+    print("Artifacts: plan-review.json")
     if review.feedback:
         print("Feedback:")
         for item in review.feedback:
@@ -959,6 +995,10 @@ def _validate_review_issue_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
 
+def _validate_review_plan_args(args: dict[str, Any]) -> None:
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+
+
 def _validate_plan_run_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
@@ -985,6 +1025,11 @@ def _publish_run_config_root(args: argparse.Namespace) -> Path:
 
 
 def _review_issue_config_root(args: argparse.Namespace) -> Path:
+    del args
+    return Path.cwd()
+
+
+def _review_plan_config_root(args: argparse.Namespace) -> Path:
     del args
     return Path.cwd()
 
@@ -1053,6 +1098,13 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
         defaults={"runs_dir": ".precision-squad/runs"},
         validate=_validate_review_issue_args,
         discovery_root=_review_issue_config_root,
+    ),
+    _review_plan: _CommandConfigSpec(
+        table=("review", "plan"),
+        supported_keys=frozenset({"runs_dir"}),
+        defaults={"runs_dir": ".precision-squad/runs"},
+        validate=_validate_review_plan_args,
+        discovery_root=_review_plan_config_root,
     ),
     _plan_run: _CommandConfigSpec(
         table=("plan",),

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -20,6 +20,9 @@ from .models import (
     IssueReview,
     IssueReviewFeedback,
     IssueReviewProvenance,
+    PlanReview,
+    PlanReviewFeedback,
+    PlanReviewProvenance,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -33,6 +36,11 @@ from .repair import RepairAdapter
 from .run_store import (
     ApprovedPlanNotFoundError,
     ApprovedPlanValidationError,
+    IssueReviewNotFoundError,
+    IssueReviewValidationError,
+    PlanReviewNotApprovedError,
+    PlanReviewNotFoundError,
+    PlanReviewValidationError,
     RunStore,
 )
 
@@ -208,6 +216,19 @@ class ReviewIssueReport:
 
 
 @dataclass(frozen=True, slots=True)
+class ReviewPlanParams:
+    run_id: str
+    runs_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewPlanReport:
+    run_record: RunRecord
+    plan_review: PlanReview
+    exit_code: int = 0
+
+
+@dataclass(frozen=True, slots=True)
 class PersistApprovedPlanParams:
     run_id: str
     runs_dir: Path
@@ -235,6 +256,19 @@ class RunCoordinator:
         else:
             exit_code = 3
         return ReviewIssueReport(run_record=record, issue_review=review, exit_code=exit_code)
+
+    def review_plan(self, *, params: ReviewPlanParams) -> ReviewPlanReport:
+        store = RunStore(params.runs_dir)
+        record = store.load_run(params.run_id)
+        review = _derive_plan_review(store=store, record=record)
+        store.write_plan_review(Path(record.run_dir).resolve(), review)
+        if review.review_status == "approved":
+            exit_code = 0
+        elif review.review_status == "changes_requested":
+            exit_code = 2
+        else:
+            exit_code = 3
+        return ReviewPlanReport(run_record=record, plan_review=review, exit_code=exit_code)
 
     def persist_approved_plan_for_planning(self, *, params: PersistApprovedPlanParams) -> Path:
         store = RunStore(params.runs_dir)
@@ -867,6 +901,179 @@ def _issue_review_summary(*, status: str, finding_count: int) -> str:
     return (
         "Planning must stop because review issue is blocked by "
         f"{finding_count} blocking {noun} in issue-draft.json."
+    )
+
+
+def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
+    blocked_findings: list[PlanReviewFeedback] = []
+    change_findings: list[PlanReviewFeedback] = []
+    run_dir = Path(record.run_dir).resolve()
+
+    try:
+        issue_review = store.load_issue_review(
+            run_dir,
+            issue_ref=record.issue_ref,
+            expected_run_id=record.run_id,
+        )
+    except IssueReviewNotFoundError:
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="issue_review_missing",
+                message=(
+                    "review issue must persist an approved issue-review.json before review plan "
+                    "can run."
+                ),
+                artifact="issue-review.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+    except IssueReviewValidationError as exc:
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="issue_review_invalid",
+                message=f"issue-review.json could not be validated for plan review: {exc}",
+                artifact="issue-review.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+
+    if issue_review.review_status != "approved":
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="issue_review_not_approved",
+                message=(
+                    "review plan requires issue-review.json.review_status to be 'approved' "
+                    "for the same run."
+                ),
+                artifact="issue-review.json",
+                field="review_status",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+
+    try:
+        approved_plan = store.load_approved_plan(run_dir, issue_ref=record.issue_ref)
+    except ApprovedPlanNotFoundError:
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_missing",
+                message=(
+                    "plan must persist approved-plan.json for the same run before review plan "
+                    "can run."
+                ),
+                artifact="approved-plan.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+    except ApprovedPlanValidationError as exc:
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_invalid",
+                message=f"approved-plan.json could not be validated for plan review: {exc}",
+                artifact="approved-plan.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+
+    _collect_plan_review_findings(
+        approved_plan=approved_plan,
+        record=record,
+        blocked_findings=blocked_findings,
+        change_findings=change_findings,
+    )
+    if blocked_findings:
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+    if change_findings:
+        return _plan_review_artifact(
+            record=record,
+            status="changes_requested",
+            feedback=tuple(change_findings),
+        )
+    return _plan_review_artifact(record=record, status="approved", feedback=())
+
+
+def _collect_plan_review_findings(
+    *,
+    approved_plan: ApprovedPlan,
+    record: RunRecord,
+    blocked_findings: list[PlanReviewFeedback],
+    change_findings: list[PlanReviewFeedback],
+) -> None:
+    if not _same_local_issue_ref(approved_plan.issue_ref, record.issue_ref):
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_issue_mismatch",
+                message="approved-plan.json issue_ref does not match the stored run issue_ref.",
+                artifact="approved-plan.json",
+                field="issue_ref",
+            )
+        )
+        return
+
+    if not approved_plan.retrieval_surface_summary.strip():
+        change_findings.append(
+            _plan_review_feedback(
+                code="missing_retrieval_surface_summary",
+                message=(
+                    "approved-plan.json must include a non-empty retrieval_surface_summary so "
+                    "implement ingress does not have to guess the reviewed plan surface."
+                ),
+                artifact="approved-plan.json",
+                field="retrieval_surface_summary",
+            )
+        )
+
+
+def _plan_review_feedback(
+    *,
+    code: str,
+    message: str,
+    artifact: str,
+    field: str,
+) -> PlanReviewFeedback:
+    return PlanReviewFeedback(code=code, message=message, artifact=artifact, field=field)
+
+
+def _plan_review_artifact(
+    *,
+    record: RunRecord,
+    status: str,
+    feedback: tuple[PlanReviewFeedback, ...],
+) -> PlanReview:
+    return PlanReview(
+        run_id=record.run_id,
+        issue_ref=record.issue_ref,
+        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
+        summary=_plan_review_summary(status=status, finding_count=len(feedback)),
+        feedback=feedback,
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id=record.run_id,
+            issue_ref=record.issue_ref,
+        ),
+    )
+
+
+def _plan_review_summary(*, status: str, finding_count: int) -> str:
+    if status == "approved":
+        return (
+            "Implementation may proceed because approved-plan.json passed the same-run "
+            "plan review gate."
+        )
+    if status == "changes_requested":
+        noun = "finding" if finding_count == 1 else "findings"
+        return (
+            "Implementation must stop because approved-plan.json has "
+            f"{finding_count} implementation-ingress {noun} that require changes."
+        )
+    noun = "finding" if finding_count == 1 else "findings"
+    return (
+        "Implementation must stop because review plan is blocked by "
+        f"{finding_count} prerequisite {noun}."
     )
 
 

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -1126,6 +1126,7 @@ def _is_change_level_approved_plan_validation_error(exc: ApprovedPlanValidationE
         "Approved plan is missing a non-empty 'plan_summary'",
         "Approved plan is missing required field 'implementation_steps'",
         "Approved plan has no implementation steps",
+        "Approved plan implementation_steps[1] must be a non-empty string",
     }
 
 

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -1020,7 +1020,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
     except ApprovedPlanValidationError as exc:
-        if not change_findings:
+        if not (_is_change_level_approved_plan_validation_error(exc) and change_findings):
             blocked_findings.append(
                 _plan_review_feedback(
                     code="approved_plan_invalid",
@@ -1117,6 +1117,16 @@ def _collect_plan_review_findings(
 
 def _has_usable_implementation_steps(value: object) -> bool:
     return isinstance(value, list) and any(isinstance(step, str) and step.strip() for step in value)
+
+
+def _is_change_level_approved_plan_validation_error(exc: ApprovedPlanValidationError) -> bool:
+    message = str(exc)
+    return message in {
+        "Approved plan is missing required field 'plan_summary'",
+        "Approved plan is missing a non-empty 'plan_summary'",
+        "Approved plan is missing required field 'implementation_steps'",
+        "Approved plan has no implementation steps",
+    }
 
 
 def _plan_review_feedback(

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Literal, Protocol, cast
@@ -908,6 +909,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
     blocked_findings: list[PlanReviewFeedback] = []
     change_findings: list[PlanReviewFeedback] = []
     run_dir = Path(record.run_dir).resolve()
+    approved_plan_path = run_dir / "approved-plan.json"
 
     try:
         issue_review = store.load_issue_review(
@@ -953,8 +955,57 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
 
+    if not approved_plan_path.exists():
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_missing",
+                message=(
+                    "plan must persist approved-plan.json for the same run before review plan "
+                    "can run."
+                ),
+                artifact="approved-plan.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
     try:
-        approved_plan = store.load_approved_plan(run_dir, issue_ref=record.issue_ref)
+        with approved_plan_path.open(encoding="utf-8") as f:
+            approved_plan_payload = json.load(f)
+    except JSONDecodeError as exc:
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_invalid",
+                message=(
+                    "approved-plan.json could not be validated for plan review: "
+                    f"invalid JSON ({exc.msg})"
+                ),
+                artifact="approved-plan.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+    if not isinstance(approved_plan_payload, dict):
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_invalid",
+                message="approved-plan.json could not be validated for plan review: expected a JSON object.",
+                artifact="approved-plan.json",
+                field="",
+            )
+        )
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+
+    _collect_plan_review_findings(
+        approved_plan_payload=approved_plan_payload,
+        record=record,
+        blocked_findings=blocked_findings,
+        change_findings=change_findings,
+    )
+    if blocked_findings:
+        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+
+    try:
+        store.load_approved_plan(run_dir, issue_ref=record.issue_ref)
     except ApprovedPlanNotFoundError:
         blocked_findings.append(
             _plan_review_feedback(
@@ -969,22 +1020,17 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
     except ApprovedPlanValidationError as exc:
-        blocked_findings.append(
-            _plan_review_feedback(
-                code="approved_plan_invalid",
-                message=f"approved-plan.json could not be validated for plan review: {exc}",
-                artifact="approved-plan.json",
-                field="",
+        if not change_findings:
+            blocked_findings.append(
+                _plan_review_feedback(
+                    code="approved_plan_invalid",
+                    message=f"approved-plan.json could not be validated for plan review: {exc}",
+                    artifact="approved-plan.json",
+                    field="",
+                )
             )
-        )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+            return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
 
-    _collect_plan_review_findings(
-        approved_plan=approved_plan,
-        record=record,
-        blocked_findings=blocked_findings,
-        change_findings=change_findings,
-    )
     if blocked_findings:
         return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
     if change_findings:
@@ -998,12 +1044,24 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
 
 def _collect_plan_review_findings(
     *,
-    approved_plan: ApprovedPlan,
+    approved_plan_payload: dict[str, object],
     record: RunRecord,
     blocked_findings: list[PlanReviewFeedback],
     change_findings: list[PlanReviewFeedback],
 ) -> None:
-    if not _same_local_issue_ref(approved_plan.issue_ref, record.issue_ref):
+    approved_plan_issue_ref = approved_plan_payload.get("issue_ref")
+    if not isinstance(approved_plan_issue_ref, str) or not approved_plan_issue_ref.strip():
+        blocked_findings.append(
+            _plan_review_feedback(
+                code="approved_plan_issue_missing",
+                message="approved-plan.json must include a non-empty issue_ref for the reviewed run.",
+                artifact="approved-plan.json",
+                field="issue_ref",
+            )
+        )
+        return
+
+    if not _same_local_issue_ref(approved_plan_issue_ref, record.issue_ref):
         blocked_findings.append(
             _plan_review_feedback(
                 code="approved_plan_issue_mismatch",
@@ -1014,7 +1072,36 @@ def _collect_plan_review_findings(
         )
         return
 
-    if not approved_plan.retrieval_surface_summary.strip():
+    plan_summary = approved_plan_payload.get("plan_summary")
+    if not isinstance(plan_summary, str) or not plan_summary.strip():
+        change_findings.append(
+            _plan_review_feedback(
+                code="missing_plan_summary",
+                message=(
+                    "approved-plan.json must include a non-empty plan_summary so implement "
+                    "ingress receives the reviewed implementation summary explicitly."
+                ),
+                artifact="approved-plan.json",
+                field="plan_summary",
+            )
+        )
+
+    implementation_steps = approved_plan_payload.get("implementation_steps")
+    if not _has_usable_implementation_steps(implementation_steps):
+        change_findings.append(
+            _plan_review_feedback(
+                code="missing_implementation_steps",
+                message=(
+                    "approved-plan.json must include at least one usable implementation step so "
+                    "implement ingress does not have to reconstruct the reviewed plan."
+                ),
+                artifact="approved-plan.json",
+                field="implementation_steps",
+            )
+        )
+
+    retrieval_surface_summary = approved_plan_payload.get("retrieval_surface_summary")
+    if not isinstance(retrieval_surface_summary, str) or not retrieval_surface_summary.strip():
         change_findings.append(
             _plan_review_feedback(
                 code="missing_retrieval_surface_summary",
@@ -1026,6 +1113,10 @@ def _collect_plan_review_findings(
                 field="retrieval_surface_summary",
             )
         )
+
+
+def _has_usable_implementation_steps(value: object) -> bool:
+    return isinstance(value, list) and any(isinstance(step, str) and step.strip() for step in value)
 
 
 def _plan_review_feedback(

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
@@ -1130,12 +1131,12 @@ def _collect_plan_review_findings(
         )
 
     implementation_steps = approved_plan_payload.get("implementation_steps")
-    if not _has_usable_implementation_steps(implementation_steps):
+    if _has_correctable_implementation_steps_defect(implementation_steps):
         change_findings.append(
             _plan_review_feedback(
                 code="missing_implementation_steps",
                 message=(
-                    "approved-plan.json must include at least one usable implementation step so "
+                    "approved-plan.json must normalize to only usable implementation steps so "
                     "implement ingress does not have to reconstruct the reviewed plan."
                 ),
                 artifact="approved-plan.json",
@@ -1162,15 +1163,31 @@ def _has_usable_implementation_steps(value: object) -> bool:
     return isinstance(value, list) and any(isinstance(step, str) and step.strip() for step in value)
 
 
+def _has_correctable_implementation_steps_defect(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    if not value:
+        return True
+    if not all(isinstance(step, str) for step in value):
+        return False
+    return any(not step.strip() for step in value) or not _has_usable_implementation_steps(value)
+
+
 def _is_change_level_approved_plan_validation_error(exc: ApprovedPlanValidationError) -> bool:
     message = str(exc)
-    return message in {
+    if message in {
         "Approved plan is missing required field 'plan_summary'",
         "Approved plan is missing a non-empty 'plan_summary'",
         "Approved plan is missing required field 'implementation_steps'",
         "Approved plan has no implementation steps",
-        "Approved plan implementation_steps[1] must be a non-empty string",
-    }
+    }:
+        return True
+    return bool(
+        re.fullmatch(
+            r"Approved plan implementation_steps\[\d+\] must be a non-empty string",
+            message,
+        )
+    )
 
 
 def _plan_review_feedback(

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Literal, Protocol, cast
@@ -39,9 +39,6 @@ from .run_store import (
     ApprovedPlanValidationError,
     IssueReviewNotFoundError,
     IssueReviewValidationError,
-    PlanReviewNotApprovedError,
-    PlanReviewNotFoundError,
-    PlanReviewValidationError,
     RunStore,
 )
 
@@ -929,7 +926,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
     except IssueReviewValidationError as exc:
         blocked_findings.append(
             _plan_review_feedback(
@@ -939,7 +940,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
 
     if issue_review.review_status != "approved":
         blocked_findings.append(
@@ -953,7 +958,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="review_status",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
 
     if not approved_plan_path.exists():
         blocked_findings.append(
@@ -967,7 +976,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
     try:
         with approved_plan_path.open(encoding="utf-8") as f:
             approved_plan_payload = json.load(f)
@@ -983,17 +996,28 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
     if not isinstance(approved_plan_payload, dict):
         blocked_findings.append(
             _plan_review_feedback(
                 code="approved_plan_invalid",
-                message="approved-plan.json could not be validated for plan review: expected a JSON object.",
+                message=(
+                    "approved-plan.json could not be validated for plan review: "
+                    "expected a JSON object."
+                ),
                 artifact="approved-plan.json",
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
 
     _collect_plan_review_findings(
         approved_plan_payload=approved_plan_payload,
@@ -1002,7 +1026,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         change_findings=change_findings,
     )
     if blocked_findings:
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
 
     try:
         store.load_approved_plan(run_dir, issue_ref=record.issue_ref)
@@ -1018,7 +1046,11 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                 field="",
             )
         )
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
     except ApprovedPlanValidationError as exc:
         if not (_is_change_level_approved_plan_validation_error(exc) and change_findings):
             blocked_findings.append(
@@ -1029,10 +1061,18 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
                     field="",
                 )
             )
-            return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+            return _plan_review_artifact(
+                record=record,
+                status="blocked",
+                feedback=tuple(blocked_findings),
+            )
 
     if blocked_findings:
-        return _plan_review_artifact(record=record, status="blocked", feedback=tuple(blocked_findings))
+        return _plan_review_artifact(
+            record=record,
+            status="blocked",
+            feedback=tuple(blocked_findings),
+        )
     if change_findings:
         return _plan_review_artifact(
             record=record,
@@ -1054,7 +1094,10 @@ def _collect_plan_review_findings(
         blocked_findings.append(
             _plan_review_feedback(
                 code="approved_plan_issue_missing",
-                message="approved-plan.json must include a non-empty issue_ref for the reviewed run.",
+                message=(
+                    "approved-plan.json must include a non-empty issue_ref for the "
+                    "reviewed run."
+                ),
                 artifact="approved-plan.json",
                 field="issue_ref",
             )

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -106,6 +106,37 @@ class IssueReview:
 
 
 @dataclass(frozen=True, slots=True)
+class PlanReviewFeedback:
+    """One deterministic implementation-ingress finding for plan review."""
+
+    code: str
+    message: str
+    artifact: str
+    field: str
+
+
+@dataclass(frozen=True, slots=True)
+class PlanReviewProvenance:
+    """Explicit provenance for a plan review artifact."""
+
+    source_artifact: str
+    run_id: str
+    issue_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class PlanReview:
+    """Deterministic same-run implementation-ingress review artifact."""
+
+    run_id: str
+    issue_ref: str
+    review_status: Literal["approved", "changes_requested", "blocked"]
+    summary: str
+    feedback: tuple[PlanReviewFeedback, ...]
+    provenance: PlanReviewProvenance
+
+
+@dataclass(frozen=True, slots=True)
 class RunRequest:
     """Operator request to run one issue through the control plane."""
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -287,7 +287,21 @@ class RunStore:
 
     @staticmethod
     def require_plan_review_for_implement(run_dir: Path, *, issue_ref: str) -> PlanReview:
-        record = _read_run_record(run_dir / "run-record.json")
+        record_path = run_dir / "run-record.json"
+        try:
+            record = _read_run_record(record_path)
+        except FileNotFoundError as exc:
+            raise PlanReviewValidationError(
+                f"Implement ingress requires a valid run-record.json at {record_path}."
+            ) from exc
+        except JSONDecodeError as exc:
+            raise PlanReviewValidationError(
+                f"Implement ingress requires run-record.json at {record_path} to be valid JSON: {exc.msg}"
+            ) from exc
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PlanReviewValidationError(
+                f"Implement ingress requires run-record.json at {record_path} to be valid: {exc}"
+            ) from exc
         review = RunStore.load_plan_review(
             run_dir,
             issue_ref=issue_ref,

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -296,7 +296,8 @@ class RunStore:
             ) from exc
         except JSONDecodeError as exc:
             raise PlanReviewValidationError(
-                f"Implement ingress requires run-record.json at {record_path} to be valid JSON: {exc.msg}"
+                "Implement ingress requires run-record.json at "
+                f"{record_path} to be valid JSON: {exc.msg}"
             ) from exc
         except (KeyError, TypeError, ValueError) as exc:
             raise PlanReviewValidationError(

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -25,6 +25,9 @@ from .models import (
     IssueReviewFeedback,
     IssueReviewProvenance,
     NamedReference,
+    PlanReview,
+    PlanReviewFeedback,
+    PlanReviewProvenance,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -43,6 +46,7 @@ PersistedArtifact = (
     | IssueDraft
     | IssueIntake
     | IssueReview
+    | PlanReview
     | PostPublishReviewResult
     | PublishPlan
     | PublishResult
@@ -55,6 +59,7 @@ PersistedArtifact = (
 APPROVED_PLAN_FILENAME = "approved-plan.json"
 DECISION_LOG_FILENAME_TEMPLATE = "decision-log.attempt-{attempt}.json"
 ISSUE_REVIEW_FILENAME = "issue-review.json"
+PLAN_REVIEW_FILENAME = "plan-review.json"
 _ALLOWED_NAMED_REFERENCE_TYPES = {"file", "interface", "symbol", "example"}
 
 
@@ -84,6 +89,22 @@ class IssueReviewValidationError(IssueReviewError):
 
 class ApprovedPlanGateError(ValueError):
     """Raised when approved-plan persistence is attempted without review approval."""
+
+
+class PlanReviewError(ValueError):
+    """Base error for plan-review artifact loading or gate failures."""
+
+
+class PlanReviewNotFoundError(PlanReviewError):
+    """Raised when a plan-review artifact is missing."""
+
+
+class PlanReviewValidationError(PlanReviewError):
+    """Raised when a plan-review artifact fails canonical validation."""
+
+
+class PlanReviewNotApprovedError(PlanReviewError):
+    """Raised when a valid plan-review artifact is not approved for implement ingress."""
 
 
 class RunStore:
@@ -189,6 +210,9 @@ class RunStore:
     def write_issue_review(self, run_dir: Path, review: IssueReview) -> None:
         self._write_json(run_dir / ISSUE_REVIEW_FILENAME, review)
 
+    def write_plan_review(self, run_dir: Path, review: PlanReview) -> None:
+        self._write_json(run_dir / PLAN_REVIEW_FILENAME, review)
+
     @staticmethod
     def load_issue_review(
         run_dir: Path,
@@ -234,6 +258,45 @@ class RunStore:
             raise ApprovedPlanGateError(
                 "Approved plan persistence requires issue-review.json.review_status to be "
                 f"'approved'; found '{review.review_status}' for {issue_ref}."
+            )
+        return review
+
+    @staticmethod
+    def load_plan_review(
+        run_dir: Path,
+        *,
+        issue_ref: str,
+        expected_run_id: str | None = None,
+    ) -> PlanReview:
+        path = run_dir / PLAN_REVIEW_FILENAME
+        if not path.exists():
+            raise PlanReviewNotFoundError(f"Plan review artifact not found: {path}")
+        try:
+            with path.open(encoding="utf-8") as f:
+                payload = json.load(f)
+        except JSONDecodeError as exc:
+            raise PlanReviewValidationError(
+                f"Plan review artifact at {path} is not valid JSON: {exc.msg}"
+            ) from exc
+        return _parse_plan_review_payload(
+            payload,
+            path=path,
+            issue_ref=issue_ref,
+            expected_run_id=expected_run_id,
+        )
+
+    @staticmethod
+    def require_plan_review_for_implement(run_dir: Path, *, issue_ref: str) -> PlanReview:
+        record = _read_run_record(run_dir / "run-record.json")
+        review = RunStore.load_plan_review(
+            run_dir,
+            issue_ref=issue_ref,
+            expected_run_id=record.run_id,
+        )
+        if review.review_status != "approved":
+            raise PlanReviewNotApprovedError(
+                "Implement ingress requires plan-review.json.review_status to be 'approved'; "
+                f"found '{review.review_status}' for {issue_ref}."
             )
         return review
 
@@ -522,6 +585,108 @@ def _parse_issue_review_payload(
         feedback=tuple(feedback),
         provenance=IssueReviewProvenance(
             source_artifact=source_artifact,
+            run_id=provenance_run_id,
+            issue_ref=provenance_issue_ref,
+        ),
+    )
+
+
+def _parse_plan_review_payload(
+    payload: object,
+    *,
+    path: Path,
+    issue_ref: str,
+    expected_run_id: str | None,
+) -> PlanReview:
+    if not isinstance(payload, dict):
+        raise PlanReviewValidationError(f"Expected JSON object in {path}")
+
+    review_issue_ref = payload.get("issue_ref")
+    if not isinstance(review_issue_ref, str):
+        raise PlanReviewValidationError("Plan review field 'issue_ref' must be a string")
+    if review_issue_ref != issue_ref:
+        raise PlanReviewValidationError(
+            "Plan review issue_ref "
+            f"'{review_issue_ref}' does not match expected issue_ref '{issue_ref}'"
+        )
+
+    run_id = payload.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise PlanReviewValidationError("Plan review field 'run_id' must be a non-empty string")
+    if expected_run_id is not None and run_id != expected_run_id:
+        raise PlanReviewValidationError(
+            f"Plan review run_id '{run_id}' does not match expected run_id '{expected_run_id}'"
+        )
+
+    review_status = payload.get("review_status")
+    if review_status not in {"approved", "changes_requested", "blocked"}:
+        raise PlanReviewValidationError(
+            "Plan review field 'review_status' must be 'approved', "
+            "'changes_requested', or 'blocked'"
+        )
+
+    summary = payload.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        raise PlanReviewValidationError("Plan review field 'summary' must be a non-empty string")
+
+    feedback_raw = payload.get("feedback")
+    if not isinstance(feedback_raw, list):
+        raise PlanReviewValidationError("Plan review field 'feedback' must be a list")
+    feedback: list[PlanReviewFeedback] = []
+    for index, item in enumerate(feedback_raw, start=1):
+        if not isinstance(item, dict):
+            raise PlanReviewValidationError(f"Plan review feedback[{index}] must be an object")
+        code = item.get("code")
+        message = item.get("message")
+        artifact = item.get("artifact")
+        field = item.get("field")
+        if not isinstance(code, str) or not code.strip():
+            raise PlanReviewValidationError(
+                f"Plan review feedback[{index}].code must be a non-empty string"
+            )
+        if not isinstance(message, str) or not message.strip():
+            raise PlanReviewValidationError(
+                f"Plan review feedback[{index}].message must be a non-empty string"
+            )
+        if not isinstance(artifact, str) or not artifact.strip():
+            raise PlanReviewValidationError(
+                f"Plan review feedback[{index}].artifact must be a non-empty string"
+            )
+        if not isinstance(field, str):
+            raise PlanReviewValidationError(
+                f"Plan review feedback[{index}].field must be a string"
+            )
+        feedback.append(
+            PlanReviewFeedback(code=code, message=message, artifact=artifact, field=field)
+        )
+
+    provenance_raw = payload.get("provenance")
+    if not isinstance(provenance_raw, dict):
+        raise PlanReviewValidationError("Plan review field 'provenance' must be an object")
+    source_artifact = provenance_raw.get("source_artifact")
+    provenance_run_id = provenance_raw.get("run_id")
+    provenance_issue_ref = provenance_raw.get("issue_ref")
+    if source_artifact != APPROVED_PLAN_FILENAME:
+        raise PlanReviewValidationError(
+            f"Plan review provenance.source_artifact must be exactly '{APPROVED_PLAN_FILENAME}'"
+        )
+    if not isinstance(provenance_run_id, str) or provenance_run_id != run_id:
+        raise PlanReviewValidationError(
+            "Plan review provenance.run_id must match plan review run_id"
+        )
+    if not isinstance(provenance_issue_ref, str) or provenance_issue_ref != review_issue_ref:
+        raise PlanReviewValidationError(
+            "Plan review provenance.issue_ref must match plan review issue_ref"
+        )
+
+    return PlanReview(
+        run_id=run_id,
+        issue_ref=review_issue_ref,
+        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        summary=summary,
+        feedback=tuple(feedback),
+        provenance=PlanReviewProvenance(
+            source_artifact=cast(str, source_artifact),
             run_id=provenance_run_id,
             issue_ref=provenance_issue_ref,
         ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,9 @@ from precision_squad.models import (
     IssueReview,
     IssueReviewFeedback,
     IssueReviewProvenance,
+    PlanReview,
+    PlanReviewFeedback,
+    PlanReviewProvenance,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -267,6 +270,149 @@ def test_review_issue_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.M
     )
 
     status = main(["review", "issue", "run-123"])
+
+    captured = capsys.readouterr()
+    assert status == 3
+    assert Path(captured_runs_dir["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
+    assert "Review Status: blocked" in captured.out
+
+
+def test_review_plan_prints_approved_review_output(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan_review = PlanReview(
+        run_id="run-123",
+        issue_ref="cracklings3d/precision-squad#70",
+        review_status="approved",
+        summary="Implementation may proceed because approved-plan.json passed the same-run plan review gate.",
+        feedback=(),
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id="run-123",
+            issue_ref="cracklings3d/precision-squad#70",
+        ),
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_plan",
+        lambda self, *, params: __import__(
+            "precision_squad.coordinator", fromlist=["ReviewPlanReport"]
+        ).ReviewPlanReport(
+            run_record=RunRecord(
+                run_id="run-123",
+                issue_ref="cracklings3d/precision-squad#70",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs" / "run-123"),
+            ),
+            plan_review=plan_review,
+            exit_code=0,
+        ),
+    )
+
+    status = main(["review", "plan", "run-123", "--runs-dir", str(tmp_path / "runs")])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Review Status: approved" in captured.out
+    assert "Artifacts: plan-review.json" in captured.out
+
+
+def test_review_plan_prints_feedback_for_changes_requested(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan_review = PlanReview(
+        run_id="run-123",
+        issue_ref="cracklings3d/precision-squad#70",
+        review_status="changes_requested",
+        summary="Implementation must stop because approved-plan.json has 1 implementation-ingress finding that require changes.",
+        feedback=(
+            PlanReviewFeedback(
+                code="missing_retrieval_surface_summary",
+                message="approved-plan.json must include a non-empty retrieval_surface_summary so implement ingress does not have to guess the reviewed plan surface.",
+                artifact="approved-plan.json",
+                field="retrieval_surface_summary",
+            ),
+        ),
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id="run-123",
+            issue_ref="cracklings3d/precision-squad#70",
+        ),
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_plan",
+        lambda self, *, params: __import__(
+            "precision_squad.coordinator", fromlist=["ReviewPlanReport"]
+        ).ReviewPlanReport(
+            run_record=RunRecord(
+                run_id="run-123",
+                issue_ref="cracklings3d/precision-squad#70",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs" / "run-123"),
+            ),
+            plan_review=plan_review,
+            exit_code=2,
+        ),
+    )
+
+    status = main(["review", "plan", "run-123", "--runs-dir", str(tmp_path / "runs")])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "Review Status: changes_requested" in captured.out
+    assert "missing_retrieval_surface_summary" in captured.out
+
+
+def test_review_plan_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[review.plan]\nruns_dir = \".precision-squad/runs\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    captured_runs_dir: dict[str, str] = {}
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_plan",
+        lambda self, *, params: (
+            captured_runs_dir.__setitem__("runs_dir", str(params.runs_dir)),
+            __import__("precision_squad.coordinator", fromlist=["ReviewPlanReport"]).ReviewPlanReport(
+                run_record=RunRecord(
+                    run_id="run-123",
+                    issue_ref="owner/repo#1",
+                    status="runnable",
+                    created_at="2026-05-01T00:00:00Z",
+                    updated_at="2026-05-01T00:00:00Z",
+                    run_dir=str(tmp_path / ".precision-squad" / "runs" / "run-123"),
+                ),
+                plan_review=PlanReview(
+                    run_id="run-123",
+                    issue_ref="owner/repo#1",
+                    review_status="blocked",
+                    summary="Implementation must stop because review plan is blocked by 1 prerequisite finding.",
+                    feedback=(
+                        PlanReviewFeedback(
+                            code="approved_plan_missing",
+                            message="plan must persist approved-plan.json for the same run before review plan can run.",
+                            artifact="approved-plan.json",
+                            field="",
+                        ),
+                    ),
+                    provenance=PlanReviewProvenance(
+                        source_artifact="approved-plan.json",
+                        run_id="run-123",
+                        issue_ref="owner/repo#1",
+                    ),
+                ),
+                exit_code=3,
+            ),
+        )[1],
+    )
+
+    status = main(["review", "plan", "run-123"])
 
     captured = capsys.readouterr()
     assert status == 3
@@ -2350,6 +2496,177 @@ def test_plan_run_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Monke
     captured = capsys.readouterr()
     assert status == 0
     assert "Run ID: run-123" in captured.out
+
+
+def test_review_plan_end_to_end_persists_approved_plan_review(capsys, tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    request = RunRequest(
+        issue_ref="cracklings3d/precision-squad#70",
+        runs_dir=str(runs_dir),
+    )
+    intake = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("cracklings3d", "precision-squad", 70),
+            title="Add the review plan stage gate",
+            body="Persist a plan review artifact.",
+            labels=("enhancement",),
+            html_url="https://github.com/cracklings3d/precision-squad/issues/70",
+        ),
+        summary="Add the review plan stage gate",
+        problem_statement="Persist a plan review artifact.",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(request, intake)
+    run_dir = Path(record.run_dir)
+    (run_dir / "issue-review.json").write_text(
+        json.dumps(
+            {
+                "run_id": record.run_id,
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "review_status": "approved",
+                "summary": "Planning may proceed because issue-draft.json passed the local planner-safety review.",
+                "feedback": [],
+                "provenance": {
+                    "source_artifact": "issue-draft.json",
+                    "run_id": record.run_id,
+                    "issue_ref": "cracklings3d/precision-squad#70",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "plan_summary": "Keep the implement ingress narrowly gated.",
+                "implementation_steps": ["Add review plan command"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/precision_squad/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(["review", "plan", record.run_id, "--runs-dir", str(runs_dir)])
+
+    captured = capsys.readouterr()
+    payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
+    assert status == 0
+    assert payload["review_status"] == "approved"
+    assert payload["provenance"]["source_artifact"] == "approved-plan.json"
+    assert "Review Status: approved" in captured.out
+
+
+def test_review_plan_end_to_end_persists_changes_requested_when_plan_summary_surface_missing(
+    capsys, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "issue-review.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "review_status": "approved",
+                "summary": "Planning may proceed because issue-draft.json passed the local planner-safety review.",
+                "feedback": [],
+                "provenance": {
+                    "source_artifact": "issue-draft.json",
+                    "run_id": "run-123",
+                    "issue_ref": "cracklings3d/precision-squad#70",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "plan_summary": "Keep the implement ingress narrowly gated.",
+                "implementation_steps": ["Add review plan command"],
+                "named_references": [],
+                "retrieval_surface_summary": "",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(["review", "plan", "run-123", "--runs-dir", str(runs_dir)])
+
+    captured = capsys.readouterr()
+    payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
+    assert status == 2
+    assert payload["review_status"] == "changes_requested"
+    assert payload["feedback"][0]["code"] == "missing_retrieval_surface_summary"
+    assert "Review Status: changes_requested" in captured.out
+
+
+def test_review_plan_end_to_end_persists_blocked_when_approved_plan_missing(
+    capsys, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-123"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run-record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "status": "runnable",
+                "created_at": "2026-05-01T00:00:00Z",
+                "updated_at": "2026-05-01T00:00:00Z",
+                "run_dir": str(run_dir),
+                "attempt": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "issue-review.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "issue_ref": "cracklings3d/precision-squad#70",
+                "review_status": "approved",
+                "summary": "Planning may proceed because issue-draft.json passed the local planner-safety review.",
+                "feedback": [],
+                "provenance": {
+                    "source_artifact": "issue-draft.json",
+                    "run_id": "run-123",
+                    "issue_ref": "cracklings3d/precision-squad#70",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = main(["review", "plan", "run-123", "--runs-dir", str(runs_dir)])
+
+    captured = capsys.readouterr()
+    payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
+    assert status == 3
+    assert payload["review_status"] == "blocked"
+    assert payload["feedback"][0]["code"] == "approved_plan_missing"
+    assert "Review Status: blocked" in captured.out
 
 
 def test_install_skill_uses_config_defaults(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,8 @@ SUPPORTED_TABLES = {
             "approved_plan_path",
         }
     ),
+    ("review", "plan"): frozenset({"runs_dir"}),
+    ("review", "issue"): frozenset({"runs_dir"}),
     ("publish", "run"): frozenset({"runs_dir", "review_model"}),
     ("install-skill",): frozenset({"project_root", "force"}),
 }
@@ -234,6 +236,18 @@ def test_load_command_config_returns_only_active_command_table(tmp_path: Path) -
     )
 
     assert result == {"runs_dir": str((tmp_path / "runs").resolve())}
+
+
+def test_review_plan_config_uses_project_root_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        '[review.plan]\nruns_dir = ".precision-squad/runs"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    args = _resolve_cli_args(build_parser(), ["review", "plan", "run-123"])
+
+    assert args.runs_dir == str((tmp_path / ".precision-squad" / "runs").resolve())
 
 
 def test_load_command_config_preserves_absolute_paths(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,8 +28,6 @@ SUPPORTED_TABLES = {
             "approved_plan_path",
         }
     ),
-    ("review", "plan"): frozenset({"runs_dir"}),
-    ("review", "issue"): frozenset({"runs_dir"}),
     ("publish", "run"): frozenset({"runs_dir", "review_model"}),
     ("install-skill",): frozenset({"project_root", "force"}),
 }
@@ -236,18 +234,6 @@ def test_load_command_config_returns_only_active_command_table(tmp_path: Path) -
     )
 
     assert result == {"runs_dir": str((tmp_path / "runs").resolve())}
-
-
-def test_review_plan_config_uses_project_root_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    (tmp_path / ".precision-squad.toml").write_text(
-        '[review.plan]\nruns_dir = ".precision-squad/runs"\n',
-        encoding="utf-8",
-    )
-    monkeypatch.chdir(tmp_path)
-
-    args = _resolve_cli_args(build_parser(), ["review", "plan", "run-123"])
-
-    assert args.runs_dir == str((tmp_path / ".precision-squad" / "runs").resolve())
 
 
 def test_load_command_config_preserves_absolute_paths(tmp_path: Path) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -334,7 +334,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
 
 
 @pytest.mark.parametrize(
-    ("approved_plan_payload", "expected_code"),
+    ("approved_plan_payload", "expected_code", "expected_exit_code"),
     [
         (
             {
@@ -346,6 +346,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
                 "approved": True,
             },
             "missing_plan_summary",
+            2,
         ),
         (
             {
@@ -357,6 +358,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
                 "approved": True,
             },
             "missing_implementation_steps",
+            2,
         ),
         (
             {
@@ -368,6 +370,19 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
                 "approved": True,
             },
             "missing_implementation_steps",
+            2,
+        ),
+        (
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": ["Step 1", "   "],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "missing_implementation_steps",
+            2,
         ),
         (
             {
@@ -379,6 +394,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
                 "approved": True,
             },
             "missing_retrieval_surface_summary",
+            2,
         ),
     ],
 )
@@ -386,6 +402,7 @@ def test_review_plan_returns_changes_requested_for_required_implementation_safet
     tmp_path: Path,
     approved_plan_payload: dict[str, object],
     expected_code: str,
+    expected_exit_code: int,
 ) -> None:
     runs_dir = tmp_path / "runs"
     store = RunStore(runs_dir)
@@ -418,9 +435,58 @@ def test_review_plan_returns_changes_requested_for_required_implementation_safet
         params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
     )
 
-    assert report.exit_code == 2
+    assert report.exit_code == expected_exit_code
     assert report.plan_review.review_status == "changes_requested"
     assert report.plan_review.feedback[0].code == expected_code
+
+
+def test_review_plan_returns_blocked_for_non_string_implementation_step_even_with_valid_ordering(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": ["Step 1", 2],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 3
+    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.feedback[0].code == "approved_plan_invalid"
+    assert "implementation_steps[2] must be a string" in report.plan_review.feedback[0].message
 
 
 def test_review_plan_returns_blocked_when_prerequisite_issue_review_missing(tmp_path: Path) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ import pytest
 from precision_squad.coordinator import (
     PersistApprovedPlanParams,
     RepairIssueParams,
+    ReviewPlanParams,
     RunCoordinator,
 )
 from precision_squad.models import (
@@ -21,6 +22,7 @@ from precision_squad.models import (
     IssueReference,
     IssueReview,
     IssueReviewProvenance,
+    PlanReview,
     PublishPlan,
     PublishResult,
     QaResult,
@@ -249,3 +251,101 @@ def test_persist_approved_plan_for_planning_rejects_issue_mismatch(tmp_path: Pat
                 approved_plan=_approved_plan(),
             )
         )
+
+
+def test_review_plan_persists_same_run_plan_review_artifact(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+    store.write_approved_plan(run_dir, _approved_plan())
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 0
+    assert isinstance(report.plan_review, PlanReview)
+    assert report.plan_review.review_status == "approved"
+    assert (run_dir / "plan-review.json").exists()
+
+
+def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+    store.write_approved_plan(
+        run_dir,
+        ApprovedPlan(
+            issue_ref="owner/repo#1",
+            plan_summary="Fix the bug with a minimal change.",
+            implementation_steps=("Update the implementation",),
+            named_references=(),
+            retrieval_surface_summary="",
+            approved=True,
+        ),
+    )
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 2
+    assert report.plan_review.review_status == "changes_requested"
+    assert report.plan_review.feedback[0].code == "missing_retrieval_surface_summary"
+
+
+def test_review_plan_returns_blocked_when_prerequisite_issue_review_missing(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_approved_plan(run_dir, _approved_plan())
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 3
+    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.feedback[0].code == "issue_review_missing"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -330,6 +331,85 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
     assert report.exit_code == 2
     assert report.plan_review.review_status == "changes_requested"
     assert report.plan_review.feedback[0].code == "missing_retrieval_surface_summary"
+
+
+@pytest.mark.parametrize(
+    ("approved_plan_payload", "expected_code"),
+    [
+        (
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "",
+                "implementation_steps": ["Update the implementation"],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "missing_plan_summary",
+        ),
+        (
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": [],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "missing_implementation_steps",
+        ),
+        (
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": ["Update the implementation"],
+                "named_references": [],
+                "retrieval_surface_summary": " ",
+                "approved": True,
+            },
+            "missing_retrieval_surface_summary",
+        ),
+    ],
+)
+def test_review_plan_returns_changes_requested_for_required_implementation_safety_defects(
+    tmp_path: Path,
+    approved_plan_payload: dict[str, object],
+    expected_code: str,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(approved_plan_payload),
+        encoding="utf-8",
+    )
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 2
+    assert report.plan_review.review_status == "changes_requested"
+    assert report.plan_review.feedback[0].code == expected_code
 
 
 def test_review_plan_returns_blocked_when_prerequisite_issue_review_missing(tmp_path: Path) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -351,6 +351,17 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
             {
                 "issue_ref": "owner/repo#1",
                 "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": ["   "],
+                "named_references": [],
+                "retrieval_surface_summary": "src/",
+                "approved": True,
+            },
+            "missing_implementation_steps",
+        ),
+        (
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
                 "implementation_steps": [],
                 "named_references": [],
                 "retrieval_surface_summary": "src/",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -429,3 +429,51 @@ def test_review_plan_returns_blocked_when_prerequisite_issue_review_missing(tmp_
     assert report.exit_code == 3
     assert report.plan_review.review_status == "blocked"
     assert report.plan_review.feedback[0].code == "issue_review_missing"
+
+
+def test_review_plan_returns_blocked_when_schema_invalid_plan_also_has_change_level_findings(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_issue_review(
+        run_dir,
+        IssueReview(
+            run_id=record.run_id,
+            issue_ref="owner/repo#1",
+            review_status="approved",
+            summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
+            feedback=(),
+            provenance=IssueReviewProvenance(
+                source_artifact="issue-draft.json",
+                run_id=record.run_id,
+                issue_ref="owner/repo#1",
+            ),
+        ),
+    )
+    (run_dir / "approved-plan.json").write_text(
+        json.dumps(
+            {
+                "issue_ref": "owner/repo#1",
+                "plan_summary": "Fix the bug with a minimal change.",
+                "implementation_steps": ["Update the implementation"],
+                "retrieval_surface_summary": "",
+                "approved": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = RunCoordinator().review_plan(
+        params=ReviewPlanParams(run_id=record.run_id, runs_dir=runs_dir)
+    )
+
+    assert report.exit_code == 3
+    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.feedback[0].code == "approved_plan_invalid"
+    assert "named_references" in report.plan_review.feedback[0].message

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -248,6 +248,27 @@ def test_require_plan_review_for_implement_requires_run_record_and_approved_revi
     assert review.review_status == "approved"
 
 
+@pytest.mark.parametrize(
+    ("writer", "match"),
+    [
+        (None, r"run-record\.json"),
+        ("{not-json", r"valid JSON"),
+    ],
+)
+def test_require_plan_review_for_implement_normalizes_missing_or_malformed_run_record(
+    tmp_path: Path, writer: str | None, match: str
+) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    if writer is not None:
+        (run_dir / "run-record.json").write_text(writer, encoding="utf-8")
+    store.write_plan_review(run_dir, _plan_review())
+
+    with pytest.raises(PlanReviewValidationError, match=match):
+        RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
+
+
 @pytest.mark.parametrize("status", ["changes_requested", "blocked"])
 def test_require_plan_review_for_implement_rejects_non_approved_status(
     tmp_path: Path, status: Literal["changes_requested", "blocked"]

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -24,6 +24,9 @@ from precision_squad.models import (
     IssueReview,
     IssueReviewFeedback,
     IssueReviewProvenance,
+    PlanReview,
+    PlanReviewFeedback,
+    PlanReviewProvenance,
     PublishPlan,
     PublishResult,
     QaResult,
@@ -35,6 +38,9 @@ from precision_squad.run_store import (
     ApprovedPlanValidationError,
     IssueReviewNotFoundError,
     IssueReviewValidationError,
+    PlanReviewNotApprovedError,
+    PlanReviewNotFoundError,
+    PlanReviewValidationError,
     RunStore,
     load_approved_plan_artifact,
 )
@@ -74,6 +80,35 @@ def _issue_review(
         feedback=feedback,
         provenance=IssueReviewProvenance(
             source_artifact="issue-draft.json",
+            run_id="run-123",
+            issue_ref="owner/repo#1",
+        ),
+    )
+
+
+def _plan_review(
+    *, status: Literal["approved", "changes_requested", "blocked"] = "approved"
+) -> PlanReview:
+    feedback = ()
+    if status != "approved":
+        feedback = (
+            PlanReviewFeedback(
+                code="missing_retrieval_surface_summary",
+                message="Retrieval surface summary is required.",
+                artifact="approved-plan.json",
+                field="retrieval_surface_summary",
+            ),
+        )
+    return PlanReview(
+        run_id="run-123",
+        issue_ref="owner/repo#1",
+        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
+        summary="Implementation may proceed because approved-plan.json passed the same-run plan review gate."
+        if status == "approved"
+        else "Implementation must stop because approved-plan.json has 1 implementation-ingress finding that require changes.",
+        feedback=feedback,
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
             run_id="run-123",
             issue_ref="owner/repo#1",
         ),
@@ -177,6 +212,76 @@ def test_write_and_load_issue_review_persists_same_run_artifact(tmp_path: Path) 
     assert loaded == _issue_review()
     assert payload["review_status"] == "approved"
     assert payload["provenance"]["source_artifact"] == "issue-draft.json"
+
+
+def test_write_and_load_plan_review_persists_same_run_artifact(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    store.write_plan_review(run_dir, _plan_review())
+
+    loaded = store.load_plan_review(run_dir, issue_ref="owner/repo#1")
+    payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
+    assert loaded == _plan_review()
+    assert payload["review_status"] == "approved"
+    assert payload["provenance"]["source_artifact"] == "approved-plan.json"
+
+
+def test_load_plan_review_missing_artifact_raises_not_found(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    with pytest.raises(PlanReviewNotFoundError, match="Plan review artifact not found"):
+        RunStore.load_plan_review(run_dir, issue_ref="owner/repo#1")
+
+
+def test_require_plan_review_for_implement_requires_run_record_and_approved_review(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    _write_run_record(run_dir)
+    store.write_plan_review(run_dir, _plan_review())
+
+    review = RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
+
+    assert review.review_status == "approved"
+
+
+@pytest.mark.parametrize("status", ["changes_requested", "blocked"])
+def test_require_plan_review_for_implement_rejects_non_approved_status(
+    tmp_path: Path, status: Literal["changes_requested", "blocked"]
+) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    _write_run_record(run_dir)
+    store.write_plan_review(run_dir, _plan_review(status=status))
+
+    with pytest.raises(PlanReviewNotApprovedError, match="review_status"):
+        RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
+
+
+def test_require_plan_review_for_implement_rejects_invalid_provenance(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    _write_run_record(run_dir)
+    payload = {
+        "run_id": "run-123",
+        "issue_ref": "owner/repo#1",
+        "review_status": "approved",
+        "summary": "Implementation may proceed because approved-plan.json passed the same-run plan review gate.",
+        "feedback": [],
+        "provenance": {
+            "source_artifact": "issue-review.json",
+            "run_id": "run-123",
+            "issue_ref": "owner/repo#1",
+        },
+    }
+    (run_dir / "plan-review.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PlanReviewValidationError, match="source_artifact"):
+        RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
 
 
 def test_load_issue_review_missing_artifact_raises_not_found(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #70

## Summary
- add the bounded `review plan` CLI stage and persisted `plan-review.json` artifact
- enforce the same-run pre-implementation gate so implementation only proceeds from a stage-approved reviewed canonical plan
- add focused run-store, coordinator, CLI, and documentation/test coverage for the new gate

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github.com-cracklings3d-precision-squad\plans\issue-70.md`

## Implementation decisions
- keep `review plan` stage-local and distinct from governance verdict vocabulary
- derive plan review from the same run's canonical `approved-plan.json` and same-run artifacts only
- gate the future `implement` ingress on same-run `plan-review.json` approval without widening into later-stage behavior

## Validation evidence
- approved implementation head: `9056db746d8b01d9e7659cdbd63d73242ee928a7`