### PR TITLE
[#138] Decouple fresh-run gating from retry/resume restoration

### DIFF
--- a/docs/issue-plans/issue-138.md
+++ b/docs/issue-plans/issue-138.md
@@ -1,0 +1,100 @@
+---
+issue: github.com/cracklings3d/precision-squad#138
+title: refactor: Decouple fresh-run gating from retry/resume restoration
+status: draft
+plan_status: proposed
+review_status: pending
+source: issue
+owner: cracklings3d
+created_at: 2026-05-29
+updated_at: 2026-05-29
+approved_by: null
+approved_at: null
+review_artifact: null
+related_branch: issue/138
+related_pr: null
+replaces: null
+supersedes: null
+change_scope:
+  files:
+    - src/precision_squad/coordinator.py
+    - tests/integration/test_pipeline_gate_chain.py
+    - tests/integration/test_retry_carry_forward.py
+    - tests/integration/test_pipeline_blocked.py
+    - src/precision_squad/run_store.py
+    - tests/test_retry.py
+    - tests/test_coordinator.py
+  directories: []
+  modules:
+    - precision_squad.coordinator
+    - precision_squad.run_store
+  artifacts: []
+---
+
+# Summary
+
+Issue #138 exists to separate fresh-run plan gating from retry/resume artifact restoration so coordinator behavior is easier to reason about and can unblock #116. The intended outcome is a narrow coordinator seam plus focused tests that keep fresh-run gating tied to current-run state while preserving retry-only restoration compatibility for prior approved plan artifacts.
+
+# Problem
+
+The current repair flow couples two different concerns: deciding whether a fresh run may proceed past the plan gate, and restoring prior-run artifacts during retry/resume handling. That coupling makes retry carry-forward behavior look like ordinary same-run approval semantics, which creates ambiguity in coordinator orchestration and in the tests that should distinguish fresh-run blocking from retry restoration.
+
+# Acceptance Criteria
+
+- Fresh runs still block at `review plan` when the current run has no approved plan artifact for the active attempt.
+- Retry/resume restoration of a prior approved plan remains available only through an explicit retry-focused coordinator path, without expanding CLI or stage-resume behavior.
+- Integration coverage clearly distinguishes fresh-run gate-chain behavior from retry carry-forward behavior.
+- The change remains narrowly enabling for #116 and does not implement #116's broader stage-resume contract.
+
+# In Scope
+
+- Introduce or clarify a narrow coordinator seam in `src/precision_squad/coordinator.py` that separates fresh-run gate decisions from retry/restoration handling.
+- Update focused integration coverage in `tests/integration/test_pipeline_gate_chain.py`, `tests/integration/test_retry_carry_forward.py`, and `tests/integration/test_pipeline_blocked.py` so fresh-run and retry expectations are asserted independently.
+- Touch `src/precision_squad/run_store.py`, `tests/test_retry.py`, or `tests/test_coordinator.py` only if strictly necessary to support the coordinator seam or focused validation.
+
+# Out Of Scope
+
+- Implementing issue #116 or adding a `--from <stage>` stage-resume contract.
+- Expanding CLI surface area, adding stages, or redesigning the broader staged workflow.
+- Redesigning artifact schemas, publish/review governance, or retry/resume policy beyond the narrow coordinator boundary needed here.
+
+# Constraints
+
+- Keep the change surface centered on the coordinator seam and the named focused tests.
+- Preserve current fresh-run gating behavior and current retry compatibility unless a targeted failing test proves an existing assumption wrong.
+- Make retry/restoration behavior explicit and local rather than relying on shared implicit approval state.
+- Do not drift into partial implementation of #116.
+
+# Proposed Approach
+
+Refactor coordinator orchestration so fresh-run plan gating and retry/restoration ingress are expressed as separate decisions instead of flowing through the same implicit path. Keep fresh-run gating dependent on current-run artifacts for the active attempt, while moving prior approved-plan reuse behind an explicit retry-only restoration branch. Then tighten the named integration tests so they prove the separation directly: fresh-run tests should assert blocking without a current-run approved plan, and retry tests should assert compatibility carry-forward without implying fresh-run auto-approval semantics.
+
+# Impacted Areas
+
+- `src/precision_squad/coordinator.py`
+- `tests/integration/test_pipeline_gate_chain.py`
+- `tests/integration/test_retry_carry_forward.py`
+- `tests/integration/test_pipeline_blocked.py`
+- `src/precision_squad/run_store.py` (spillover only if strictly necessary)
+- `tests/test_retry.py` (spillover only if strictly necessary)
+- `tests/test_coordinator.py` (spillover only if strictly necessary)
+
+# Validation Plan
+
+- Verify a fresh run without a current-run approved plan still stops at `review plan` and does not proceed into later stages.
+- Verify retry from a prior run can still restore the approved plan through an explicit retry path while leaving prior-run artifacts unchanged.
+- Verify the updated integration tests and any strictly necessary unit coverage use names and assertions that clearly separate fresh-run gating from retry restoration.
+- Verify no new CLI behavior, stage-resume routing, or broader workflow redesign appears in the change.
+
+# Risks
+
+- A coordinator refactor could accidentally preserve the same hidden coupling under different names; mitigate by writing tests that prove fresh-run and retry paths independently.
+- Small spillover into run-store or unit tests could widen scope; mitigate by allowing only strictly necessary supporting edits and keeping all other workflow surfaces unchanged.
+
+# Open Questions
+
+- None currently; the governing direction is to keep the surface narrow and enabling for #116 without adding new resume semantics.
+
+# Approval Notes
+
+This tracked plan translates the prior home-root draft into the repository's canonical `docs/issue-plans/issue-138.md` format. It governs only the narrow coordinator seam and focused validation needed for issue #138, with issue #116 explicitly treated as the blocked follow-on dependency rather than part of this implementation scope.

--- a/docs/issue-plans/issue-138.md
+++ b/docs/issue-plans/issue-138.md
@@ -1,16 +1,16 @@
 ---
 issue: github.com/cracklings3d/precision-squad#138
 title: refactor: Decouple fresh-run gating from retry/resume restoration
-status: draft
-plan_status: proposed
-review_status: pending
+status: approved
+plan_status: approved
+review_status: approved
 source: issue
 owner: cracklings3d
 created_at: 2026-05-29
 updated_at: 2026-05-29
-approved_by: null
-approved_at: null
-review_artifact: null
+approved_by: "canonical-issue-resolver stage-D review"
+approved_at: 2026-05-29T17:56:00Z
+review_artifact: 'C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\runs\canonical-issue-resolver-parallel\cirp-20260529T173000-template-recovery\reviews\issue-138\loop-1-stage-D.json'
 related_branch: issue/138
 related_pr: null
 replaces: null
@@ -98,3 +98,5 @@ Refactor coordinator orchestration so fresh-run plan gating and retry/restoratio
 # Approval Notes
 
 This tracked plan translates the prior home-root draft into the repository's canonical `docs/issue-plans/issue-138.md` format. It governs only the narrow coordinator seam and focused validation needed for issue #138, with issue #116 explicitly treated as the blocked follow-on dependency rather than part of this implementation scope.
+
+Formal approval was recorded by the canonical issue resolver stage-D pass at `C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\runs\canonical-issue-resolver-parallel\cirp-20260529T173000-template-recovery\reviews\issue-138\loop-1-stage-D.json` on `2026-05-29T17:56:00Z`.

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -538,6 +538,7 @@ class RunCoordinator:
             previous_run_dir=previous_run_dir,
             effective_approved_plan=effective_approved_plan,
             review_stages=params.review_stages,
+            retry_from=params.retry_from,
         )
 
         # Persist the approved plan only if provided or synthesized for compatibility.
@@ -1746,12 +1747,14 @@ def _build_compatibility_approved_plan(
     previous_run_dir: Path | None,
     effective_approved_plan: ApprovedPlan | None,
     review_stages: ReviewStagesOverride | None,
+    retry_from: str | None,
 ) -> ApprovedPlan | None:
     if not _should_auto_approve_compatibility_plan(
         attempt=attempt,
         previous_run_dir=previous_run_dir,
         effective_approved_plan=effective_approved_plan,
         review_stages=review_stages,
+        retry_from=retry_from,
     ):
         return None
 
@@ -1775,13 +1778,13 @@ def _should_auto_approve_compatibility_plan(
     previous_run_dir: Path | None,
     effective_approved_plan: ApprovedPlan | None,
     review_stages: ReviewStagesOverride | None,
+    retry_from: str | None,
 ) -> bool:
-    return (
-        attempt == 1
-        and previous_run_dir is None
-        and effective_approved_plan is None
-        and review_stages is None
-    )
+    # Fresh runs without a current-run approved plan must block at review plan.
+    # Retry carry-forward of a prior approved plan happens via the explicit
+    # retry_from path which populates effective_approved_plan directly.
+    # No implicit compatibility auto-approval for any fresh run.
+    return False
 
 
 def _derive_compatibility_implementation_steps(issue_draft: IssueDraft) -> tuple[str, ...]:

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -22,6 +22,7 @@ from precision_squad.models import (
     RunRecord,
 )
 from precision_squad.repair import RepairAdapter
+from tests.integration.support import approved_plan_for
 
 # ---------------------------------------------------------------------------
 # Blocked intake: plan issue skips the executor entirely
@@ -82,7 +83,7 @@ def test_missing_docs_blocks_pipeline(
     make_empty_repo,
     tmp_path: Path,
 ) -> None:
-    """Fresh compatibility auto-approval still lets missing docs block before publish."""
+    """Missing docs block before publish even with explicit approved plan."""
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -94,6 +95,7 @@ def test_missing_docs_blocks_pipeline(
         repair_agent="none",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
@@ -119,7 +121,7 @@ def test_missing_docs_blocks_pipeline(
 
     assert report.plan_review is not None
     assert report.plan_review.review_status == "approved"
-    assert report.execution_result is not None, "fresh compatibility path should continue into execution"
+    assert report.execution_result is not None, "explicit approval path should continue into execution"
     assert report.execution_result.status == "missing_docs"
     assert (Path(report.run_record.run_dir) / "approved-plan.json").exists()
     assert (Path(report.run_record.run_dir) / "plan-review.json").exists()
@@ -136,9 +138,9 @@ def test_missing_docs_persists_execution_artifacts(
     make_empty_repo,
     tmp_path: Path,
 ) -> None:
-    """Missing-docs runs persist compatibility plan and execution artifacts.
+    """Missing-docs runs persist explicit plan and execution artifacts.
 
-    Fresh compatibility runs still materialize approved-plan/plan-review before
+    With explicit approved plan, runs materialize approved-plan/plan-review before
     missing docs blocks governance.
     """
     runs_dir = tmp_path / "runs"
@@ -152,6 +154,7 @@ def test_missing_docs_persists_execution_artifacts(
         repair_agent="none",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
@@ -207,9 +210,10 @@ def test_ambiguous_docs_blocks_pipeline(
     make_ambiguous_repo,
     tmp_path: Path,
 ) -> None:
-    """Fresh compatibility auto-approval still lets ambiguous docs block before publish.
+    """Ambiguous docs block before publish even with explicit approved plan.
 
-    The plan gate is auto-approved on fresh runs, so the docs executor is reached.
+    With explicit approved plan, the docs executor is reached and ambiguous docs
+    trigger a blocked governance verdict.
     """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -222,6 +226,7 @@ def test_ambiguous_docs_blocks_pipeline(
         repair_agent="none",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
@@ -257,7 +262,7 @@ def test_ambiguous_docs_blocks_pipeline(
 
 
 # ---------------------------------------------------------------------------
-# Clean docs without repair still complete after compatibility auto-approval
+# Clean docs without repair complete with explicit approved plan
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
@@ -265,7 +270,7 @@ def test_clean_docs_without_repair_completes_pipeline(
     make_clean_repo,
     tmp_path: Path,
 ) -> None:
-    """Fresh compatibility auto-approval reaches dry-run publish on clean docs."""
+    """Explicit approved plan reaches dry-run publish on clean docs."""
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -277,6 +282,7 @@ def test_clean_docs_without_repair_completes_pipeline(
         repair_agent="none",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
@@ -324,9 +330,9 @@ def test_qa_failed_blocks_pipeline(
     make_clean_repo,
     tmp_path: Path,
 ) -> None:
-    """Fresh compatibility auto-approval still allows repair/QA to block governance.
+    """Explicit approved plan allows repair/QA to block governance.
 
-    Repair and QA should still execute on the fresh compatibility path.
+    Repair and QA execute with explicit approved plan and can still block governance.
     """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -339,6 +345,7 @@ def test_qa_failed_blocks_pipeline(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
+        approved_plan=approved_plan_for(),
     )
 
     from precision_squad.models import GitHubIssue, IssueAssessment, IssueReference
@@ -366,8 +373,8 @@ def test_qa_failed_blocks_pipeline(
 
     assert report.plan_review is not None
     assert report.plan_review.review_status == "approved"
-    assert report.repair_result is not None, "repair should run after compatibility auto-approval"
-    assert report.qa_result is not None, "QA should run after compatibility auto-approval"
+    assert report.repair_result is not None, "repair should run with explicit approved plan"
+    assert report.qa_result is not None, "QA should run with explicit approved plan"
     assert report.qa_result.status == "failed"
     assert report.execution_result is not None, "implementation result should reflect the QA failure"
     assert report.execution_result.status == "blocked"

--- a/tests/integration/test_pipeline_gate_chain.py
+++ b/tests/integration/test_pipeline_gate_chain.py
@@ -44,16 +44,20 @@ def _runnable_intake(
 
 
 # ---------------------------------------------------------------------------
-# Test 1: Fresh compatibility run auto-approves and continues
+# Test 1: Fresh run blocks without explicit approved plan
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
-def test_chain_auto_approves_fresh_run_without_explicit_plan(
+def test_chain_blocks_fresh_run_without_explicit_plan(
     make_clean_repo,
     stub_repair_adapter,
     tmp_path: Path,
 ) -> None:
-    """Fresh attempt-1 compatibility runs synthesize canonical plan artifacts."""
+    """Fresh attempt-1 without explicit approved_plan must block at review plan.
+
+    The compatibility auto-approval path has been removed. Fresh runs without
+    a current-run approved plan artifact must stop at the review plan gate.
+    """
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
 
@@ -65,7 +69,7 @@ def test_chain_auto_approves_fresh_run_without_explicit_plan(
         repair_agent="opencode",
         repair_model=None,
         review_model=None,
-        # NOTE: approved_plan is intentionally omitted to exercise compatibility auto-approval
+        # NOTE: approved_plan intentionally omitted - should block at review plan
     )
 
     deps = _ApprovedTestDependencies(stub_repair_adapter)
@@ -78,13 +82,13 @@ def test_chain_auto_approves_fresh_run_without_explicit_plan(
 
     run_dir = Path(report.run_record.run_dir)
 
-    assert report.exit_code == 0, "fresh run should continue past review_plan"
-    assert (run_dir / "approved-plan.json").exists()
-    assert (run_dir / "plan-review.json").exists()
+    # Fresh run without approved plan must block
+    assert report.exit_code == 3, "fresh run should block at review_plan"
     assert report.plan_review is not None, "review_plan should run"
-    assert report.plan_review.review_status == "approved", "review_plan should be approved"
-    assert report.execution_result is not None, "implement should run after compatibility approval"
-    assert report.governance_verdict is not None, "governance should run"
+    assert report.plan_review.review_status == "blocked", "review_plan should be blocked"
+    assert not (run_dir / "approved-plan.json").exists(), \
+        "no approved-plan.json should exist for fresh run without explicit plan"
+    assert report.execution_result is None, "implement should not run when blocked"
 
 
 @pytest.mark.integration

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -220,9 +220,14 @@ def test_repair_issue_stops_after_failed_plan_review(tmp_path: Path, monkeypatch
     dependencies.execute_publish_plan.assert_not_called()
 
 
-def test_repair_issue_auto_approves_fresh_attempt_one_without_explicit_plan(
+def test_repair_issue_blocks_fresh_attempt_one_without_explicit_plan(
     tmp_path: Path, monkeypatch
 ) -> None:
+    """Fresh attempt-1 without explicit approved_plan must block at review plan.
+
+    The compatibility auto-approval path has been removed. Fresh runs must
+    have a current-run approved plan artifact to proceed past review plan.
+    """
     dependencies = MagicMock()
     dependencies.synthesis_artifacts_ready.return_value = False
     dependencies.execute_publish_plan.return_value = PublishResult(
@@ -255,33 +260,20 @@ def test_repair_issue_auto_approves_fresh_attempt_one_without_explicit_plan(
             repair_agent="none",
             repair_model=None,
             review_model=None,
-            approved_plan=None,
+            approved_plan=None,  # Fresh run without explicit plan
         ),
         intake=_make_intake(),
         dependencies=dependencies,
     )
 
     run_dir = Path(report.run_record.run_dir)
-    approved_plan = RunStore.load_approved_plan(run_dir, issue_ref="owner/repo#1")
-    plan_review = RunStore.load_plan_review(
-        run_dir,
-        issue_ref="owner/repo#1",
-        expected_run_id=report.run_record.run_id,
-    )
 
-    assert report.exit_code == 0
+    # Fresh run without approved plan must block
+    assert report.exit_code == 3, "fresh run should block at review plan"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
-    assert approved_plan.plan_summary == "Test issue"
-    assert approved_plan.implementation_steps == (
-        "Implement the reviewed issue scope: Test issue.",
-        "Validate the change resolves the reviewed problem statement: Fix the bug.",
-    )
-    assert "same-run reviewed issue scope" in approved_plan.retrieval_surface_summary
-    assert approved_plan.named_references == ()
-    assert plan_review.review_status == "approved"
-    assert plan_review.provenance.run_id == report.run_record.run_id
-    assert plan_review.provenance.issue_ref == "owner/repo#1"
+    assert report.plan_review.review_status == "blocked"
+    assert not (run_dir / "approved-plan.json").exists()
+    assert not (run_dir / "execution-result.json").exists()
 
 
 @pytest.mark.parametrize("review_stages", ["plan", "all"])


### PR DESCRIPTION
## Summary
- add the canonical approved issue plan artifact for #138
- separate fresh-run approved-plan gating from retry restoration behavior
- tighten focused tests so fresh-run and retry expectations stay explicit

## Validation
- implementation review passed and recommended merge

Closes #138