### PR TITLE
fix: Make --repo-path visible in help + fix non-interactive failure

### DIFF
--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -1171,7 +1171,7 @@ class _CommandConfigSpec:
 
 
 def _validate_repair_issue_args(args: dict[str, Any]) -> None:
-    _require_config_value(args, "repo_path")
+    _require_repair_issue_repo_path(args)
     args["runs_dir"] = _config_str(args.get("runs_dir"), key="runs_dir")
     args["repo_path"] = _config_str(args.get("repo_path"), key="repo_path")
     args["publish"] = _coerce_bool(args.get("publish"), key="publish")
@@ -1418,6 +1418,24 @@ def _require_config_value(args: dict[str, Any], key: str) -> None:
             f"Missing required value for {_arg_reference(key)}. "
             f"Provide --{key.replace('_', '-')} or set it in a precision-squad config file "
             f"at {format_config_search_locations()} under the active command's discovery root."
+        )
+
+
+def _require_repair_issue_repo_path(args: dict[str, Any]) -> None:
+    value = args.get("repo_path", argparse.SUPPRESS)
+    if value is argparse.SUPPRESS or value is None:
+        raise ValueError(
+            "repair issue could not resolve the target repository local checkout path from "
+            f"{_arg_reference('repo_path')} or [repair.issue].repo_path in a precision-squad "
+            f"config file at {format_config_search_locations()} under the active command's "
+            "discovery root."
+        )
+    if isinstance(value, str) and not value.strip():
+        raise ValueError(
+            "repair issue could not resolve the target repository local checkout path from "
+            f"{_arg_reference('repo_path')} or [repair.issue].repo_path in a precision-squad "
+            f"config file at {format_config_search_locations()} under the active command's "
+            "discovery root."
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1006,6 +1006,9 @@ def test_repair_issue_help_shows_current_choices_and_legacy_note(capsys) -> None
 
     captured = capsys.readouterr()
     assert exc_info.value.code == 0
+    assert "--repo-path REPO_PATH" in captured.out
+    assert "Local filesystem path to the target repository" in captured.out
+    assert "checkout." in captured.out
     assert "--repair-agent {opencode,none}" in captured.out
     assert "Defaults to opencode" in captured.out
     assert "when omitted. Normal choices: opencode, none." in captured.out
@@ -2609,11 +2612,18 @@ def test_missing_repo_path_error_lists_supported_config_locations(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "precision_squad.cli._prompt_for_run_selection",
+        lambda prior_runs: (_ for _ in ()).throw(AssertionError("prompt should not run")),
+    )
 
     status = main(["repair", "issue", "owner/repo#1"])
 
     captured = capsys.readouterr()
     assert status == 1
+    assert "repair issue could not resolve the target repository local checkout path" in captured.err
+    assert "'repo_path' (--repo-path)" in captured.err
+    assert "[repair.issue].repo_path" in captured.err
     assert "./.precision-squad.toml" in captured.err
     assert "./.precision-squad/precision-squad.toml" in captured.err
     assert "active command's discovery root" in captured.err


### PR DESCRIPTION
Closes #120

## Summary
- make `repair issue --help` visibly include `--repo-path` as the local checkout path for the target repository
- fail `repair issue` early with a deterministic non-interactive error when `repo_path` is missing from both CLI input and `[repair.issue].repo_path`
- add focused CLI regression coverage for the help contract and missing-path behavior

## Plan
- Approved plan: `C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\plans\issue-120.md`

## Notable implementation decisions
- keep repo-path validation scoped to `repair issue`
- preserve CLI-over-config precedence for `repo_path`
- do not introduce any interactive fallback or prompt

## Validation evidence
- Stage F already passed per controller input
- changed files remain scoped to `src/precision_squad/cli.py` and `tests/test_cli.py`