### PR TITLE
[#128] Fix Ruff violations in pipeline gate chain test

### DIFF
--- a/tests/integration/test_pipeline_gate_chain.py
+++ b/tests/integration/test_pipeline_gate_chain.py
@@ -15,7 +15,6 @@ import pytest
 
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
-    ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
     IssueAssessment,
@@ -35,7 +34,7 @@ def _runnable_intake(
             title="[Enhancement] Add --version flag to CLI",
             body="## Description\nAdd a version flag.",
             labels=("enhancement",),
-            html_url=f"https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
+            html_url="https://github.com/cracklings3d/markdown-pdf-renderer/issues/9",
         ),
         summary="Add --version flag to CLI",
         problem_statement="Add a version flag.",


### PR DESCRIPTION
Closes #128

## Approved plan
- `docs/implementation-plan.md`

## Implementation summary
- remove the unused `ApprovedPlan` import in `tests/integration/test_pipeline_gate_chain.py`
- replace the placeholder-free f-string with a plain string literal
- keep the test behavior and assertions unchanged

## Validation evidence
- Controller supplied: Stage F passed
- Issue verification target: `ruff check tests/integration/test_pipeline_gate_chain.py`

## Scope
- single-issue PR for #128
- changes limited to `tests/integration/test_pipeline_gate_chain.py`