### PR TITLE
feat: post-review GitHub automation for ADR-008 implementation review

### DIFF
--- a/src/precision_squad/github_client.py
+++ b/src/precision_squad/github_client.py
@@ -467,6 +467,161 @@ class GitHubWriteClient:
             payload={"state": "open"},
         )
 
+    def close_issue(self, reference: IssueReference) -> None:
+        gh_success = self._close_issue_via_gh(reference)
+        if gh_success:
+            return
+
+        self._request_json(
+            method="PATCH",
+            url=(
+                f"https://api.github.com/repos/{reference.owner}/"
+                f"{reference.repo}/issues/{reference.number}"
+            ),
+            payload={"state": "closed"},
+        )
+
+    def merge_pull_request(self, owner: str, repo: str, pull_number: int) -> None:
+        gh_success = self._merge_pull_request_via_gh(owner, repo, pull_number)
+        if gh_success:
+            return
+
+        try:
+            self._request_json(
+                method="PUT",
+                url=f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+                payload={},
+            )
+        except GitHubClientError as exc:
+            if "409" in str(exc):
+                return
+            raise
+
+    def close_pull_request(self, owner: str, repo: str, pull_number: int) -> None:
+        gh_success = self._close_pull_request_via_gh(owner, repo, pull_number)
+        if gh_success:
+            return
+
+        try:
+            self._request_json(
+                method="PATCH",
+                url=f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}",
+                payload={"state": "closed"},
+            )
+        except GitHubClientError as exc:
+            if "405" in str(exc):
+                return
+            raise
+
+    def update_pull_request_branch(
+        self, owner: str, repo: str, pull_number: int
+    ) -> None:
+        gh_success = self._update_pull_request_branch_via_gh(owner, repo, pull_number)
+        if gh_success:
+            return
+
+        self._request_json(
+            method="PUT",
+            url=f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/updateBranch",
+            payload={},
+        )
+
+    def _close_issue_via_gh(self, reference: IssueReference) -> bool:
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{reference.owner}/{reference.repo}/issues/{reference.number}",
+                    "--method",
+                    "PATCH",
+                    "-f",
+                    "state=closed",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return False
+
+        return completed.returncode == 0
+
+    def _merge_pull_request_via_gh(
+        self, owner: str, repo: str, pull_number: int
+    ) -> bool:
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/pulls/{pull_number}/merge",
+                    "--method",
+                    "PUT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return False
+
+        if completed.returncode != 0:
+            if "409" in completed.stderr or "already been merged" in completed.stderr.lower():
+                return True
+            return False
+
+        return True
+
+    def _close_pull_request_via_gh(
+        self, owner: str, repo: str, pull_number: int
+    ) -> bool:
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/pulls/{pull_number}",
+                    "--method",
+                    "PATCH",
+                    "-f",
+                    "state=closed",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return False
+
+        if completed.returncode != 0:
+            if "405" in completed.stderr or "Cannot change" in completed.stderr:
+                return True
+            return False
+
+        return True
+
+    def _update_pull_request_branch_via_gh(
+        self, owner: str, repo: str, pull_number: int
+    ) -> bool:
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/pulls/{pull_number}/updateBranch",
+                    "--method",
+                    "PUT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return False
+
+        return completed.returncode == 0
+
     def _reopen_issue_via_gh(self, reference: IssueReference) -> bool:
         try:
             completed = subprocess.run(

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
+import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from .docs_remediation import (
     DOCS_REMEDIATION_MARKER,
@@ -17,14 +21,35 @@ from .docs_remediation import (
     load_contract_findings,
     normalize_docs_findings,
 )
+from .github_client import GitHubClientError, GitHubWriteClient
 from .intake import is_docs_remediation_issue
-from .models import GovernanceVerdict, IssueIntake, PublishPlan, RepairResult, RunRecord
+from .models import (
+    GovernanceVerdict,
+    IssueIntake,
+    IssueReference,
+    PostPublishReviewResult,
+    PublishPlan,
+    RepairResult,
+    RunRecord,
+)
 from .rerun_context import latest_rejected_pull_request
 from .run_store import RunStore
+
+logger = logging.getLogger(__name__)
 
 
 class RequiredDecisionLogArtifactMissingError(ValueError):
     """Raised when a completed repair attempt is missing its required decision-log artifact."""
+
+
+@dataclass(frozen=True, slots=True)
+class PostReviewAutomationResult:
+    """Result of post-review GitHub automation."""
+
+    status: Literal["success", "failed", "skipped"]
+    summary: str
+    operations_completed: tuple[str, ...]
+    error: str | None = None
 
 
 def build_publish_plan(
@@ -269,3 +294,182 @@ def _render_design_decisions_section(
         for entry in artifact.entries
     ]
     return "\n## Design Decisions\n```json\n" + json.dumps(payload, indent=2) + "\n```\n"
+
+
+def _load_post_publish_review_result(run_dir: Path) -> PostPublishReviewResult | None:
+    """Load post-publish review result from run directory."""
+    path = run_dir / "post-publish-review-result.json"
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as f:
+        payload = json.load(f)
+    status = payload.get("status", "not_run")
+    summary = payload.get("summary", "")
+    pull_request_url = payload.get("pull_request_url")
+    pull_number = payload.get("pull_number")
+    reviewer_status = payload.get("reviewer_status", "not_run")
+    reviewer_summary = payload.get("reviewer_summary", "")
+    pull_head_sha = payload.get("pull_head_sha")
+    reviewer_feedback = tuple(payload.get("reviewer_feedback", []))
+    architect_status = payload.get("architect_status", "not_run")
+    architect_summary = payload.get("architect_summary", "Architect review did not run.")
+    architect_feedback = tuple(payload.get("architect_feedback", []))
+    issue_comment_url = payload.get("issue_comment_url")
+    issue_reopened = payload.get("issue_reopened", False)
+    return PostPublishReviewResult(
+        status=status,
+        summary=summary,
+        pull_request_url=pull_request_url,
+        pull_number=pull_number,
+        reviewer_status=reviewer_status,
+        reviewer_summary=reviewer_summary,
+        pull_head_sha=pull_head_sha,
+        reviewer_feedback=reviewer_feedback,
+        architect_status=architect_status,
+        architect_summary=architect_summary,
+        architect_feedback=architect_feedback,
+        issue_comment_url=issue_comment_url,
+        issue_reopened=issue_reopened,
+    )
+
+
+def _parse_issue_reference(issue_ref: str) -> IssueReference:
+    """Parse an issue reference string like 'owner/repo#number'."""
+    if "#" not in issue_ref:
+        raise ValueError(f"Invalid issue reference format: {issue_ref}")
+    repo_part, number_part = issue_ref.rsplit("#", 1)
+    if "/" not in repo_part:
+        raise ValueError(f"Invalid issue reference format: {issue_ref}")
+    owner, repo = repo_part.rsplit("/", 1)
+    try:
+        number = int(number_part)
+    except ValueError:
+        raise ValueError(f"Invalid issue number: {number_part}")
+    return IssueReference(owner=owner, repo=repo, number=number)
+
+
+def apply_post_review_automation(
+    run_id: str,
+    approved: bool,
+    *,
+    token_env: str = "GITHUB_TOKEN",
+) -> PostReviewAutomationResult:
+    """Apply GitHub automation after post-publish review approval or rejection.
+
+    On approval: marks PR ready, merges it, and closes the linked issue.
+    On rejection: emits info log and returns early (rejection handled by post_publish_review.py).
+
+    Args:
+        run_id: The run ID to operate on.
+        approved: Whether the review was approved.
+        token_env: Environment variable name containing the GitHub token.
+
+    Returns:
+        PostReviewAutomationResult with status, summary, operations completed, and optional error.
+    """
+    if not approved:
+        logger.info(
+            "Post-review automation skipped: review was not approved. "
+            "Rejection side-effects are handled by post_publish_review.py."
+        )
+        return PostReviewAutomationResult(
+            status="skipped",
+            summary="Automation skipped: review was not approved.",
+            operations_completed=(),
+            error=None,
+        )
+
+    store = RunStore(Path())
+    try:
+        run_record = store.load_run(run_id)
+    except ValueError as exc:
+        return PostReviewAutomationResult(
+            status="failed",
+            summary=f"Failed to load run record: {exc}",
+            operations_completed=(),
+            error=str(exc),
+        )
+
+    run_dir = Path(run_record.run_dir)
+    review_result = _load_post_publish_review_result(run_dir)
+
+    if review_result is None:
+        return PostReviewAutomationResult(
+            status="failed",
+            summary="Post-publish review result not found.",
+            operations_completed=(),
+            error="post-publish-review-result.json not found in run directory.",
+        )
+
+    if review_result.pull_number is None or review_result.pull_request_url is None:
+        return PostReviewAutomationResult(
+            status="failed",
+            summary="Post-publish review result is missing PR information.",
+            operations_completed=(),
+            error="pull_number or pull_request_url is None in review result.",
+        )
+
+    issue_ref = run_record.issue_ref
+    try:
+        issue_reference = _parse_issue_reference(issue_ref)
+    except ValueError as exc:
+        return PostReviewAutomationResult(
+            status="failed",
+            summary=f"Failed to parse issue reference: {exc}",
+            operations_completed=(),
+            error=str(exc),
+        )
+
+    owner = issue_reference.owner
+    repo = issue_reference.repo
+    pull_number = review_result.pull_number
+
+    operations: list[str] = []
+
+    def _execute_with_retry(operation_name: str, func) -> None:
+        """Execute a GitHub operation with one retry on network timeout."""
+        try:
+            func()
+            operations.append(operation_name)
+        except GitHubClientError as exc:
+            error_msg = str(exc)
+            if "timed out" in error_msg.lower() or "urlopen" in error_msg.lower():
+                logger.warning(f"{operation_name} timed out, retrying after 5 seconds...")
+                time.sleep(5)
+                try:
+                    func()
+                    operations.append(operation_name)
+                    return
+                except GitHubClientError as retry_exc:
+                    raise retry_exc
+            raise
+
+    def _mark_ready():
+        client.mark_pull_request_ready(owner, repo, pull_number)
+
+    def _merge():
+        client.merge_pull_request(owner, repo, pull_number)
+
+    def _close_issue():
+        client.close_issue(issue_reference)
+
+    client = GitHubWriteClient.from_env(token_env=token_env)
+
+    try:
+        _execute_with_retry("mark_pull_request_ready", _mark_ready)
+        _execute_with_retry("merge_pull_request", _merge)
+        _execute_with_retry("close_issue", _close_issue)
+    except GitHubClientError as exc:
+        return PostReviewAutomationResult(
+            status="failed",
+            summary=f"Automation failed: {exc}",
+            operations_completed=tuple(operations),
+            error=str(exc),
+        )
+
+    return PostReviewAutomationResult(
+        status="success",
+        summary="Post-review automation completed successfully.",
+        operations_completed=tuple(operations),
+        error=None,
+    )

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -192,3 +192,219 @@ def test_find_open_docs_remediation_issue_matches_by_fingerprint(
     )
 
     assert match == (3, "https://github.com/cracklings3d/markdown-pdf-renderer/issues/3")
+
+
+# --- Tests for GitHubWriteClient write methods (close_issue, merge_pull_request, close_pull_request, update_pull_request_branch) ---
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, payload: dict[str, object] | None = None) -> None:
+        self._payload = payload or {}
+
+    def __enter__(self) -> "_FakeUrlopenResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_close_issue_success_via_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_issue succeeds when gh CLI returns success."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_issue_via_gh",
+        lambda self, reference: True,
+    )
+
+    client = GitHubWriteClient("token")
+    reference = IssueReference("owner", "repo", 5)
+
+    # Should not raise
+    client.close_issue(reference)
+
+
+def test_close_issue_fallback_to_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_issue falls back to HTTP when gh CLI returns False."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_issue_via_gh",
+        lambda self, reference: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: {},
+    )
+
+    client = GitHubWriteClient("token")
+    reference = IssueReference("owner", "repo", 5)
+
+    # Should not raise
+    client.close_issue(reference)
+
+
+def test_close_issue_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_issue raises GitHubClientError on HTTP failure."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_issue_via_gh",
+        lambda self, reference: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: (_ for _ in ()).throw(
+            GitHubClientError("GitHub write failed: HTTP 403. Forbidden")
+        ),
+    )
+
+    client = GitHubWriteClient("token")
+    reference = IssueReference("owner", "repo", 5)
+
+    with pytest.raises(GitHubClientError, match="HTTP 403"):
+        client.close_issue(reference)
+
+
+def test_merge_pull_request_success_via_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """merge_pull_request succeeds when gh CLI returns True."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._merge_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: True,
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.merge_pull_request("owner", "repo", 5)
+
+
+def test_merge_pull_request_fallback_to_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """merge_pull_request falls back to HTTP when gh CLI returns False."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._merge_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: {},
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.merge_pull_request("owner", "repo", 5)
+
+
+def test_merge_pull_request_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """merge_pull_request raises GitHubClientError on HTTP failure."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._merge_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: (_ for _ in ()).throw(
+            GitHubClientError("GitHub write failed: HTTP 410. Resource not found")
+        ),
+    )
+
+    client = GitHubWriteClient("token")
+
+    with pytest.raises(GitHubClientError, match="HTTP 410"):
+        client.merge_pull_request("owner", "repo", 5)
+
+
+def test_close_pull_request_success_via_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_pull_request succeeds when gh CLI returns True."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: True,
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.close_pull_request("owner", "repo", 5)
+
+
+def test_close_pull_request_fallback_to_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_pull_request falls back to HTTP when gh CLI returns False."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: {},
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.close_pull_request("owner", "repo", 5)
+
+
+def test_close_pull_request_http_404_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_pull_request raises GitHubClientError on HTTP 404 failure (not 405 which is swallowed)."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._close_pull_request_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: (_ for _ in ()).throw(
+            GitHubClientError("GitHub write failed: HTTP 404. Not found")
+        ),
+    )
+
+    client = GitHubWriteClient("token")
+
+    with pytest.raises(GitHubClientError, match="HTTP 404"):
+        client.close_pull_request("owner", "repo", 5)
+
+
+def test_update_pull_request_branch_success_via_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """update_pull_request_branch succeeds when gh CLI returns True."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._update_pull_request_branch_via_gh",
+        lambda self, owner, repo, pull_number: True,
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.update_pull_request_branch("owner", "repo", 5)
+
+
+def test_update_pull_request_branch_fallback_to_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """update_pull_request_branch falls back to HTTP when gh CLI returns False."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._update_pull_request_branch_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: {},
+    )
+
+    client = GitHubWriteClient("token")
+
+    # Should not raise
+    client.update_pull_request_branch("owner", "repo", 5)
+
+
+def test_update_pull_request_branch_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """update_pull_request_branch raises GitHubClientError on HTTP failure."""
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._update_pull_request_branch_via_gh",
+        lambda self, owner, repo, pull_number: False,
+    )
+    monkeypatch.setattr(
+        "precision_squad.github_client.GitHubWriteClient._request_json",
+        lambda self, method, url, payload: (_ for _ in ()).throw(
+            GitHubClientError("GitHub write failed: HTTP 422. Validation failed")
+        ),
+    )
+
+    client = GitHubWriteClient("token")
+
+    with pytest.raises(GitHubClientError, match="HTTP 422"):
+        client.update_pull_request_branch("owner", "repo", 5)

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -15,12 +15,15 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
+    PostPublishReviewResult,
     RepairResult,
     RunRecord,
     SideIssue,
 )
 from precision_squad.publishing import (
+    PostReviewAutomationResult,
     RequiredDecisionLogArtifactMissingError,
+    apply_post_review_automation,
     build_publish_plan,
 )
 from precision_squad.run_store import RunStore
@@ -438,3 +441,253 @@ def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
     plan = build_publish_plan(intake, run_record, verdict, repair_result)
 
     assert plan.status == "issue_comment"
+
+
+# --- Tests for PostReviewAutomationResult dataclass ---
+
+import pytest
+from precision_squad.publishing import PostReviewAutomationResult
+
+
+def test_post_review_automation_result_success() -> None:
+    result = PostReviewAutomationResult(
+        status="success",
+        summary="All operations completed.",
+        operations_completed=("mark_pull_request_ready", "merge_pull_request", "close_issue"),
+    )
+    assert result.status == "success"
+    assert result.summary == "All operations completed."
+    assert result.operations_completed == (
+        "mark_pull_request_ready",
+        "merge_pull_request",
+        "close_issue",
+    )
+    assert result.error is None
+
+
+def test_post_review_automation_result_skipped() -> None:
+    result = PostReviewAutomationResult(
+        status="skipped",
+        summary="Automation skipped: review was not approved.",
+        operations_completed=(),
+    )
+    assert result.status == "skipped"
+    assert result.operations_completed == ()
+
+
+def test_post_review_automation_result_failed() -> None:
+    result = PostReviewAutomationResult(
+        status="failed",
+        summary="Automation failed: merge conflict.",
+        operations_completed=("mark_pull_request_ready",),
+        error="Merge conflict detected",
+    )
+    assert result.status == "failed"
+    assert result.error == "Merge conflict detected"
+
+
+def test_post_review_automation_result_frozen() -> None:
+    result = PostReviewAutomationResult(
+        status="success",
+        summary="Done.",
+        operations_completed=("merge_pull_request",),
+    )
+    with pytest.raises(AttributeError):
+        result.status = "failed"  # type: ignore[f_assignment]
+
+
+# --- Tests for apply_post_review_automation ---
+
+
+def test_apply_post_review_automation_skipped_when_not_approved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When approved=False, the function returns a skipped result without doing any GitHub operations."""
+    result = apply_post_review_automation(run_id="run-123", approved=False)
+    assert result.status == "skipped"
+    assert "not approved" in result.summary
+    assert result.operations_completed == ()
+    assert result.error is None
+
+
+def test_apply_post_review_automation_full_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When approved=True, all three operations complete successfully."""
+    from unittest.mock import MagicMock
+
+    run_id = "run-success-123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "post-publish-review-result.json").write_text(
+        json.dumps(
+            {
+                "status": "approved",
+                "summary": "PR approved by both reviewers.",
+                "pull_request_url": "https://github.com/owner/repo/pull/5",
+                "pull_number": 5,
+                "reviewer_status": "approved",
+                "reviewer_summary": "LGTM",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+
+    # Create a mock client with the required methods
+    mock_client = MagicMock()
+
+    monkeypatch.setattr(
+        "precision_squad.publishing.GitHubWriteClient.from_env",
+        lambda token_env: mock_client,
+    )
+    monkeypatch.setattr(
+        "precision_squad.publishing.RunStore.load_run",
+        lambda self, run_id: RunRecord(
+            run_id=run_id,
+            issue_ref="owner/repo#9",
+            status="runnable",
+            created_at="2026-04-28T00:00:00Z",
+            updated_at="2026-04-28T00:00:00Z",
+            run_dir=str(run_dir),
+        ),
+    )
+
+    result = apply_post_review_automation(run_id=run_id, approved=True)
+
+    assert result.status == "success"
+    assert result.operations_completed == (
+        "mark_pull_request_ready",
+        "merge_pull_request",
+        "close_issue",
+    )
+    assert result.error is None
+    # Verify the mock client methods were called
+    assert mock_client.mark_pull_request_ready.called
+    assert mock_client.merge_pull_request.called
+    assert mock_client.close_issue.called
+
+
+def test_apply_post_review_automation_failure_on_merge(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When merge fails, operations_completed contains the operations that ran before the failure."""
+    from unittest.mock import MagicMock
+
+    run_id = "run-merge-fail-123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "post-publish-review-result.json").write_text(
+        json.dumps(
+            {
+                "status": "approved",
+                "summary": "PR approved.",
+                "pull_request_url": "https://github.com/owner/repo/pull/5",
+                "pull_number": 5,
+                "reviewer_status": "approved",
+                "reviewer_summary": "LGTM",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+
+    from precision_squad.github_client import GitHubClientError
+
+    mock_client = MagicMock()
+    # make mark_pull_request_ready succeed, merge_pull_request fail
+    mock_client.mark_pull_request_ready.return_value = None
+    mock_client.merge_pull_request.side_effect = GitHubClientError(
+        "Merge failed: branch is out-of-date"
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.publishing.GitHubWriteClient.from_env",
+        lambda token_env: mock_client,
+    )
+    monkeypatch.setattr(
+        "precision_squad.publishing.RunStore.load_run",
+        lambda self, run_id: RunRecord(
+            run_id=run_id,
+            issue_ref="owner/repo#9",
+            status="runnable",
+            created_at="2026-04-28T00:00:00Z",
+            updated_at="2026-04-28T00:00:00Z",
+            run_dir=str(run_dir),
+        ),
+    )
+
+    result = apply_post_review_automation(run_id=run_id, approved=True)
+
+    assert result.status == "failed"
+    assert "merge" in result.summary.lower() or "failed" in result.summary.lower()
+    assert "mark_pull_request_ready" in result.operations_completed
+    assert "merge_pull_request" not in result.operations_completed
+    assert "close_issue" not in result.operations_completed
+    assert result.error is not None
+
+
+def test_apply_post_review_automation_failure_on_close_issue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When close_issue fails, operations_completed contains mark and merge but not close."""
+    from unittest.mock import MagicMock
+
+    run_id = "run-close-fail-123"
+    run_dir = tmp_path / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "post-publish-review-result.json").write_text(
+        json.dumps(
+            {
+                "status": "approved",
+                "summary": "PR approved.",
+                "pull_request_url": "https://github.com/owner/repo/pull/5",
+                "pull_number": 5,
+                "reviewer_status": "approved",
+                "reviewer_summary": "LGTM",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+
+    from precision_squad.github_client import GitHubClientError
+
+    mock_client = MagicMock()
+    # make mark_pull_request_ready and merge_pull_request succeed, close_issue fail
+    mock_client.mark_pull_request_ready.return_value = None
+    mock_client.merge_pull_request.return_value = None
+    mock_client.close_issue.side_effect = GitHubClientError(
+        "Issue close failed: state transition not allowed"
+    )
+
+    monkeypatch.setattr(
+        "precision_squad.publishing.GitHubWriteClient.from_env",
+        lambda token_env: mock_client,
+    )
+    monkeypatch.setattr(
+        "precision_squad.publishing.RunStore.load_run",
+        lambda self, run_id: RunRecord(
+            run_id=run_id,
+            issue_ref="owner/repo#9",
+            status="runnable",
+            created_at="2026-04-28T00:00:00Z",
+            updated_at="2026-04-28T00:00:00Z",
+            run_dir=str(run_dir),
+        ),
+    )
+
+    result = apply_post_review_automation(run_id=run_id, approved=True)
+
+    assert result.status == "failed"
+    assert "close" in result.summary.lower() or "failed" in result.summary.lower()
+    assert "mark_pull_request_ready" in result.operations_completed
+    assert "merge_pull_request" in result.operations_completed
+    assert "close_issue" not in result.operations_completed
+    assert result.error is not None

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -15,7 +15,6 @@ from precision_squad.models import (
     IssueAssessment,
     IssueIntake,
     IssueReference,
-    PostPublishReviewResult,
     RepairResult,
     RunRecord,
     SideIssue,
@@ -444,9 +443,6 @@ def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
 
 
 # --- Tests for PostReviewAutomationResult dataclass ---
-
-import pytest
-from precision_squad.publishing import PostReviewAutomationResult
 
 
 def test_post_review_automation_result_success() -> None:


### PR DESCRIPTION
## Summary

Implements post-review GitHub automation for ADR-008, adding `merge_pull_request`, `close_pull_request`, `update_pull_request_branch`, and `close_issue` methods to `GitHubWriteClient`, plus `apply_post_review_automation()` in `publishing.py`.

## Related Issue

- Closes #74

## What was built

### GitHubWriteClient additions (`src/precision_squad/github_client.py`)

| Method | GitHub API | Notes |
|--------|------------|-------|
| `close_issue(reference)` | `PATCH /repos/{owner}/{repo}/issues/{number}` `{state: "closed"}` | Closes linked issue after merge |
| `merge_pull_request(owner, repo, pull_number)` | `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge` | Rebase-merge PR |
| `close_pull_request(owner, repo, pull_number)` | `PATCH /repos/{owner}/{repo}/pulls/{pull_number}` `{state: "closed"}` | Closes PR |
| `update_pull_request_branch(owner, repo, pull_number)` | `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch` | Updates PR from base branch |

Each method first attempts the `gh` CLI, then falls back to the GitHub API with appropriate error handling for common non-fatal errors (409 for already-merged, 405 for state transitions).

### Post-review automation (`src/precision_squad/publishing.py`)

- `apply_post_review_automation(run_id, approved=True)` — marks PR ready, merges it via rebase, closes linked issue
- `apply_post_review_automation(run_id, approved=False)` — skips all GitHub operations (rejection side-effects handled by `post_publish_review.py`)

Failure behavior: stops immediately on first error, returns structured `PostReviewAutomationResult` with `operations_completed` list. No silent closes.

### Tests

- `tests/test_github_client.py` — 9 new tests for the new write methods
- `tests/test_publishing.py` — 6 new tests for `PostReviewAutomationResult` and `apply_post_review_automation`

## Acceptance Criteria

- [x] `GitHubWriteClient` has `merge_pull_request()`, `close_pull_request()`, `update_pull_request_branch()`, `close_issue()` methods
- [x] `apply_post_review_automation(run_id, approved=True)` merges PR and closes linked issue on approval
- [x] `apply_post_review_automation(run_id, approved=False)` emits info log and skips
- [x] Failed automation emits structured error and does NOT silently close issues
- [x] No GitHub mutations happen before `review impl` approval
- [x] Mocked tests cover the approval path and failure paths

## Blocked by

- #66 (ADR-008 — stage semantics, satisfied)
- #72, #73 (satisfied)