### PR TITLE
feat: add review impl stage gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,27 +221,29 @@ It runs:
 - baseline QA against a clean clone of the original repo
 - final QA against the repaired workspace
 
-If the final state is strictly better than a broken baseline without introducing new failures, governance may classify the run as `provisional` instead of `approved`.
+If the final state is strictly better than a broken baseline without introducing new failures, that improvement is tracked as execution quality rather than as a separate governance verdict.
 
 This is a pragmatic escape hatch for broken repos, not a substitute for green QA.
 
+Baseline-tolerant repair no longer introduces a provisional governance verdict. Instead, quality is recorded on `ExecutionResult` as an informational tag (`green`, `improved`, or `degraded`) while governance remains a separate gate.
+
 ## Governance
 
-Governance has three outcomes:
+Governance has two outcomes:
 
 - `approved`
-- `provisional`
 - `blocked`
 
 Current intent:
 
 - `approved`: documented setup and QA evidence is present and passes
-- `provisional`: the run improved a broken baseline but is not fully green
 - `blocked`: intake, documentation, execution, or QA evidence is missing, ambiguous, unrunnable, or failed
+
+Quality is informational on `ExecutionResult`, not a governance verdict. A baseline-tolerant repair may therefore be quality-tagged as `improved` while governance still resolves to either `approved` or `blocked`.
 
 Publish behavior:
 
-- `approved` and `provisional` runs can produce draft PRs
+- `approved` runs can produce draft PRs
 - `blocked` docs-policy runs from otherwise runnable issues can produce follow-up repo issues instead
 - other `blocked` runs produce issue comments instead
 
@@ -255,7 +257,7 @@ The active fingerprint is no longer based only on a human-facing summary. It is 
 
 ## Publishing And Review
 
-Per [ADR-008](./adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md), `publish` sits between local `implement` work and `review impl`.
+Per [ADR-008](./adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md), `publish` sits between local `implement` work and the post-publish `review impl` stage.
 
 Publishing uses the stored implementation result rather than rerunning repair.
 
@@ -272,7 +274,7 @@ It then:
 - creates a draft PR
 - persists publish artifacts such as `publish-plan.json` and `publish-result.json`
 
-`review impl` happens only after that draft PR exists. Post-publish review consumes the published PR context and diff rather than an unpublished local-only workspace artifact.
+`review impl` happens only after that draft PR exists and reviews the same published draft PR for the same issue. The stage consumes persisted same-run context plus live published PR body, diff, locator, and head-SHA data rather than an unpublished local-only workspace artifact.
 
 After publish, local review agents can inspect the draft PR as:
 
@@ -283,7 +285,9 @@ If either rejects the PR, `precision-squad`:
 
 - posts structured feedback back to the GitHub issue
 - reopens or keeps open the issue
-- persists a `post-publish-review-result.json`
+- persists canonical `impl-review.json`
+
+`impl-review.json` is the canonical artifact for this stage. A derived `post-publish-review-result.json` compatibility mirror may still exist temporarily, but it is compatibility output rather than the canonical source of truth.
 
 Draft PR creation does not itself close the issue.
 
@@ -308,7 +312,9 @@ Important persisted artifacts include:
 - `repair-result.json`
 - `qa-baseline-result.json`
 - `qa-result.json`
-- `post-publish-review-result.json`
+- `impl-review.json`
+
+When compatibility output is still required by existing flows, `post-publish-review-result.json` may also be persisted as a derived mirror of `impl-review.json`.
 
 This is deliberate. The system prefers inspectability and replayability over hidden state.
 

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -36,10 +36,10 @@ from .models import (
     ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
+    ImplReviewResult,
     IssueAssessment,
     IssueIntake,
     IssueReference,
-    ImplReviewResult,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -49,7 +49,6 @@ from .models import (
 )
 from .post_publish_review import (
     OpenCodePrReviewAgent,
-    mirror_impl_review_to_post_publish,
     run_impl_review,
 )
 from .publish_executor import execute_publish_plan

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -23,6 +23,7 @@ from .coordinator import (
     PersistApprovedPlanParams,
     PublishRunParams,
     RepairIssueParams,
+    ReviewImplParams,
     ReviewIssueParams,
     ReviewPlanParams,
     RunCoordinator,
@@ -38,6 +39,7 @@ from .models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    ImplReviewResult,
     PostPublishReviewResult,
     PublishPlan,
     PublishResult,
@@ -45,7 +47,11 @@ from .models import (
     RepairResult,
     RunRecord,
 )
-from .post_publish_review import OpenCodePrReviewAgent, run_post_publish_review
+from .post_publish_review import (
+    OpenCodePrReviewAgent,
+    mirror_impl_review_to_post_publish,
+    run_impl_review,
+)
 from .publish_executor import execute_publish_plan
 from .repair import (
     OpenCodeRepairAdapter,
@@ -210,6 +216,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory where run artifacts are stored.",
     )
     review_plan_parser.set_defaults(handler=_review_plan)
+
+    review_impl_parser = review_subparsers.add_parser(
+        "impl",
+        help="Review the published draft PR for an existing run ID.",
+    )
+    review_impl_parser.add_argument("run_id", help="Existing run ID to review.")
+    review_impl_parser.add_argument(
+        "--runs-dir",
+        default=argparse.SUPPRESS,
+        help="Directory where run artifacts are stored.",
+    )
+    review_impl_parser.add_argument(
+        "--review-model",
+        default=argparse.SUPPRESS,
+        help="Optional model override for post-publish review agents.",
+    )
+    review_impl_parser.set_defaults(handler=_review_impl)
 
     plan_parser = subparsers.add_parser(
         "plan",
@@ -490,6 +513,35 @@ def _review_plan(args: argparse.Namespace) -> int:
     return report.exit_code
 
 
+def _review_impl(args: argparse.Namespace) -> int:
+    report = RunCoordinator().review_impl(
+        params=ReviewImplParams(
+            run_id=args.run_id,
+            runs_dir=Path(args.runs_dir),
+            review_model=args.review_model,
+        ),
+        dependencies=_CliPublishDependencies(),
+    )
+    review = report.impl_review
+
+    print(f"Run ID: {report.run_record.run_id}")
+    print(f"Run Dir: {report.run_record.run_dir}")
+    print(f"Issue: {report.run_record.issue_ref}")
+    print(f"Review Status: {review.review_status}")
+    print(f"Review Summary: {review.summary}")
+    if review.pull_request_url:
+        print(f"Publish URL: {review.pull_request_url}")
+    print(f"Downstream Automation Allowed: {review.allows_downstream_automation}")
+    print("Artifacts: impl-review.json")
+    if review.issue_comment_url:
+        print(f"Review Feedback URL: {review.issue_comment_url}")
+    if review.feedback:
+        print("Feedback:")
+        for item in review.feedback:
+            print(f"- {item.code}: {item.message} [{item.source}]")
+    return report.exit_code
+
+
 def _plan_run(args: argparse.Namespace) -> int:
     store = RunStore(Path(args.runs_dir))
     record = store.load_run(args.run_id)
@@ -640,7 +692,7 @@ class _CliRepairDependencies:
         run_dir: Path,
         publish_result: PublishResult,
         review_model: str | None,
-    ) -> PostPublishReviewResult | None:
+    ) -> ImplReviewResult | PostPublishReviewResult | None:
         return _run_post_publish_review_if_needed(
             intake=intake,
             run_record=run_record,
@@ -669,7 +721,7 @@ class _CliPublishDependencies:
         run_dir: Path,
         publish_result: PublishResult,
         review_model: str | None,
-    ) -> PostPublishReviewResult | None:
+    ) -> ImplReviewResult | PostPublishReviewResult | None:
         return _run_post_publish_review_if_needed(
             intake=intake,
             run_record=run_record,
@@ -682,6 +734,27 @@ class _CliPublishDependencies:
         self, intake: IssueIntake, review_result: PostPublishReviewResult
     ) -> bool:
         return _post_publish_review_is_stale(intake, review_result)
+
+    def run_impl_review(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        publish_plan: PublishPlan,
+        publish_result: PublishResult,
+        review_model: str | None,
+    ) -> ImplReviewResult:
+        return run_impl_review(
+            intake=intake,
+            run_record=run_record,
+            run_dir=run_dir,
+            publish_plan_pull_request_url=publish_plan.pull_request_url,
+            publish_plan_pull_number=publish_plan.pull_number,
+            publish_result=publish_result,
+            reviewer=OpenCodePrReviewAgent(role="reviewer", model=review_model),
+            architect=OpenCodePrReviewAgent(role="architect", model=review_model),
+        )
 
 
 def _install_skill(args: argparse.Namespace) -> int:
@@ -792,6 +865,24 @@ def _read_post_publish_review_result(run_dir: Path) -> PostPublishReviewResult |
         issue_comment_url=_as_optional_str(payload.get("issue_comment_url")),
         issue_reopened=_as_bool(payload.get("issue_reopened", False)),
     )
+
+
+def _read_impl_review_result(run_dir: Path) -> ImplReviewResult | None:
+    path = run_dir / "impl-review.json"
+    if not path.exists():
+        return None
+    return RunStore.load_impl_review(run_dir)
+
+
+def _read_publish_plan_for_impl_review(run_dir: Path) -> PublishPlan:
+    return _read_publish_plan(run_dir)
+
+
+def _read_publish_result_for_impl_review(run_dir: Path) -> PublishResult:
+    result = _read_publish_result(run_dir)
+    if result is None:
+        raise ValueError(f"Run {run_dir.name} is missing publish-result.json")
+    return result
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -995,7 +1086,7 @@ def _run_post_publish_review_if_needed(
     run_dir: Path,
     publish_result: PublishResult,
     review_model: str | None,
-) -> PostPublishReviewResult | None:
+) -> ImplReviewResult | None:
     if (
         publish_result.status != "published"
         or publish_result.target != "draft_pr"
@@ -1003,11 +1094,14 @@ def _run_post_publish_review_if_needed(
     ):
         return None
 
-    return run_post_publish_review(
+    publish_plan = _read_publish_plan_for_impl_review(run_dir)
+    return run_impl_review(
         intake=intake,
         run_record=run_record,
         run_dir=run_dir,
-        pull_request_url=publish_result.url,
+        publish_plan_pull_request_url=publish_plan.pull_request_url,
+        publish_plan_pull_number=publish_plan.pull_number,
+        publish_result=publish_result,
         reviewer=OpenCodePrReviewAgent(role="reviewer", model=review_model),
         architect=OpenCodePrReviewAgent(role="architect", model=review_model),
     )
@@ -1064,6 +1158,11 @@ def _validate_review_plan_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
 
+def _validate_review_impl_args(args: dict[str, Any]) -> None:
+    args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
+    _normalize_optional_str_arg(args, "review_model")
+
+
 def _validate_plan_run_args(args: dict[str, Any]) -> None:
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
 
@@ -1102,6 +1201,11 @@ def _review_issue_config_root(args: argparse.Namespace) -> Path:
 
 
 def _review_plan_config_root(args: argparse.Namespace) -> Path:
+    del args
+    return Path.cwd()
+
+
+def _review_impl_config_root(args: argparse.Namespace) -> Path:
     del args
     return Path.cwd()
 
@@ -1184,6 +1288,13 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
         defaults={"runs_dir": ".precision-squad/runs"},
         validate=_validate_review_plan_args,
         discovery_root=_review_plan_config_root,
+    ),
+    _review_impl: _CommandConfigSpec(
+        table=("review", "impl"),
+        supported_keys=frozenset({"runs_dir", "review_model"}),
+        defaults={"runs_dir": ".precision-squad/runs", "review_model": None},
+        validate=_validate_review_impl_args,
+        discovery_root=_review_impl_config_root,
     ),
     _plan_run: _CommandConfigSpec(
         table=("plan",),

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -19,6 +19,7 @@ from .models import (
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
+    ImplReviewResult,
     IssueAssessment,
     IssueDraft,
     IssueIntake,
@@ -37,6 +38,7 @@ from .models import (
     RunRecord,
     RunRequest,
 )
+from .post_publish_review import mirror_impl_review_to_post_publish
 from .publishing import RequiredDecisionLogArtifactMissingError, build_publish_plan
 from .repair import RepairAdapter
 from .run_store import (
@@ -119,7 +121,7 @@ class RepairDependencies(Protocol):
         run_dir: Path,
         publish_result: PublishResult,
         review_model: str | None,
-    ) -> PostPublishReviewResult | None: ...
+    ) -> ImplReviewResult | PostPublishReviewResult | None: ...
 
 
 class PublishDependencies(Protocol):
@@ -142,11 +144,22 @@ class PublishDependencies(Protocol):
         run_dir: Path,
         publish_result: PublishResult,
         review_model: str | None,
-    ) -> PostPublishReviewResult | None: ...
+    ) -> ImplReviewResult | PostPublishReviewResult | None: ...
 
     def post_publish_review_is_stale(
         self, intake: IssueIntake, review_result: PostPublishReviewResult
     ) -> bool: ...
+
+    def run_impl_review(
+        self,
+        *,
+        intake: IssueIntake,
+        run_record: RunRecord,
+        run_dir: Path,
+        publish_plan: PublishPlan,
+        publish_result: PublishResult,
+        review_model: str | None,
+    ) -> ImplReviewResult: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -255,6 +268,20 @@ class ReviewPlanReport:
 
 
 @dataclass(frozen=True, slots=True)
+class ReviewImplParams:
+    run_id: str
+    runs_dir: Path
+    review_model: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewImplReport:
+    run_record: RunRecord
+    impl_review: ImplReviewResult
+    exit_code: int = 0
+
+
+@dataclass(frozen=True, slots=True)
 class PersistApprovedPlanParams:
     run_id: str
     runs_dir: Path
@@ -295,6 +322,37 @@ class RunCoordinator:
         else:
             exit_code = 3
         return ReviewPlanReport(run_record=record, plan_review=review, exit_code=exit_code)
+
+    def review_impl(
+        self,
+        *,
+        params: ReviewImplParams,
+        dependencies: PublishDependencies,
+    ) -> ReviewImplReport:
+        store = RunStore(params.runs_dir)
+        record = store.load_run(params.run_id)
+        run_dir = Path(record.run_dir).resolve()
+        intake = _load_issue_intake_artifact(run_dir, expected_issue_ref=record.issue_ref)
+        RunStore.load_approved_plan(run_dir, issue_ref=record.issue_ref)
+        publish_plan = _load_publish_plan_artifact(run_dir)
+        publish_result = _load_publish_result_artifact(run_dir)
+        impl_review = dependencies.run_impl_review(
+            intake=intake,
+            run_record=record,
+            run_dir=run_dir,
+            publish_plan=publish_plan,
+            publish_result=publish_result,
+            review_model=params.review_model,
+        )
+        store.write_impl_review(run_dir, impl_review)
+        store.write_post_publish_review_result(run_dir, mirror_impl_review_to_post_publish(impl_review))
+        if impl_review.review_status == "approved":
+            exit_code = 0
+        elif impl_review.review_status == "changes_requested":
+            exit_code = 2
+        else:
+            exit_code = 3
+        return ReviewImplReport(run_record=record, impl_review=impl_review, exit_code=exit_code)
 
     def persist_approved_plan_for_planning(self, *, params: PersistApprovedPlanParams) -> Path:
         store = RunStore(params.runs_dir)
@@ -778,15 +836,18 @@ class RunCoordinator:
             run_dir=run_dir,
         )
         store.write_publish_result(run_dir, publish_result)
-        post_publish_review_result = dependencies.run_post_publish_review_if_needed(
+        compatibility_review_result = dependencies.run_post_publish_review_if_needed(
             intake=intake,
             run_record=record,
             run_dir=run_dir,
             publish_result=publish_result,
             review_model=params.review_model,
         )
-        if post_publish_review_result is not None:
-            store.write_post_publish_review_result(run_dir, post_publish_review_result)
+        post_publish_review_result = _persist_post_publish_compatibility_artifacts(
+            store=store,
+            run_dir=run_dir,
+            review_result=compatibility_review_result,
+        )
 
         return RepairIssueReport(
             intake=intake,
@@ -937,15 +998,18 @@ class RunCoordinator:
                 "failed_infra",
                 "not_run",
             } or dependencies.post_publish_review_is_stale(intake, review_result):
-                review_result = dependencies.run_post_publish_review_if_needed(
+                compatibility_review_result = dependencies.run_post_publish_review_if_needed(
                     intake=intake,
                     run_record=run_record,
                     run_dir=run_dir,
                     publish_result=existing_result,
                     review_model=params.review_model,
                 )
-                if review_result is not None:
-                    store.write_post_publish_review_result(run_dir, review_result)
+                review_result = _persist_post_publish_compatibility_artifacts(
+                    store=store,
+                    run_dir=run_dir,
+                    review_result=compatibility_review_result,
+                )
         else:
             result = dependencies.execute_publish_plan(
                 intake,
@@ -954,15 +1018,18 @@ class RunCoordinator:
                 run_dir=run_dir,
             )
             store.write_publish_result(run_dir, result)
-            review_result = dependencies.run_post_publish_review_if_needed(
+            compatibility_review_result = dependencies.run_post_publish_review_if_needed(
                 intake=intake,
                 run_record=run_record,
                 run_dir=run_dir,
                 publish_result=result,
                 review_model=params.review_model,
             )
-            if review_result is not None:
-                store.write_post_publish_review_result(run_dir, review_result)
+            review_result = _persist_post_publish_compatibility_artifacts(
+                store=store,
+                run_dir=run_dir,
+                review_result=compatibility_review_result,
+            )
 
         if result is None:
             raise ValueError(f"Run {params.run_id} is missing publish-result.json")
@@ -1529,6 +1596,99 @@ def _load_issue_intake_artifact(run_dir: Path, *, expected_issue_ref: str) -> Is
             "Implement ingress requires issue-intake.json to match the stored run issue_ref."
         )
     return intake
+
+
+def _load_publish_plan_artifact(run_dir: Path) -> PublishPlan:
+    path = run_dir / "publish-plan.json"
+    if not path.exists():
+        raise ValueError(f"Implementation review requires publish-plan.json at {path}.")
+    try:
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except JSONDecodeError as exc:
+        raise ValueError(
+            f"Implementation review requires publish-plan.json at {path} to be valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Implementation review requires publish-plan.json at {path} to be a JSON object.")
+    status = payload.get("status")
+    title = payload.get("title")
+    body = payload.get("body")
+    reason_codes = payload.get("reason_codes")
+    if status not in {"draft_pr", "issue_comment", "follow_up_issue"}:
+        raise ValueError("Implementation review requires publish-plan.json.status to be valid.")
+    if not isinstance(title, str) or not isinstance(body, str):
+        raise ValueError("Implementation review requires publish-plan.json title/body strings.")
+    if not isinstance(reason_codes, list) or not all(isinstance(item, str) for item in reason_codes):
+        raise ValueError("Implementation review requires publish-plan.json.reason_codes to be a list of strings.")
+    return PublishPlan(
+        status=cast(Literal["draft_pr", "issue_comment", "follow_up_issue"], status),
+        title=title,
+        body=body,
+        reason_codes=tuple(reason_codes),
+        branch_name=cast(str | None, payload.get("branch_name")),
+        pull_request_url=cast(str | None, payload.get("pull_request_url")),
+        pull_number=cast(int | None, payload.get("pull_number")),
+    )
+
+
+def _load_publish_result_artifact(run_dir: Path) -> PublishResult:
+    path = run_dir / "publish-result.json"
+    if not path.exists():
+        raise ValueError(f"Implementation review requires publish-result.json at {path}.")
+    try:
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except JSONDecodeError as exc:
+        raise ValueError(
+            f"Implementation review requires publish-result.json at {path} to be valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Implementation review requires publish-result.json at {path} to be a JSON object."
+        )
+    status = payload.get("status")
+    target = payload.get("target")
+    summary = payload.get("summary")
+    if status not in {"dry_run", "published"}:
+        raise ValueError("Implementation review requires publish-result.json.status to be valid.")
+    if target not in {"draft_pr", "issue_comment", "follow_up_issue"}:
+        raise ValueError("Implementation review requires publish-result.json.target to be valid.")
+    if not isinstance(summary, str):
+        raise ValueError("Implementation review requires publish-result.json.summary to be a string.")
+    return PublishResult(
+        status=cast(Literal["dry_run", "published"], status),
+        target=cast(Literal["draft_pr", "issue_comment", "follow_up_issue"], target),
+        summary=summary,
+        url=cast(str | None, payload.get("url")),
+        branch_name=cast(str | None, payload.get("branch_name")),
+        pull_number=cast(int | None, payload.get("pull_number")),
+    )
+
+
+def _persist_post_publish_compatibility_artifacts(
+    *,
+    store: RunStore,
+    run_dir: Path,
+    review_result: ImplReviewResult | PostPublishReviewResult | None,
+) -> PostPublishReviewResult | None:
+    if review_result is None:
+        return None
+    if isinstance(review_result, ImplReviewResult):
+        impl_review = review_result
+        legacy_review = mirror_impl_review_to_post_publish(review_result)
+    else:
+        legacy_review = review_result
+        impl_review = _map_legacy_post_publish_review(review_result)
+    store.write_impl_review(run_dir, impl_review)
+    store.write_post_publish_review_result(run_dir, legacy_review)
+    return legacy_review
+
+
+def _map_legacy_post_publish_review(review: PostPublishReviewResult) -> ImplReviewResult:
+    from .post_publish_review import _map_post_publish_to_impl_review
+
+    return _map_post_publish_to_impl_review(review)
 
 
 def _parse_issue_intake_payload(payload: object) -> IssueIntake:

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -345,7 +345,10 @@ class RunCoordinator:
             review_model=params.review_model,
         )
         store.write_impl_review(run_dir, impl_review)
-        store.write_post_publish_review_result(run_dir, mirror_impl_review_to_post_publish(impl_review))
+        store.write_post_publish_review_result(
+            run_dir,
+            mirror_impl_review_to_post_publish(impl_review),
+        )
         if impl_review.review_status == "approved":
             exit_code = 0
         elif impl_review.review_status == "changes_requested":
@@ -1607,10 +1610,14 @@ def _load_publish_plan_artifact(run_dir: Path) -> PublishPlan:
             payload = json.load(f)
     except JSONDecodeError as exc:
         raise ValueError(
-            f"Implementation review requires publish-plan.json at {path} to be valid JSON: {exc.msg}"
+            "Implementation review requires publish-plan.json at "
+            f"{path} to be valid JSON: {exc.msg}"
         ) from exc
     if not isinstance(payload, dict):
-        raise ValueError(f"Implementation review requires publish-plan.json at {path} to be a JSON object.")
+        raise ValueError(
+            "Implementation review requires publish-plan.json at "
+            f"{path} to be a JSON object."
+        )
     status = payload.get("status")
     title = payload.get("title")
     body = payload.get("body")
@@ -1619,8 +1626,13 @@ def _load_publish_plan_artifact(run_dir: Path) -> PublishPlan:
         raise ValueError("Implementation review requires publish-plan.json.status to be valid.")
     if not isinstance(title, str) or not isinstance(body, str):
         raise ValueError("Implementation review requires publish-plan.json title/body strings.")
-    if not isinstance(reason_codes, list) or not all(isinstance(item, str) for item in reason_codes):
-        raise ValueError("Implementation review requires publish-plan.json.reason_codes to be a list of strings.")
+    if not isinstance(reason_codes, list) or not all(
+        isinstance(item, str) for item in reason_codes
+    ):
+        raise ValueError(
+            "Implementation review requires publish-plan.json.reason_codes "
+            "to be a list of strings."
+        )
     return PublishPlan(
         status=cast(Literal["draft_pr", "issue_comment", "follow_up_issue"], status),
         title=title,
@@ -1641,7 +1653,8 @@ def _load_publish_result_artifact(run_dir: Path) -> PublishResult:
             payload = json.load(f)
     except JSONDecodeError as exc:
         raise ValueError(
-            f"Implementation review requires publish-result.json at {path} to be valid JSON: {exc.msg}"
+            "Implementation review requires publish-result.json at "
+            f"{path} to be valid JSON: {exc.msg}"
         ) from exc
     if not isinstance(payload, dict):
         raise ValueError(
@@ -1655,7 +1668,9 @@ def _load_publish_result_artifact(run_dir: Path) -> PublishResult:
     if target not in {"draft_pr", "issue_comment", "follow_up_issue"}:
         raise ValueError("Implementation review requires publish-result.json.target to be valid.")
     if not isinstance(summary, str):
-        raise ValueError("Implementation review requires publish-result.json.summary to be a string.")
+        raise ValueError(
+            "Implementation review requires publish-result.json.summary to be a string."
+        )
     return PublishResult(
         status=cast(Literal["dry_run", "published"], status),
         target=cast(Literal["draft_pr", "issue_comment", "follow_up_issue"], target),

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -362,6 +362,38 @@ class ApprovedPlan:
 
 
 @dataclass(frozen=True, slots=True)
+class ImplReviewFeedback:
+    """One structured feedback item for the canonical implementation-review stage."""
+
+    code: str
+    message: str
+    source: Literal["stage", "reviewer", "architect"]
+
+
+@dataclass(frozen=True, slots=True)
+class ImplReviewResult:
+    """Canonical post-publish implementation review result."""
+
+    review_status: Literal["approved", "changes_requested", "blocked"]
+    summary: str
+    pull_request_url: str | None
+    pull_number: int | None
+    pull_head_sha: str | None
+    feedback: tuple[ImplReviewFeedback, ...] = ()
+    reviewer_status: Literal["approved", "rejected", "failed_infra", "not_run"] = "not_run"
+    reviewer_summary: str = "Reviewer review did not run."
+    architect_status: Literal["approved", "rejected", "failed_infra", "not_run"] = "not_run"
+    architect_summary: str = "Architect review did not run."
+    issue_comment_url: str | None = None
+    issue_reopened: bool = False
+
+    @property
+    def allows_downstream_automation(self) -> bool:
+        """Return whether downstream automation may continue."""
+        return self.review_status == "approved"
+
+
+@dataclass(frozen=True, slots=True)
 class PostPublishReviewResult:
     """Combined result for post-publish PR review."""
 

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -7,12 +7,14 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, cast
 
 from .github_client import GitHubWriteClient
 from .json_events import extract_json_events
 from .models import (
     AggregatedPlanAlignment,
+    ImplReviewFeedback,
+    ImplReviewResult,
     IssueIntake,
     PerAgentEvidence,
     PostPublishReviewResult,
@@ -23,6 +25,8 @@ from .opencode_model import resolve_opencode_model
 from .stage_contracts import ReviewStageContract, load_review_stage_contract, render_review_prompt
 
 PULL_NUMBER_PATTERN = re.compile(r"/pull/(?P<number>[0-9]+)$")
+RUN_ID_MARKER_PATTERN = re.compile(r"^- Run ID: `(?P<run_id>[^`]+)`$", re.MULTILINE)
+ISSUE_MARKER_PATTERN = re.compile(r"^- Issue: `(?P<issue_ref>[^`]+)`$", re.MULTILINE)
 _PLAN_ALIGNMENT_VALUES = {
     "aligned",
     "justified_deviation",
@@ -144,6 +148,7 @@ def run_post_publish_review(
     reviewer: ReviewRunner | None,
     architect: ReviewRunner | None,
     token_env: str = "GITHUB_TOKEN",
+    apply_rejection_side_effects: bool = True,
 ) -> PostPublishReviewResult:
     pull_number = _extract_pull_number(pull_request_url)
     pull_head_sha = None
@@ -268,16 +273,20 @@ def run_post_publish_review(
             aggregated_plan_alignment=aggregated_plan_alignment,
         )
 
-    client = GitHubWriteClient.from_env(token_env)
-    body = _build_issue_feedback_comment(
-        intake=intake,
-        run_record=run_record,
-        pull_request_url=pull_request_url,
-        reviewer_result=reviewer_result,
-        architect_result=architect_result,
-    )
-    issue_comment_url = client.create_issue_comment(intake.issue.reference, body)
-    client.reopen_issue(intake.issue.reference)
+    issue_comment_url = None
+    issue_reopened = False
+    if apply_rejection_side_effects:
+        client = GitHubWriteClient.from_env(token_env)
+        body = _build_issue_feedback_comment(
+            intake=intake,
+            run_record=run_record,
+            pull_request_url=pull_request_url,
+            reviewer_result=reviewer_result,
+            architect_result=architect_result,
+        )
+        issue_comment_url = client.create_issue_comment(intake.issue.reference, body)
+        client.reopen_issue(intake.issue.reference)
+        issue_reopened = True
     return PostPublishReviewResult(
         status="rejected",
         summary="Post-publish review rejected the pull request and reopened the issue.",
@@ -293,7 +302,230 @@ def run_post_publish_review(
         per_agent_evidence=per_agent_evidence,
         aggregated_plan_alignment=aggregated_plan_alignment,
         issue_comment_url=issue_comment_url,
-        issue_reopened=True,
+        issue_reopened=issue_reopened,
+    )
+
+
+def run_impl_review(
+    *,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    run_dir: Path,
+    publish_plan_pull_request_url: str | None,
+    publish_plan_pull_number: int | None,
+    publish_result: object,
+    reviewer: ReviewRunner | None,
+    architect: ReviewRunner | None,
+    token_env: str = "GITHUB_TOKEN",
+) -> ImplReviewResult:
+    feedback: list[ImplReviewFeedback] = []
+
+    published_status = getattr(publish_result, "status", None)
+    published_target = getattr(publish_result, "target", None)
+    if published_status != "published" or published_target != "draft_pr":
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review requires a published draft PR for the same run.",
+            feedback=(
+                ImplReviewFeedback(
+                    code="publish_not_reviewable",
+                    message="publish-result.json must indicate a published draft PR before review impl can run.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    result_url = getattr(publish_result, "url", None)
+    result_pull_number = getattr(publish_result, "pull_number", None)
+    normalized_url, normalized_pull_number = _normalize_review_target(
+        publish_plan_pull_request_url=publish_plan_pull_request_url,
+        publish_plan_pull_number=publish_plan_pull_number,
+        publish_result_url=result_url,
+        publish_result_pull_number=result_pull_number,
+    )
+    if normalized_pull_number is None:
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review could not normalize one coherent published PR target.",
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_request_locator_invalid",
+                    message="publish-plan.json and publish-result.json must resolve to one published PR URL and pull number.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    client = GitHubWriteClient.from_env(token_env)
+    try:
+        pr_payload = client.get_pull_request(
+            intake.issue.reference.owner,
+            intake.issue.reference.repo,
+            normalized_pull_number,
+        )
+    except Exception as exc:
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review could not fetch the published PR.",
+            pull_request_url=normalized_url,
+            pull_number=normalized_pull_number,
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_request_fetch_failed",
+                    message=f"Published PR lookup failed: {exc}",
+                    source="stage",
+                ),
+            ),
+        )
+
+    live_url = pr_payload.get("html_url")
+    if not isinstance(live_url, str) or not live_url.strip():
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review requires a live published PR URL.",
+            pull_request_url=normalized_url,
+            pull_number=normalized_pull_number,
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_request_url_missing",
+                    message="Live PR payload did not include html_url.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    live_head_sha = _extract_live_pull_head_sha(pr_payload)
+    if not live_head_sha:
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review requires the live PR head SHA.",
+            pull_request_url=live_url,
+            pull_number=normalized_pull_number,
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_head_sha_missing",
+                    message="Live PR payload did not expose head.sha for review provenance.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    pr_body = _fetch_pr_body(intake.issue.reference.owner, intake.issue.reference.repo, live_url)
+    if not isinstance(pr_body, str) or not pr_body.strip():
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review requires the live PR body.",
+            pull_request_url=live_url,
+            pull_number=normalized_pull_number,
+            pull_head_sha=live_head_sha,
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_request_body_missing",
+                    message="Published PR body is missing or empty.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    pr_diff = _fetch_pr_diff(intake.issue.reference.owner, intake.issue.reference.repo, live_url)
+    if not pr_diff.strip():
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review requires the live PR diff.",
+            pull_request_url=live_url,
+            pull_number=normalized_pull_number,
+            pull_head_sha=live_head_sha,
+            feedback=(
+                ImplReviewFeedback(
+                    code="pull_request_diff_missing",
+                    message="Published PR diff is missing or empty.",
+                    source="stage",
+                ),
+            ),
+        )
+
+    provenance_feedback = _validate_review_provenance(
+        intake=intake,
+        run_record=run_record,
+        pr_payload=pr_payload,
+        pr_body=pr_body,
+        normalized_pull_number=normalized_pull_number,
+        normalized_url=normalized_url,
+        live_url=live_url,
+    )
+    if provenance_feedback:
+        return _finalize_non_approved_impl_review(
+            intake=intake,
+            run_record=run_record,
+            summary="Implementation review could not validate published PR provenance for this run.",
+            pull_request_url=live_url,
+            pull_number=normalized_pull_number,
+            pull_head_sha=live_head_sha,
+            feedback=tuple(provenance_feedback),
+        )
+
+    legacy_result = run_post_publish_review(
+        intake=intake,
+        run_record=run_record,
+        run_dir=run_dir,
+        pull_request_url=live_url,
+        reviewer=reviewer,
+        architect=architect,
+        token_env=token_env,
+        apply_rejection_side_effects=False,
+    )
+    mapped_review = _map_post_publish_to_impl_review(legacy_result)
+    if mapped_review.pull_head_sha != live_head_sha:
+        mapped_review = ImplReviewResult(
+            review_status=mapped_review.review_status,
+            summary=mapped_review.summary,
+            pull_request_url=mapped_review.pull_request_url,
+            pull_number=mapped_review.pull_number,
+            pull_head_sha=live_head_sha,
+            feedback=mapped_review.feedback,
+            reviewer_status=mapped_review.reviewer_status,
+            reviewer_summary=mapped_review.reviewer_summary,
+            architect_status=mapped_review.architect_status,
+            architect_summary=mapped_review.architect_summary,
+            issue_comment_url=mapped_review.issue_comment_url,
+            issue_reopened=mapped_review.issue_reopened,
+        )
+    return _finalize_non_approved_impl_review(
+        intake=intake,
+        run_record=run_record,
+        review=mapped_review,
+        token_env=token_env,
+    )
+
+
+def mirror_impl_review_to_post_publish(review: ImplReviewResult) -> PostPublishReviewResult:
+    status = cast(
+        Literal["approved", "rejected", "failed_infra", "not_run"],
+        {
+        "approved": "approved",
+        "changes_requested": "rejected",
+        "blocked": "failed_infra",
+        }[review.review_status],
+    )
+    return PostPublishReviewResult(
+        status=status,
+        summary=review.summary,
+        pull_request_url=review.pull_request_url,
+        pull_number=review.pull_number,
+        pull_head_sha=review.pull_head_sha,
+        reviewer_status=review.reviewer_status,
+        reviewer_summary=review.reviewer_summary,
+        architect_status=review.architect_status,
+        architect_summary=review.architect_summary,
+        issue_comment_url=review.issue_comment_url,
+        issue_reopened=review.issue_reopened,
     )
 
 
@@ -436,6 +668,282 @@ def _as_plan_alignment(
     if value == "non_material_detail":
         return "non_material_detail"
     raise ValueError("Expected plan alignment")
+
+
+def _blocked_impl_review(
+    *,
+    summary: str,
+    feedback: tuple[ImplReviewFeedback, ...],
+    pull_request_url: str | None = None,
+    pull_number: int | None = None,
+    pull_head_sha: str | None = None,
+) -> ImplReviewResult:
+    return ImplReviewResult(
+        review_status="blocked",
+        summary=summary,
+        pull_request_url=pull_request_url,
+        pull_number=pull_number,
+        pull_head_sha=pull_head_sha,
+        feedback=feedback,
+        reviewer_status="not_run",
+        reviewer_summary="Reviewer did not run because review impl was blocked.",
+        architect_status="not_run",
+        architect_summary="Architect did not run because review impl was blocked.",
+    )
+
+
+def _normalize_review_target(
+    *,
+    publish_plan_pull_request_url: str | None,
+    publish_plan_pull_number: int | None,
+    publish_result_url: str | None,
+    publish_result_pull_number: int | None,
+) -> tuple[str | None, int | None]:
+    candidate_url = publish_result_url or publish_plan_pull_request_url
+    candidate_number = publish_result_pull_number or publish_plan_pull_number
+    url_number = _extract_pull_number(candidate_url) if candidate_url else None
+
+    if publish_plan_pull_number is not None and publish_result_pull_number is not None:
+        if publish_plan_pull_number != publish_result_pull_number:
+            return None, None
+    if publish_plan_pull_request_url and publish_result_url and publish_plan_pull_request_url != publish_result_url:
+        return None, None
+    if candidate_number is None and url_number is not None:
+        candidate_number = url_number
+    if candidate_number is None:
+        return None, None
+    if candidate_url is not None and url_number is not None and url_number != candidate_number:
+        return None, None
+    return candidate_url, candidate_number
+
+
+def _extract_live_pull_head_sha(pr_payload: dict[str, Any]) -> str | None:
+    head = pr_payload.get("head")
+    if not isinstance(head, dict):
+        return None
+    sha = head.get("sha")
+    return sha if isinstance(sha, str) and sha.strip() else None
+
+
+def _validate_review_provenance(
+    *,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    pr_payload: dict[str, Any],
+    pr_body: str,
+    normalized_pull_number: int,
+    normalized_url: str | None,
+    live_url: str,
+) -> list[ImplReviewFeedback]:
+    feedback: list[ImplReviewFeedback] = []
+
+    live_number = pr_payload.get("number")
+    if live_number != normalized_pull_number:
+        feedback.append(
+            ImplReviewFeedback(
+                code="pull_request_number_mismatch",
+                message="Live PR number does not match persisted publish artifacts.",
+                source="stage",
+            )
+        )
+
+    if normalized_url is not None and live_url != normalized_url:
+        feedback.append(
+            ImplReviewFeedback(
+                code="pull_request_url_mismatch",
+                message="Live PR URL does not match persisted publish artifacts.",
+                source="stage",
+            )
+        )
+
+    base = pr_payload.get("base")
+    repo_payload = base.get("repo") if isinstance(base, dict) else None
+    owner_payload = repo_payload.get("owner") if isinstance(repo_payload, dict) else None
+    repo_name = repo_payload.get("name") if isinstance(repo_payload, dict) else None
+    owner_login = owner_payload.get("login") if isinstance(owner_payload, dict) else None
+    if owner_login != intake.issue.reference.owner or repo_name != intake.issue.reference.repo:
+        feedback.append(
+            ImplReviewFeedback(
+                code="repository_identity_mismatch",
+                message="Live PR repository identity does not match issue-intake.json.",
+                source="stage",
+            )
+        )
+
+    run_id_match = RUN_ID_MARKER_PATTERN.search(pr_body)
+    issue_match = ISSUE_MARKER_PATTERN.search(pr_body)
+    if run_id_match is None:
+        feedback.append(
+            ImplReviewFeedback(
+                code="pr_body_run_id_missing",
+                message="Published PR body is missing the Run ID provenance marker.",
+                source="stage",
+            )
+        )
+    elif run_id_match.group("run_id") != run_record.run_id:
+        feedback.append(
+            ImplReviewFeedback(
+                code="pr_body_run_id_mismatch",
+                message="Published PR Run ID marker does not match run-record.json.",
+                source="stage",
+            )
+        )
+
+    if issue_match is None:
+        feedback.append(
+            ImplReviewFeedback(
+                code="pr_body_issue_missing",
+                message="Published PR body is missing the Issue provenance marker.",
+                source="stage",
+            )
+        )
+    elif issue_match.group("issue_ref") != str(intake.issue.reference):
+        feedback.append(
+            ImplReviewFeedback(
+                code="pr_body_issue_mismatch",
+                message="Published PR Issue marker does not match the canonical issue being reviewed.",
+                source="stage",
+            )
+        )
+
+    return feedback
+
+
+def _map_post_publish_to_impl_review(result: PostPublishReviewResult) -> ImplReviewResult:
+    if result.status == "approved":
+        return ImplReviewResult(
+            review_status="approved",
+            summary=result.summary,
+            pull_request_url=result.pull_request_url,
+            pull_number=result.pull_number,
+            pull_head_sha=result.pull_head_sha,
+            feedback=(),
+            reviewer_status=result.reviewer_status,
+            reviewer_summary=result.reviewer_summary,
+            architect_status=result.architect_status,
+            architect_summary=result.architect_summary,
+            issue_comment_url=result.issue_comment_url,
+            issue_reopened=result.issue_reopened,
+        )
+    if result.status == "rejected":
+        feedback: list[ImplReviewFeedback] = []
+        for message in result.reviewer_feedback:
+            feedback.append(
+                ImplReviewFeedback(code="reviewer_changes_requested", message=message, source="reviewer")
+            )
+        for message in result.architect_feedback:
+            feedback.append(
+                ImplReviewFeedback(code="architect_changes_requested", message=message, source="architect")
+            )
+        if not feedback:
+            feedback.append(
+                ImplReviewFeedback(
+                    code="changes_requested",
+                    message="Published PR requires changes before downstream automation may proceed.",
+                    source="stage",
+                )
+            )
+        return ImplReviewResult(
+            review_status="changes_requested",
+            summary=result.summary,
+            pull_request_url=result.pull_request_url,
+            pull_number=result.pull_number,
+            pull_head_sha=result.pull_head_sha,
+            feedback=tuple(feedback),
+            reviewer_status=result.reviewer_status,
+            reviewer_summary=result.reviewer_summary,
+            architect_status=result.architect_status,
+            architect_summary=result.architect_summary,
+            issue_comment_url=result.issue_comment_url,
+            issue_reopened=result.issue_reopened,
+        )
+    return ImplReviewResult(
+        review_status="blocked",
+        summary=result.summary,
+        pull_request_url=result.pull_request_url,
+        pull_number=result.pull_number,
+        pull_head_sha=result.pull_head_sha,
+        feedback=(
+            ImplReviewFeedback(
+                code="review_infrastructure_blocked",
+                message=result.summary,
+                source="stage",
+            ),
+        ),
+        reviewer_status=result.reviewer_status,
+        reviewer_summary=result.reviewer_summary,
+        architect_status=result.architect_status,
+        architect_summary=result.architect_summary,
+        issue_comment_url=result.issue_comment_url,
+        issue_reopened=result.issue_reopened,
+    )
+
+
+def _finalize_non_approved_impl_review(
+    *,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    token_env: str = "GITHUB_TOKEN",
+    review: ImplReviewResult | None = None,
+    summary: str | None = None,
+    feedback: tuple[ImplReviewFeedback, ...] = (),
+    pull_request_url: str | None = None,
+    pull_number: int | None = None,
+    pull_head_sha: str | None = None,
+) -> ImplReviewResult:
+    result = review or _blocked_impl_review(
+        summary=summary or "Implementation review is blocked.",
+        feedback=feedback,
+        pull_request_url=pull_request_url,
+        pull_number=pull_number,
+        pull_head_sha=pull_head_sha,
+    )
+    if result.review_status == "approved":
+        return result
+
+    client = GitHubWriteClient.from_env(token_env)
+    body = _build_impl_review_issue_comment(
+        intake=intake,
+        run_record=run_record,
+        review=result,
+    )
+    issue_comment_url = client.create_issue_comment(intake.issue.reference, body)
+    client.reopen_issue(intake.issue.reference)
+    return ImplReviewResult(
+        review_status=result.review_status,
+        summary=result.summary,
+        pull_request_url=result.pull_request_url,
+        pull_number=result.pull_number,
+        pull_head_sha=result.pull_head_sha,
+        feedback=result.feedback,
+        reviewer_status=result.reviewer_status,
+        reviewer_summary=result.reviewer_summary,
+        architect_status=result.architect_status,
+        architect_summary=result.architect_summary,
+        issue_comment_url=issue_comment_url,
+        issue_reopened=True,
+    )
+
+
+def _build_impl_review_issue_comment(
+    *,
+    intake: IssueIntake,
+    run_record: RunRecord,
+    review: ImplReviewResult,
+) -> str:
+    lines = [
+        "## Precision Squad Implementation Review",
+        f"- Run ID: `{run_record.run_id}`",
+        f"- Issue: `{intake.issue.reference}`",
+        f"- Review status: `{review.review_status}`",
+        f"- PR: {review.pull_request_url or '(unavailable)'}",
+        f"- PR Head SHA: `{review.pull_head_sha or '(unavailable)'}`",
+        "",
+        "### Structured Feedback",
+    ]
+    for item in review.feedback:
+        lines.append(f"- `{item.code}` [{item.source}] {item.message}")
+    return "\n".join(lines) + "\n"
 
 
 def _build_issue_feedback_comment(

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -318,8 +318,6 @@ def run_impl_review(
     architect: ReviewRunner | None,
     token_env: str = "GITHUB_TOKEN",
 ) -> ImplReviewResult:
-    feedback: list[ImplReviewFeedback] = []
-
     published_status = getattr(publish_result, "status", None)
     published_target = getattr(publish_result, "target", None)
     if published_status != "published" or published_target != "draft_pr":
@@ -330,7 +328,10 @@ def run_impl_review(
             feedback=(
                 ImplReviewFeedback(
                     code="publish_not_reviewable",
-                    message="publish-result.json must indicate a published draft PR before review impl can run.",
+                    message=(
+                        "publish-result.json must indicate a published draft PR "
+                        "before review impl can run."
+                    ),
                     source="stage",
                 ),
             ),
@@ -352,7 +353,10 @@ def run_impl_review(
             feedback=(
                 ImplReviewFeedback(
                     code="pull_request_locator_invalid",
-                    message="publish-plan.json and publish-result.json must resolve to one published PR URL and pull number.",
+                    message=(
+                        "publish-plan.json and publish-result.json must resolve "
+                        "to one published PR URL and pull number."
+                    ),
                     source="stage",
                 ),
             ),
@@ -464,7 +468,10 @@ def run_impl_review(
         return _finalize_non_approved_impl_review(
             intake=intake,
             run_record=run_record,
-            summary="Implementation review could not validate published PR provenance for this run.",
+            summary=(
+                "Implementation review could not validate published PR provenance "
+                "for this run."
+            ),
             pull_request_url=live_url,
             pull_number=normalized_pull_number,
             pull_head_sha=live_head_sha,
@@ -706,7 +713,11 @@ def _normalize_review_target(
     if publish_plan_pull_number is not None and publish_result_pull_number is not None:
         if publish_plan_pull_number != publish_result_pull_number:
             return None, None
-    if publish_plan_pull_request_url and publish_result_url and publish_plan_pull_request_url != publish_result_url:
+    if (
+        publish_plan_pull_request_url
+        and publish_result_url
+        and publish_plan_pull_request_url != publish_result_url
+    ):
         return None, None
     if candidate_number is None and url_number is not None:
         candidate_number = url_number
@@ -801,7 +812,10 @@ def _validate_review_provenance(
         feedback.append(
             ImplReviewFeedback(
                 code="pr_body_issue_mismatch",
-                message="Published PR Issue marker does not match the canonical issue being reviewed.",
+                message=(
+                    "Published PR Issue marker does not match the canonical issue "
+                    "being reviewed."
+                ),
                 source="stage",
             )
         )
@@ -829,17 +843,28 @@ def _map_post_publish_to_impl_review(result: PostPublishReviewResult) -> ImplRev
         feedback: list[ImplReviewFeedback] = []
         for message in result.reviewer_feedback:
             feedback.append(
-                ImplReviewFeedback(code="reviewer_changes_requested", message=message, source="reviewer")
+                ImplReviewFeedback(
+                    code="reviewer_changes_requested",
+                    message=message,
+                    source="reviewer",
+                )
             )
         for message in result.architect_feedback:
             feedback.append(
-                ImplReviewFeedback(code="architect_changes_requested", message=message, source="architect")
+                ImplReviewFeedback(
+                    code="architect_changes_requested",
+                    message=message,
+                    source="architect",
+                )
             )
         if not feedback:
             feedback.append(
                 ImplReviewFeedback(
                     code="changes_requested",
-                    message="Published PR requires changes before downstream automation may proceed.",
+                    message=(
+                        "Published PR requires changes before downstream automation "
+                        "may proceed."
+                    ),
                     source="stage",
                 )
             )

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -18,6 +18,8 @@ from .models import (
     EvaluationResult,
     ExecutionResult,
     GovernanceVerdict,
+    ImplReviewFeedback,
+    ImplReviewResult,
     IssueDraft,
     IssueDraftProvenance,
     IssueIntake,
@@ -43,6 +45,7 @@ PersistedArtifact = (
     | EvaluationResult
     | ExecutionResult
     | GovernanceVerdict
+    | ImplReviewResult
     | IssueDraft
     | IssueIntake
     | IssueReview
@@ -58,6 +61,7 @@ PersistedArtifact = (
 
 APPROVED_PLAN_FILENAME = "approved-plan.json"
 DECISION_LOG_FILENAME_TEMPLATE = "decision-log.attempt-{attempt}.json"
+IMPL_REVIEW_FILENAME = "impl-review.json"
 ISSUE_REVIEW_FILENAME = "issue-review.json"
 PLAN_REVIEW_FILENAME = "plan-review.json"
 _ALLOWED_NAMED_REFERENCE_TYPES = {"file", "interface", "symbol", "example"}
@@ -212,6 +216,18 @@ class RunStore:
 
     def write_plan_review(self, run_dir: Path, review: PlanReview) -> None:
         self._write_json(run_dir / PLAN_REVIEW_FILENAME, review)
+
+    def write_impl_review(self, run_dir: Path, review: ImplReviewResult) -> None:
+        self._write_json(run_dir / IMPL_REVIEW_FILENAME, review)
+
+    @staticmethod
+    def load_impl_review(run_dir: Path) -> ImplReviewResult:
+        path = run_dir / IMPL_REVIEW_FILENAME
+        if not path.exists():
+            raise ValueError(f"Implementation review artifact not found: {path}")
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+        return _parse_impl_review_payload(payload, path=path)
 
     @staticmethod
     def load_issue_review(
@@ -705,6 +721,76 @@ def _parse_plan_review_payload(
             run_id=provenance_run_id,
             issue_ref=provenance_issue_ref,
         ),
+    )
+
+
+def _parse_impl_review_payload(payload: object, *, path: Path) -> ImplReviewResult:
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+
+    review_status = payload.get("review_status")
+    if review_status not in {"approved", "changes_requested", "blocked"}:
+        raise ValueError(
+            "Implementation review field 'review_status' must be 'approved', "
+            "'changes_requested', or 'blocked'"
+        )
+
+    summary = payload.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        raise ValueError("Implementation review field 'summary' must be a non-empty string")
+
+    feedback_raw = payload.get("feedback")
+    if not isinstance(feedback_raw, list):
+        raise ValueError("Implementation review field 'feedback' must be a list")
+    feedback: list[ImplReviewFeedback] = []
+    for index, item in enumerate(feedback_raw, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"Implementation review feedback[{index}] must be an object")
+        code = item.get("code")
+        message = item.get("message")
+        source = item.get("source")
+        if not isinstance(code, str) or not code.strip():
+            raise ValueError(
+                f"Implementation review feedback[{index}].code must be a non-empty string"
+            )
+        if not isinstance(message, str) or not message.strip():
+            raise ValueError(
+                f"Implementation review feedback[{index}].message must be a non-empty string"
+            )
+        if source not in {"stage", "reviewer", "architect"}:
+            raise ValueError(
+                "Implementation review feedback[{}].source must be 'stage', 'reviewer', or "
+                "'architect'".format(index)
+            )
+        feedback.append(
+            ImplReviewFeedback(
+                code=code,
+                message=message,
+                source=cast(Literal["stage", "reviewer", "architect"], source),
+            )
+        )
+
+    return ImplReviewResult(
+        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        summary=summary,
+        pull_request_url=cast(str | None, payload.get("pull_request_url")),
+        pull_number=cast(int | None, payload.get("pull_number")),
+        pull_head_sha=cast(str | None, payload.get("pull_head_sha")),
+        feedback=tuple(feedback),
+        reviewer_status=cast(
+            Literal["approved", "rejected", "failed_infra", "not_run"],
+            payload.get("reviewer_status", "not_run"),
+        ),
+        reviewer_summary=cast(str, payload.get("reviewer_summary", "Reviewer review did not run.")),
+        architect_status=cast(
+            Literal["approved", "rejected", "failed_infra", "not_run"],
+            payload.get("architect_status", "not_run"),
+        ),
+        architect_summary=cast(
+            str, payload.get("architect_summary", "Architect review did not run.")
+        ),
+        issue_comment_url=cast(str | None, payload.get("issue_comment_url")),
+        issue_reopened=bool(payload.get("issue_reopened", False)),
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,8 @@ from precision_squad.models import (
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
+    ImplReviewFeedback,
+    ImplReviewResult,
     IssueAssessment,
     IssueIntake,
     IssueReference,
@@ -418,6 +420,141 @@ def test_review_plan_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
     assert status == 3
     assert Path(captured_runs_dir["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
     assert "Review Status: blocked" in captured.out
+
+
+def test_review_impl_prints_approved_review_output(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    impl_review = ImplReviewResult(
+        review_status="approved",
+        summary="Published PR passed implementation review.",
+        pull_request_url="https://github.com/cracklings3d/precision-squad/pull/72",
+        pull_number=72,
+        pull_head_sha="head-sha",
+        reviewer_status="approved",
+        reviewer_summary="Reviewer approved.",
+        architect_status="approved",
+        architect_summary="Architect approved.",
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_impl",
+        lambda self, *, params, dependencies: __import__(
+            "precision_squad.coordinator", fromlist=["ReviewImplReport"]
+        ).ReviewImplReport(
+            run_record=RunRecord(
+                run_id="run-123",
+                issue_ref="cracklings3d/precision-squad#72",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs" / "run-123"),
+            ),
+            impl_review=impl_review,
+            exit_code=0,
+        ),
+    )
+
+    status = main(["review", "impl", "run-123", "--runs-dir", str(tmp_path / "runs")])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Review Status: approved" in captured.out
+    assert "Artifacts: impl-review.json" in captured.out
+    assert "Downstream Automation Allowed: True" in captured.out
+
+
+def test_review_impl_prints_feedback_for_blocked_review(
+    capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    impl_review = ImplReviewResult(
+        review_status="blocked",
+        summary="Implementation review could not validate provenance.",
+        pull_request_url="https://github.com/cracklings3d/precision-squad/pull/72",
+        pull_number=72,
+        pull_head_sha="head-sha",
+        feedback=(
+            ImplReviewFeedback(
+                code="pr_body_run_id_mismatch",
+                message="Published PR Run ID marker does not match run-record.json.",
+                source="stage",
+            ),
+        ),
+        reviewer_status="not_run",
+        reviewer_summary="Reviewer did not run because review impl was blocked.",
+        architect_status="not_run",
+        architect_summary="Architect did not run because review impl was blocked.",
+        issue_comment_url="comment-url",
+        issue_reopened=True,
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_impl",
+        lambda self, *, params, dependencies: __import__(
+            "precision_squad.coordinator", fromlist=["ReviewImplReport"]
+        ).ReviewImplReport(
+            run_record=RunRecord(
+                run_id="run-123",
+                issue_ref="cracklings3d/precision-squad#72",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(tmp_path / "runs" / "run-123"),
+            ),
+            impl_review=impl_review,
+            exit_code=3,
+        ),
+    )
+
+    status = main(["review", "impl", "run-123", "--runs-dir", str(tmp_path / "runs")])
+
+    captured = capsys.readouterr()
+    assert status == 3
+    assert "Review Status: blocked" in captured.out
+    assert "pr_body_run_id_mismatch" in captured.out
+    assert "Review Feedback URL: comment-url" in captured.out
+
+
+def test_review_impl_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    (tmp_path / ".precision-squad.toml").write_text(
+        "[review.impl]\nruns_dir = \".precision-squad/runs\"\nreview_model = \"test-model\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    captured_params: dict[str, str] = {}
+    monkeypatch.setattr(
+        "precision_squad.cli.RunCoordinator.review_impl",
+        lambda self, *, params, dependencies: (
+            captured_params.__setitem__("runs_dir", str(params.runs_dir)),
+            captured_params.__setitem__("review_model", str(params.review_model)),
+            __import__("precision_squad.coordinator", fromlist=["ReviewImplReport"]).ReviewImplReport(
+                run_record=RunRecord(
+                    run_id="run-123",
+                    issue_ref="owner/repo#1",
+                    status="runnable",
+                    created_at="2026-05-01T00:00:00Z",
+                    updated_at="2026-05-01T00:00:00Z",
+                    run_dir=str(tmp_path / ".precision-squad" / "runs" / "run-123"),
+                ),
+                impl_review=ImplReviewResult(
+                    review_status="approved",
+                    summary="ok",
+                    pull_request_url="https://github.com/owner/repo/pull/1",
+                    pull_number=1,
+                    pull_head_sha="sha",
+                ),
+                exit_code=0,
+            ),
+        )[2],
+    )
+
+    status = main(["review", "impl", "run-123"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert Path(captured_params["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
+    assert captured_params["review_model"] == "test-model"
+    assert "Review Status: approved" in captured.out
 
 
 def test_review_issue_end_to_end_persists_approved_issue_review(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,6 +12,7 @@ from precision_squad.coordinator import (
     ImplementRunParams,
     PersistApprovedPlanParams,
     RepairIssueParams,
+    ReviewImplParams,
     ReviewPlanParams,
     RunCoordinator,
 )
@@ -19,6 +20,7 @@ from precision_squad.models import (
     ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
+    ImplReviewResult,
     IssueAssessment,
     IssueIntake,
     IssueReference,
@@ -298,6 +300,131 @@ def test_implement_run_refuses_when_approved_plan_missing(
             params=_make_implement_params(tmp_path, record.run_id),
             dependencies=MagicMock(),
         )
+
+
+def test_review_impl_persists_canonical_and_compatibility_review_artifacts(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+    run_dir = Path(record.run_dir)
+    store.write_approved_plan(run_dir, _approved_plan())
+    (run_dir / "publish-plan.json").write_text(
+        json.dumps(
+            {
+                "status": "draft_pr",
+                "title": "title",
+                "body": "body",
+                "reason_codes": [],
+                "pull_request_url": "https://github.com/owner/repo/pull/1",
+                "pull_number": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "publish-result.json").write_text(
+        json.dumps(
+            {
+                "status": "published",
+                "target": "draft_pr",
+                "summary": "published",
+                "url": "https://github.com/owner/repo/pull/1",
+                "pull_number": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dependencies = MagicMock()
+    dependencies.run_impl_review.return_value = ImplReviewResult(
+        review_status="changes_requested",
+        summary="Published PR needs changes.",
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+        pull_head_sha="head-sha",
+        reviewer_status="rejected",
+        reviewer_summary="Reviewer requested changes.",
+        architect_status="approved",
+        architect_summary="Architect approved.",
+    )
+
+    report = RunCoordinator().review_impl(
+        params=ReviewImplParams(run_id=record.run_id, runs_dir=runs_dir, review_model=None),
+        dependencies=dependencies,
+    )
+
+    impl_payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
+    legacy_payload = json.loads((run_dir / "post-publish-review-result.json").read_text(encoding="utf-8"))
+    assert report.exit_code == 2
+    assert impl_payload["review_status"] == "changes_requested"
+    assert legacy_payload["status"] == "rejected"
+
+
+def test_publish_run_compatibility_path_persists_shared_canonical_review_and_legacy_mirror(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    intake = _make_intake()
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        intake,
+    )
+    run_dir = Path(record.run_dir)
+    publish_plan = PublishPlan(
+        status="draft_pr",
+        title="title",
+        body="body",
+        reason_codes=(),
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+    )
+    publish_result = PublishResult(
+        status="published",
+        target="draft_pr",
+        summary="published",
+        url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+    )
+    store.write_publish_plan(run_dir, publish_plan)
+    store.write_publish_result(run_dir, publish_result)
+
+    dependencies = MagicMock()
+    dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
+        review_status="blocked",
+        summary="Implementation review could not validate provenance.",
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+        pull_head_sha="head-sha",
+        feedback=(),
+        reviewer_status="not_run",
+        reviewer_summary="Reviewer did not run because review impl was blocked.",
+        architect_status="not_run",
+        architect_summary="Architect did not run because review impl was blocked.",
+    )
+
+    report = RunCoordinator().publish_run(
+        params=__import__("precision_squad.coordinator", fromlist=["PublishRunParams"]).PublishRunParams(
+            run_id=record.run_id,
+            runs_dir=runs_dir,
+            review_model=None,
+        ),
+        intake=intake,
+        run_record=record,
+        publish_plan=publish_plan,
+        existing_result=publish_result,
+        existing_review_result=None,
+        dependencies=dependencies,
+    )
+
+    impl_payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
+    legacy_payload = json.loads((run_dir / "post-publish-review-result.json").read_text(encoding="utf-8"))
+    assert report.post_publish_review_result is not None
+    assert impl_payload["review_status"] == "blocked"
+    assert legacy_payload["status"] == "failed_infra"
+    assert legacy_payload["pull_head_sha"] == "head-sha"
 
 
 @pytest.mark.parametrize("review_status", ["changes_requested", "blocked"])

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -10,6 +10,7 @@ import pytest
 
 from precision_squad.models import (
     GitHubIssue,
+    ImplReviewResult,
     IssueAssessment,
     IssueIntake,
     IssueReference,
@@ -21,6 +22,8 @@ from precision_squad.post_publish_review import (
     ReviewRunner,
     _build_review_prompt,
     _parse_review_output,
+    mirror_impl_review_to_post_publish,
+    run_impl_review,
     run_post_publish_review,
 )
 from precision_squad.run_store import RunStore
@@ -547,3 +550,324 @@ def test_run_post_publish_review_rejection_comment_stays_bounded_but_concrete(
     assert "Surfaced justification conflicts with implementation." in comment
     assert "aggregated_plan_alignment" not in comment
     assert "stdout_path" not in comment
+
+
+def test_run_impl_review_returns_approved_for_same_run_same_issue_published_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+    comments: list[str] = []
+
+    class StubWriter:
+        def get_pull_request(self, owner: str, repo: str, pull_number: int):
+            del owner, repo
+            return {
+                "number": pull_number,
+                "html_url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "head": {"sha": "head-sha"},
+                "base": {"repo": {"name": "markdown-pdf-renderer", "owner": {"login": "cracklings3d"}}},
+                "body": "- Run ID: `run-123`\n- Issue: `cracklings3d/markdown-pdf-renderer#9`\n",
+            }
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return "comment-url"
+
+        def reopen_issue(self, reference):
+            del reference
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "- Run ID: `run-123`\n- Issue: `cracklings3d/markdown-pdf-renderer#9`\n",
+    )
+
+    result = run_impl_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        publish_plan_pull_request_url=None,
+        publish_plan_pull_number=None,
+        publish_result=type("PublishResultStub", (), {"status": "published", "target": "draft_pr", "url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13", "pull_number": 13})(),
+        reviewer=_stub_agent(_review_result(role="reviewer", status="approved", summary="Reviewer approves.")),
+        architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
+    )
+
+    assert result.review_status == "approved"
+    assert result.allows_downstream_automation is True
+    assert result.pull_head_sha == "head-sha"
+    assert comments == []
+
+
+def test_run_impl_review_derives_live_pr_url_when_only_pull_number_is_persisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+    comments: list[str] = []
+
+    class StubWriter:
+        def get_pull_request(self, owner: str, repo: str, pull_number: int):
+            del owner, repo
+            return {
+                "number": pull_number,
+                "html_url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "head": {"sha": "head-sha"},
+                "base": {"repo": {"name": "markdown-pdf-renderer", "owner": {"login": "cracklings3d"}}},
+            }
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return "comment-url"
+
+        def reopen_issue(self, reference):
+            del reference
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "- Run ID: `run-123`\n- Issue: `cracklings3d/markdown-pdf-renderer#9`\n",
+    )
+
+    result = run_impl_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        publish_plan_pull_request_url=None,
+        publish_plan_pull_number=13,
+        publish_result=type(
+            "PublishResultStub",
+            (),
+            {"status": "published", "target": "draft_pr", "url": None, "pull_number": 13},
+        )(),
+        reviewer=_stub_agent(_review_result(role="reviewer", status="approved", summary="Reviewer approves.")),
+        architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
+    )
+
+    assert result.review_status == "approved"
+    assert result.pull_request_url == "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13"
+    assert result.pull_number == 13
+    assert comments == []
+
+
+@pytest.mark.parametrize("review_status", ["changes_requested", "blocked"])
+def test_mirror_impl_review_to_post_publish_maps_stage_statuses(review_status: str) -> None:
+    review = ImplReviewResult(
+        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        summary="summary",
+        pull_request_url="https://example/pull/1",
+        pull_number=1,
+        pull_head_sha="sha",
+    )
+
+    mirrored = mirror_impl_review_to_post_publish(review)
+
+    assert mirrored.status == ("rejected" if review_status == "changes_requested" else "failed_infra")
+
+
+def test_run_impl_review_blocks_on_provenance_mismatch_and_posts_feedback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+    comments: list[str] = []
+
+    class StubWriter:
+        def get_pull_request(self, owner: str, repo: str, pull_number: int):
+            del owner, repo
+            return {
+                "number": pull_number,
+                "html_url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "head": {"sha": "head-sha"},
+                "base": {"repo": {"name": "markdown-pdf-renderer", "owner": {"login": "cracklings3d"}}},
+            }
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return "comment-url"
+
+        def reopen_issue(self, reference):
+            del reference
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "- Run ID: `run-other`\n- Issue: `cracklings3d/markdown-pdf-renderer#999`\n",
+    )
+
+    result = run_impl_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        publish_plan_pull_request_url=None,
+        publish_plan_pull_number=None,
+        publish_result=type("PublishResultStub", (), {"status": "published", "target": "draft_pr", "url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13", "pull_number": 13})(),
+        reviewer=_stub_agent(_review_result(role="reviewer", status="approved", summary="Reviewer approves.")),
+        architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
+    )
+
+    assert result.review_status == "blocked"
+    assert result.issue_reopened is True
+    assert result.issue_comment_url == "comment-url"
+    assert any(item.code == "pr_body_run_id_mismatch" for item in result.feedback)
+    assert comments and "Structured Feedback" in comments[0]
+
+
+def test_run_impl_review_uses_canonical_validation_before_mapping_compatibility_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+
+    class StubWriter:
+        def get_pull_request(self, owner: str, repo: str, pull_number: int):
+            del owner, repo
+            return {
+                "number": pull_number,
+                "html_url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "head": {"sha": "live-head-sha"},
+                "base": {"repo": {"name": "markdown-pdf-renderer", "owner": {"login": "cracklings3d"}}},
+            }
+
+        def create_issue_comment(self, reference, body):
+            del reference, body
+            return "comment-url"
+
+        def reopen_issue(self, reference):
+            del reference
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "- Run ID: `run-other`\n- Issue: `cracklings3d/markdown-pdf-renderer#9`\n",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.run_post_publish_review",
+        lambda **kwargs: pytest.fail("legacy review flow should not run when canonical provenance fails"),
+    )
+
+    result = run_impl_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        publish_plan_pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        publish_plan_pull_number=13,
+        publish_result=type(
+            "PublishResultStub",
+            (),
+            {
+                "status": "published",
+                "target": "draft_pr",
+                "url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "pull_number": 13,
+            },
+        )(),
+        reviewer=_stub_agent(_review_result(role="reviewer", status="approved", summary="Reviewer approves.")),
+        architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
+    )
+
+    assert result.review_status == "blocked"
+    assert result.pull_head_sha == "live-head-sha"
+    assert any(item.code == "pr_body_run_id_mismatch" for item in result.feedback)
+
+
+def test_run_impl_review_posts_non_approved_side_effects_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_approved_plan(tmp_path)
+    comments: list[str] = []
+    reopen_calls = 0
+
+    class StubWriter:
+        def get_pull_request(self, owner: str, repo: str, pull_number: int):
+            del owner, repo
+            return {
+                "number": pull_number,
+                "html_url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "head": {"sha": "live-head-sha"},
+                "base": {"repo": {"name": "markdown-pdf-renderer", "owner": {"login": "cracklings3d"}}},
+            }
+
+        def create_issue_comment(self, reference, body):
+            del reference
+            comments.append(body)
+            return f"comment-url-{len(comments)}"
+
+        def reopen_issue(self, reference):
+            nonlocal reopen_calls
+            del reference
+            reopen_calls += 1
+
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review.GitHubWriteClient.from_env",
+        lambda token_env="GITHUB_TOKEN": StubWriter(),
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_body",
+        lambda *args, **kwargs: "- Run ID: `run-123`\n- Issue: `cracklings3d/markdown-pdf-renderer#9`\n",
+    )
+    monkeypatch.setattr(
+        "precision_squad.post_publish_review._fetch_pr_diff",
+        lambda *args, **kwargs: "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@",
+    )
+
+    result = run_impl_review(
+        intake=_intake(),
+        run_record=_record(tmp_path),
+        run_dir=tmp_path,
+        publish_plan_pull_request_url="https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+        publish_plan_pull_number=13,
+        publish_result=type(
+            "PublishResultStub",
+            (),
+            {
+                "status": "published",
+                "target": "draft_pr",
+                "url": "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13",
+                "pull_number": 13,
+            },
+        )(),
+        reviewer=_stub_agent(
+            _review_result(
+                role="reviewer",
+                status="rejected",
+                summary="Reviewer requests changes.",
+                feedback=("Fix the implementation review flow.",),
+            )
+        ),
+        architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
+    )
+
+    assert result.review_status == "changes_requested"
+    assert result.issue_comment_url == "comment-url-1"
+    assert result.issue_reopened is True
+    assert len(comments) == 1
+    assert reopen_calls == 1

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -17,6 +17,8 @@ from precision_squad.models import (
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
+    ImplReviewFeedback,
+    ImplReviewResult,
     IssueAssessment,
     IssueDraft,
     IssueIntake,
@@ -226,6 +228,40 @@ def test_write_and_load_plan_review_persists_same_run_artifact(tmp_path: Path) -
     assert loaded == _plan_review()
     assert payload["review_status"] == "approved"
     assert payload["provenance"]["source_artifact"] == "approved-plan.json"
+
+
+def test_write_and_load_impl_review_persists_canonical_artifact(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "runs")
+    run_dir = tmp_path / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+    review = ImplReviewResult(
+        review_status="changes_requested",
+        summary="Published PR requires changes.",
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+        pull_head_sha="abc123",
+        feedback=(
+            ImplReviewFeedback(
+                code="reviewer_changes_requested",
+                message="Fix the implementation.",
+                source="reviewer",
+            ),
+        ),
+        reviewer_status="rejected",
+        reviewer_summary="Reviewer requested changes.",
+        architect_status="approved",
+        architect_summary="Architect approved.",
+        issue_comment_url="comment-url",
+        issue_reopened=True,
+    )
+
+    store.write_impl_review(run_dir, review)
+
+    loaded = store.load_impl_review(run_dir)
+    payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
+    assert loaded == review
+    assert payload["review_status"] == "changes_requested"
+    assert payload["feedback"][0]["source"] == "reviewer"
 
 
 def test_load_plan_review_missing_artifact_raises_not_found(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #72

## Summary
- add an explicit `review impl` stage and canonical `impl-review.json` artifact
- validate published PR provenance and head SHA before implementation review proceeds
- preserve compatibility by mirroring canonical implementation-review results to legacy post-publish review artifacts

## Approved plan
- `docs/implementation-plan.md`

## Notable implementation decisions
- `review impl` now targets the published PR, not unpublished local-only artifacts
- canonical implementation review writes `impl-review.json` and maps compatibility output for existing post-publish consumers
- non-approved implementation review outcomes post structured feedback back to the source issue and reopen it when needed

## Validation evidence
- implementation review already passed for controller run `20260522-233234-888`
- focused coverage added in `tests/test_cli.py`, `tests/test_coordinator.py`, `tests/test_post_publish_review.py`, and `tests/test_run_store.py`
