### PR TITLE
[#119] Auto-approve fresh repair issue plan gate

### DIFF
--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -531,13 +531,23 @@ class RunCoordinator:
                 exit_code=issue_review_report.exit_code,
             )
 
-        # Persist the approved plan only if provided
-        if effective_approved_plan is not None:
+        compatibility_approved_plan = _build_compatibility_approved_plan(
+            store=store,
+            record=record,
+            attempt=attempt,
+            previous_run_dir=previous_run_dir,
+            effective_approved_plan=effective_approved_plan,
+            review_stages=params.review_stages,
+        )
+
+        # Persist the approved plan only if provided or synthesized for compatibility.
+        approved_plan_to_persist = effective_approved_plan or compatibility_approved_plan
+        if approved_plan_to_persist is not None:
             self.persist_approved_plan_for_planning(
                 params=PersistApprovedPlanParams(
                     run_id=record.run_id,
                     runs_dir=params.runs_dir,
-                    approved_plan=effective_approved_plan,
+                    approved_plan=approved_plan_to_persist,
                 )
             )
         plan_review_report = self.review_plan(
@@ -1726,6 +1736,67 @@ def _blocked_retry_report(*, intake: IssueIntake, issue_ref: str) -> RepairIssue
         ),
         exit_code=3,
     )
+
+
+def _build_compatibility_approved_plan(
+    *,
+    store: RunStore,
+    record: RunRecord,
+    attempt: int,
+    previous_run_dir: Path | None,
+    effective_approved_plan: ApprovedPlan | None,
+    review_stages: ReviewStagesOverride | None,
+) -> ApprovedPlan | None:
+    if not _should_auto_approve_compatibility_plan(
+        attempt=attempt,
+        previous_run_dir=previous_run_dir,
+        effective_approved_plan=effective_approved_plan,
+        review_stages=review_stages,
+    ):
+        return None
+
+    issue_draft = store.load_issue_draft(record.run_id)
+    return ApprovedPlan(
+        issue_ref=record.issue_ref,
+        plan_summary=issue_draft.summary,
+        implementation_steps=_derive_compatibility_implementation_steps(issue_draft),
+        named_references=(),
+        retrieval_surface_summary=(
+            "Compatibility auto-approved from same-run reviewed issue scope "
+            "(issue-draft.json summary and problem_statement); named_references omitted."
+        ),
+        approved=True,
+    )
+
+
+def _should_auto_approve_compatibility_plan(
+    *,
+    attempt: int,
+    previous_run_dir: Path | None,
+    effective_approved_plan: ApprovedPlan | None,
+    review_stages: ReviewStagesOverride | None,
+) -> bool:
+    return (
+        attempt == 1
+        and previous_run_dir is None
+        and effective_approved_plan is None
+        and review_stages is None
+    )
+
+
+def _derive_compatibility_implementation_steps(issue_draft: IssueDraft) -> tuple[str, ...]:
+    return (
+        f"Implement the reviewed issue scope: {_ensure_terminal_period(issue_draft.summary)}",
+        "Validate the change resolves the reviewed problem statement: "
+        f"{_ensure_terminal_period(issue_draft.problem_statement)}",
+    )
+
+
+def _ensure_terminal_period(value: str) -> str:
+    text = value.strip()
+    if text.endswith((".", "!", "?")):
+        return text
+    return f"{text}."
 
 
 def _load_issue_intake_artifact(run_dir: Path, *, expected_issue_ref: str) -> IssueIntake:

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -82,7 +82,7 @@ def test_missing_docs_blocks_pipeline(
     make_empty_repo,
     tmp_path: Path,
 ) -> None:
-    """A repo with no README triggers missing_docs and a follow_up_issue publish plan."""
+    """Fresh compatibility auto-approval still lets missing docs block before publish."""
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -117,17 +117,18 @@ def test_missing_docs_blocks_pipeline(
         dependencies=_BlockedTestDependencies(),
     )
 
-    # Per canonical plan #73: if plan review fails, the chain stops before implementation.
-    # In this test scenario, plan review fails because approved-plan.json is missing
-    # (persist_approved_plan_for_planning was not called or did not produce the artifact).
-    assert report.execution_result is None, "implementation should not run when plan review fails"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
-    # Chain stops at plan review - governance and publish stages are not reached
-    assert report.governance_verdict is None
+    assert report.plan_review.review_status == "approved"
+    assert report.execution_result is not None, "fresh compatibility path should continue into execution"
+    assert report.execution_result.status == "missing_docs"
+    assert (Path(report.run_record.run_dir) / "approved-plan.json").exists()
+    assert (Path(report.run_record.run_dir) / "plan-review.json").exists()
+    # Missing docs blocks at governance after execution; publish is not reached.
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
-    assert report.exit_code == 3
+    assert report.exit_code == 4
 
 
 @pytest.mark.integration
@@ -135,10 +136,10 @@ def test_missing_docs_persists_execution_artifacts(
     make_empty_repo,
     tmp_path: Path,
 ) -> None:
-    """When plan review fails (no approved plan), chain stops before execution.
+    """Missing-docs runs persist compatibility plan and execution artifacts.
 
-    Per canonical plan #73: if plan review fails, the chain stops before implementation.
-    No execution artifacts should exist because implementation did not run.
+    Fresh compatibility runs still materialize approved-plan/plan-review before
+    missing docs blocks governance.
     """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -174,15 +175,27 @@ def test_missing_docs_persists_execution_artifacts(
         dependencies=_BlockedTestDependencies(),
     )
 
-    # Per canonical plan #73: chain stops at plan review when no approved plan
-    assert report.execution_result is None, "implementation should not run when plan review fails"
+    run_dir = Path(report.run_record.run_dir)
+
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
-    # Chain stops at plan review - no execution artifacts
-    assert report.governance_verdict is None
+    assert report.plan_review.review_status == "approved"
+    assert report.execution_result is not None
+    assert report.execution_result.status == "missing_docs"
+    assert (run_dir / "approved-plan.json").exists()
+    assert (run_dir / "plan-review.json").exists()
+    assert (run_dir / "execution-result.json").exists()
+    assert (run_dir / "evaluation-result.json").exists()
+    assert (run_dir / "governance-verdict.json").exists()
+    assert not (run_dir / "repair-result.json").exists()
+    assert not (run_dir / "qa-baseline-result.json").exists()
+    assert not (run_dir / "qa-result.json").exists()
+    assert not (run_dir / "publish-plan.json").exists()
+    assert not (run_dir / "publish-result.json").exists()
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
-    assert report.exit_code == 3
+    assert report.exit_code == 4
 
 
 # ---------------------------------------------------------------------------
@@ -194,10 +207,9 @@ def test_ambiguous_docs_blocks_pipeline(
     make_ambiguous_repo,
     tmp_path: Path,
 ) -> None:
-    """When plan review fails (no approved plan), chain stops before ambiguous docs check.
+    """Fresh compatibility auto-approval still lets ambiguous docs block before publish.
 
-    Per canonical plan #73: if plan review fails, the chain stops before implementation.
-    Even though repo has ambiguous docs, execution should not run because plan review failed.
+    The plan gate is auto-approved on fresh runs, so the docs executor is reached.
     """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -233,31 +245,27 @@ def test_ambiguous_docs_blocks_pipeline(
         dependencies=_BlockedTestDependencies(),
     )
 
-    # Per canonical plan #73: chain stops at plan review when no approved plan
-    assert report.execution_result is None, "implementation should not run when plan review fails"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
-    # Chain stops at plan review - governance and publish stages are not reached
-    assert report.governance_verdict is None
+    assert report.plan_review.review_status == "approved"
+    assert report.execution_result is not None
+    assert report.execution_result.status == "ambiguous_docs"
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
-    assert report.exit_code == 3
+    assert report.exit_code == 4
 
 
 # ---------------------------------------------------------------------------
-# Blocked execution result from a custom executor stub
+# Clean docs without repair still complete after compatibility auto-approval
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
-def test_blocked_execution_result_blocks_pipeline(
+def test_clean_docs_without_repair_completes_pipeline(
     make_clean_repo,
     tmp_path: Path,
 ) -> None:
-    """When plan review fails (no approved plan), chain stops before execution.
-
-    Per canonical plan #73: if plan review fails, the chain stops before implementation.
-    Even with a clean repo, execution_result should be None because plan review failed.
-    """
+    """Fresh compatibility auto-approval reaches dry-run publish on clean docs."""
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -292,15 +300,19 @@ def test_blocked_execution_result_blocks_pipeline(
         dependencies=_BlockedTestDependencies(),
     )
 
-    # Per canonical plan #73: chain stops at plan review when no approved plan
-    assert report.execution_result is None, "implementation should not run when plan review fails"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
-    # Chain stops at plan review - no blocked execution result possible
-    assert report.governance_verdict is None
-    assert report.publish_plan is None
-    assert report.publish_result is None
-    assert report.exit_code == 3
+    assert report.plan_review.review_status == "approved"
+    assert report.execution_result is not None
+    assert report.execution_result.status == "completed"
+    assert report.repair_result is None
+    assert report.qa_result is None
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "approved"
+    assert report.publish_plan is not None
+    assert report.publish_plan.status == "draft_pr"
+    assert report.publish_result is not None
+    assert report.publish_result.status == "dry_run"
+    assert report.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -312,11 +324,9 @@ def test_qa_failed_blocks_pipeline(
     make_clean_repo,
     tmp_path: Path,
 ) -> None:
-    """When plan review fails (no approved plan), chain stops before repair/QA.
+    """Fresh compatibility auto-approval still allows repair/QA to block governance.
 
-    Per canonical plan #73: if plan review fails, the chain stops before implementation.
-    Even though repair_agent is set to "opencode", repair should not run because
-    plan review failed first.
+    Repair and QA should still execute on the fresh compatibility path.
     """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -354,17 +364,18 @@ def test_qa_failed_blocks_pipeline(
         dependencies=deps,
     )
 
-    # Per canonical plan #73: chain stops at plan review when no approved plan
-    assert report.repair_result is None, "repair should not run when plan review fails"
-    assert report.qa_result is None, "QA should not run when plan review fails"
-    assert report.execution_result is None, "implementation should not run when plan review fails"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
-    # Chain stops at plan review - governance is not reached
-    assert report.governance_verdict is None
+    assert report.plan_review.review_status == "approved"
+    assert report.repair_result is not None, "repair should run after compatibility auto-approval"
+    assert report.qa_result is not None, "QA should run after compatibility auto-approval"
+    assert report.qa_result.status == "failed"
+    assert report.execution_result is not None, "implementation result should reflect the QA failure"
+    assert report.execution_result.status == "blocked"
+    assert report.governance_verdict is not None
+    assert report.governance_verdict.status == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
-    assert report.exit_code == 3
+    assert report.exit_code == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_pipeline_gate_chain.py
+++ b/tests/integration/test_pipeline_gate_chain.py
@@ -1,7 +1,7 @@
-"""Integration tests: gate stop behavior and happy-path chain through RunCoordinator.
+"""Integration tests: plan gate behavior and happy-path chain through RunCoordinator.
 
 Verifies that chained execution:
-1. Stops at review gate (no approved_plan → blocked at review_plan)
+1. Auto-approves a fresh compatibility run with no approved_plan override
 2. Stops at governance gate (blocked verdict → no publish)
 3. Completes full happy path with all stages invoked
 4. Only invokes publish when governance verdict is approved
@@ -10,6 +10,7 @@ Verifies that chained execution:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal, cast
 
 import pytest
 
@@ -43,22 +44,16 @@ def _runnable_intake(
 
 
 # ---------------------------------------------------------------------------
-# Test 1: Chain stops at review gate (no approved plan → exit_code 3)
+# Test 1: Fresh compatibility run auto-approves and continues
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
-def test_chain_stops_at_review_gate_rejected(
+def test_chain_auto_approves_fresh_run_without_explicit_plan(
     make_clean_repo,
     stub_repair_adapter,
     tmp_path: Path,
 ) -> None:
-    """When no approved_plan is provided, review_plan returns blocked with exit_code 3.
-
-    Without approved_plan, persist_approved_plan_for_planning is not called,
-    so approved-plan.json is never written. When review_plan runs, it finds
-    approved_plan_path.exists() is False and returns review_status="blocked"
-    with exit_code=3. The chain stops at review_plan and implement is never invoked.
-    """
+    """Fresh attempt-1 compatibility runs synthesize canonical plan artifacts."""
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -70,7 +65,7 @@ def test_chain_stops_at_review_gate_rejected(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
-        # NOTE: approved_plan is intentionally omitted to trigger blocked review_plan
+        # NOTE: approved_plan is intentionally omitted to exercise compatibility auto-approval
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -81,13 +76,57 @@ def test_chain_stops_at_review_gate_rejected(
         dependencies=deps,
     )
 
-    assert report.exit_code != 0, "chain should stop at review gate"
-    assert report.execution_result is None, "implement should not be invoked"
+    run_dir = Path(report.run_record.run_dir)
+
+    assert report.exit_code == 0, "fresh run should continue past review_plan"
+    assert (run_dir / "approved-plan.json").exists()
+    assert (run_dir / "plan-review.json").exists()
     assert report.plan_review is not None, "review_plan should run"
-    assert report.plan_review.review_status == "blocked", "review_plan should be blocked"
-    assert report.governance_verdict is None, "governance should not run"
-    assert report.publish_plan is None, "publish_plan should not run"
-    assert report.publish_result is None, "publish_result should not run"
+    assert report.plan_review.review_status == "approved", "review_plan should be approved"
+    assert report.execution_result is not None, "implement should run after compatibility approval"
+    assert report.governance_verdict is not None, "governance should run"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("review_stages", ["plan", "all"])
+def test_chain_preserves_explicit_plan_gating_without_approved_plan(
+    make_clean_repo,
+    stub_repair_adapter,
+    tmp_path: Path,
+    review_stages: str,
+) -> None:
+    """Explicit review-stage gating must still stop runs lacking an approved plan."""
+    review_stages_value = cast(Literal["plan", "all"], review_stages)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+
+    params = RepairIssueParams(
+        issue_ref="cracklings3d/markdown-pdf-renderer#9",
+        runs_dir=runs_dir,
+        repo_path=make_clean_repo,
+        publish=False,
+        repair_agent="opencode",
+        repair_model=None,
+        review_model=None,
+        review_stages=review_stages_value,
+    )
+
+    deps = _ApprovedTestDependencies(stub_repair_adapter)
+
+    report = RunCoordinator().repair_issue(
+        params=params,
+        intake=_runnable_intake(),
+        dependencies=deps,
+    )
+
+    run_dir = Path(report.run_record.run_dir)
+    assert report.exit_code == 3
+    assert not (run_dir / "approved-plan.json").exists()
+    assert report.execution_result is None
+    assert report.plan_review is not None
+    assert report.plan_review.review_status == "blocked"
+    assert report.publish_plan is None
+    assert report.publish_result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Literal, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -217,6 +218,130 @@ def test_repair_issue_stops_after_failed_plan_review(tmp_path: Path, monkeypatch
     assert not (run_dir / "execution-result.json").exists()
     assert not (run_dir / "publish-plan.json").exists()
     dependencies.execute_publish_plan.assert_not_called()
+
+
+def test_repair_issue_auto_approves_fresh_attempt_one_without_explicit_plan(
+    tmp_path: Path, monkeypatch
+) -> None:
+    dependencies = MagicMock()
+    dependencies.synthesis_artifacts_ready.return_value = False
+    dependencies.execute_publish_plan.return_value = PublishResult(
+        status="dry_run",
+        target="draft_pr",
+        summary="Dry run only.",
+        url=None,
+    )
+    dependencies.run_post_publish_review_if_needed.return_value = None
+
+    import precision_squad.coordinator as coord_module
+
+    monkeypatch.setattr(
+        coord_module.DocsFirstExecutor,
+        "execute",
+        lambda self, intake, run_record, run_dir: ExecutionResult(
+            status="completed",
+            executor_name="docs",
+            summary="Execution completed.",
+            detail_codes=(),
+        ),
+    )
+
+    report = RunCoordinator().repair_issue(
+        params=RepairIssueParams(
+            issue_ref="owner/repo#1",
+            runs_dir=tmp_path / "runs",
+            repo_path=tmp_path / "repo",
+            publish=False,
+            repair_agent="none",
+            repair_model=None,
+            review_model=None,
+            approved_plan=None,
+        ),
+        intake=_make_intake(),
+        dependencies=dependencies,
+    )
+
+    run_dir = Path(report.run_record.run_dir)
+    approved_plan = RunStore.load_approved_plan(run_dir, issue_ref="owner/repo#1")
+    plan_review = RunStore.load_plan_review(
+        run_dir,
+        issue_ref="owner/repo#1",
+        expected_run_id=report.run_record.run_id,
+    )
+
+    assert report.exit_code == 0
+    assert report.plan_review is not None
+    assert report.plan_review.review_status == "approved"
+    assert approved_plan.plan_summary == "Test issue"
+    assert approved_plan.implementation_steps == (
+        "Implement the reviewed issue scope: Test issue.",
+        "Validate the change resolves the reviewed problem statement: Fix the bug.",
+    )
+    assert "same-run reviewed issue scope" in approved_plan.retrieval_surface_summary
+    assert approved_plan.named_references == ()
+    assert plan_review.review_status == "approved"
+    assert plan_review.provenance.run_id == report.run_record.run_id
+    assert plan_review.provenance.issue_ref == "owner/repo#1"
+
+
+@pytest.mark.parametrize("review_stages", ["plan", "all"])
+def test_repair_issue_respects_explicit_review_stage_gating_without_plan(
+    tmp_path: Path, review_stages: str
+) -> None:
+    review_stages_value = cast(Literal["plan", "all"], review_stages)
+    dependencies = MagicMock()
+
+    report = RunCoordinator().repair_issue(
+        params=RepairIssueParams(
+            issue_ref="owner/repo#1",
+            runs_dir=tmp_path / "runs",
+            repo_path=tmp_path / "repo",
+            publish=False,
+            repair_agent="none",
+            repair_model=None,
+            review_model=None,
+            review_stages=review_stages_value,
+            approved_plan=None,
+        ),
+        intake=_make_intake(),
+        dependencies=dependencies,
+    )
+
+    run_dir = Path(report.run_record.run_dir)
+    assert report.exit_code == 3
+    assert report.plan_review is not None
+    assert report.plan_review.review_status == "blocked"
+    assert not (run_dir / "approved-plan.json").exists()
+    assert not (run_dir / "execution-result.json").exists()
+    dependencies.execute_publish_plan.assert_not_called()
+
+
+def test_repair_issue_retry_without_prior_approved_plan_still_fails_before_compatibility_path(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    previous_record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)),
+        _make_intake(),
+    )
+
+    with pytest.raises(ValueError, match="Retry requires a prior approved-plan.json"):
+        RunCoordinator().repair_issue(
+            params=RepairIssueParams(
+                issue_ref="owner/repo#1",
+                runs_dir=runs_dir,
+                repo_path=tmp_path / "repo",
+                publish=False,
+                repair_agent="none",
+                repair_model=None,
+                review_model=None,
+                retry_from=previous_record.run_id,
+                approved_plan=None,
+            ),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
 
 
 def test_repair_issue_stops_before_publish_when_governance_blocked(


### PR DESCRIPTION
## Summary
- implement the issue #119 coordinator-local compatibility auto-approval path for fresh attempt-1 `repair issue` runs without an approved plan override
- preserve the canonical staged artifact contract by materializing same-run `approved-plan.json` before approved `plan-review.json`
- add focused coordinator and integration coverage for eligible, explicitly gated, and retry-preservation paths

## Plan
- Canonical plan: `C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\plans\issue-119.md`

## Notable implementation decisions
- keep the eligibility seam inside `RunCoordinator.repair_issue`
- synthesize a compatibility `ApprovedPlan` from same-run reviewed issue scope only
- preserve explicit `review_stages` gating and retry behavior

## Validation
- `PYTHONPATH=src python -m pytest tests/test_coordinator.py tests/integration/test_pipeline_gate_chain.py`

Closes #119