### PR TITLE
[#130] Align retry carry-forward test seam

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,6 +236,15 @@ class StubRepairAdapter:
         self.qa_feedback: str | None = None
         self._file_content = file_content
 
+    def with_qa_feedback(self, feedback: str) -> StubRepairAdapter:
+        """Return an equivalent stub adapter carrying QA feedback."""
+        adapter = StubRepairAdapter(file_content=self._file_content)
+        adapter.binary = self.binary
+        adapter.agent = self.agent
+        adapter.model = self.model
+        adapter.qa_feedback = feedback
+        return adapter
+
     def repair(
         self,
         *,

--- a/tests/integration/test_retry_carry_forward.py
+++ b/tests/integration/test_retry_carry_forward.py
@@ -26,7 +26,7 @@ from precision_squad.models import (
 )
 from precision_squad.run_store import RunStore
 from tests.integration.conftest import StubRepairAdapter
-from tests.integration.support import _ApprovedTestDependencies, approved_plan_for
+from tests.integration.support import _ApprovedTestDependencies
 
 
 def _runnable_intake(issue_ref: str = "cracklings3d/markdown-pdf-renderer#9") -> IssueIntake:
@@ -207,8 +207,6 @@ def test_retry_does_not_overwrite_decision_log(
     # Capture original approved-plan.json content
     original_plan_path = previous_run_dir / "approved-plan.json"
     original_plan_content = original_plan_path.read_text(encoding="utf-8")
-    original_plan_data = json.loads(original_plan_content)
-
     # Capture original decision-log.attempt-1.json content
     original_decision_log_path = previous_run_dir / "decision-log.attempt-1.json"
     original_decision_log_content = original_decision_log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #130

## Summary
- remove the unused retry carry-forward test names in `tests/integration/test_retry_carry_forward.py`
- add `StubRepairAdapter.with_qa_feedback()` in `tests/integration/conftest.py` to satisfy the current `RepairAdapter` protocol
- preserve retry carry-forward behavior and keep the change scoped to the two planned test files

## Approved plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\plans\issue-130.md`

## Implementation notes
- scope matches the approved plan's allowed files only
- no production files under `src/` were modified
- branch was reconciled against current `origin/master` before PR creation

## Validation evidence
- `python -m ruff check tests/integration/test_retry_carry_forward.py tests/integration/conftest.py`
- `python -m pyright tests/integration/test_retry_carry_forward.py tests/integration/conftest.py`
- `python -m pytest tests/integration/test_retry_carry_forward.py`