### PR TITLE
[#122] Add /repair-issue command artifact

### DIFF
--- a/.opencode/commands/repair-issue.md
+++ b/.opencode/commands/repair-issue.md
@@ -1,0 +1,22 @@
+---
+description: Dry-run publish a GitHub issue repair
+---
+
+Handle GitHub issue repair requests only.
+
+Before continuing, load or use the `precision-squad` skill from `skills/precision-squad/SKILL.md`.
+
+Treat `$1` as `issue_ref`.
+
+- `issue_ref` is required and must be in `owner/repo#number` format.
+- If `$1` is missing, ask the user for `issue_ref` before running anything.
+
+Treat `$2` as `repo_path`.
+
+- `repo_path` is required and must be the local checkout path of the target repository.
+- If `$2` is missing, ask the user for `repo_path` before running anything.
+- If you are already in the target repository root, `repo_path` may be `.` and the command may use `--repo-path .`.
+
+After both values are known, run only:
+
+`python -m precision_squad.cli repair issue <issue_ref> --repo-path <repo_path> --publish --dry-run`


### PR DESCRIPTION
Closes #122

## Summary
- add `.opencode/commands/repair-issue.md` for the `/repair-issue` OpenCode slash command
- explicitly require loading or using `skills/precision-squad/SKILL.md`
- require `issue_ref` and `repo_path` inputs before running the bounded dry-run publish flow

## Approved plan
- `C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\plans\issue-122.md`

## Notable implementation decisions
- kept scope to the single command artifact only
- treated `$1` as `issue_ref` in `owner/repo#number` format
- treated `$2` as `repo_path` for the local checkout, allowing `.` at repo root
- runs only `python -m precision_squad.cli repair issue <issue_ref> --repo-path <repo_path> --publish --dry-run`

## Validation evidence
- implementation review pass completed by controller before merge coordination
- implementation commit: `37751f58556c4523a25709c2f6d82f8a4c764309`
- live diff confirms only `.opencode/commands/repair-issue.md` changed