### PR TITLE
feat: Implement stage-resume retry capability

### DIFF
--- a/docs/staged-command-surface.md
+++ b/docs/staged-command-surface.md
@@ -93,7 +93,12 @@ create issue → review issue → plan → review plan → implement → publish
 
 **Inputs:**
 - `governance-verdict.json` — must contain `verdict: approved`
-- Implementation artifacts from `implement`
+- `execution-result.json`
+- `repair-result.json`
+- `qa-baseline-result.json`
+- `qa-result.json`
+- `evaluation-result.json`
+- `decision-log.attempt-{attempt}.json`
 
 **Outputs:**
 - `publish-plan.json`

--- a/docs/staged-command-surface.md
+++ b/docs/staged-command-surface.md
@@ -175,7 +175,7 @@ Earlier-stage history is preserved by copying only the artifacts before the sele
 | `plan` | approved `issue-review.json` | `issue-draft.json`, `issue-review.json` | `approved-plan.json` and later artifacts |
 | `review plan` | valid `approved-plan.json` | `issue-draft.json`, `issue-review.json`, `approved-plan.json` | `plan-review.json` and later artifacts |
 | `implement` | valid `approved-plan.json`, approved `plan-review.json` | issue/planning artifacts through `plan-review.json` | implement-stage artifacts and later artifacts |
-| `publish` | approved implement-stage artifacts, preserved decision log, preserved `repair-workspace/repo` | planning + implement artifacts required for publish | `publish-plan.json`, `publish-result.json`, review-impl outputs |
+| `publish` | `issue-draft.json`, approved `issue-review.json`, `approved-plan.json`, approved `plan-review.json`, `execution-result.json`, completed `repair-result.json` with `workspace_path`, `qa-baseline-result.json`, `qa-result.json`, `evaluation-result.json`, approved `governance-verdict.json`, `decision-log.attempt-{attempt}.json`, preserved `repair-workspace/repo` | planning + implement artifacts required for publish | `publish-plan.json`, `publish-result.json`, review-impl outputs |
 | `review impl` | `approved-plan.json`, `issue-intake.json`, `publish-plan.json`, published-draft-PR `publish-result.json` | earlier artifacts plus publish artifacts | `impl-review.json`, `post-publish-review-result.json` |
 
 `impl-review.json` is produced by `review impl`. It is not an input to `review impl` resume.

--- a/docs/staged-command-surface.md
+++ b/docs/staged-command-surface.md
@@ -75,11 +75,13 @@ create issue → review issue → plan → review plan → implement → publish
 - `plan-review.json`
 
 **Outputs:**
-- `impl-review.json`
+- `execution-result.json`
 - `repair-result.json`
+- `qa-baseline-result.json`
 - `qa-result.json`
 - `evaluation-result.json`
 - `governance-verdict.json`
+- `decision-log.attempt-{attempt}.json`
 
 **Gate Behavior:** Governance check after implement. If `governance-verdict.json` does not contain `verdict: approved`, `publish` is not invoked.
 
@@ -107,10 +109,13 @@ create issue → review issue → plan → review plan → implement → publish
 **Purpose:** Final review of the draft PR prior to merge automation.
 
 **Inputs:**
-- Draft PR URL/number and head SHA
-- `impl-review.json`
+- `approved-plan.json`
+- `issue-intake.json`
+- `publish-plan.json`
+- `publish-result.json` for a published draft PR with URL / PR number metadata
 
 **Outputs:**
+- `impl-review.json`
 - `post-publish-review-result.json` — consumed by GitHub automation
 
 **Gate Behavior:** n/a (final review stage; outcomes handled by GitHub automation).
@@ -125,11 +130,52 @@ create issue → review issue → plan → review plan → implement → publish
 | `issue-review.json` | review issue |
 | `approved-plan.json` | plan |
 | `plan-review.json` | review plan |
-| `impl-review.json` | implement |
+| `execution-result.json` | implement |
 | `governance-verdict.json` | implement |
 | `repair-result.json` | implement |
+| `qa-baseline-result.json` | implement |
 | `qa-result.json` | implement |
 | `evaluation-result.json` | implement |
+| `decision-log.attempt-{attempt}.json` | implement |
 | `publish-plan.json` | publish |
 | `publish-result.json` | publish |
+| `impl-review.json` | review impl |
 | `post-publish-review-result.json` | review impl |
+
+---
+
+## `repair issue` manual retry resume contract
+
+`repair issue --retry-from <run-id> --from "<stage>"` supports exactly these resume targets:
+
+- `review issue`
+- `plan`
+- `review plan`
+- `implement`
+- `publish`
+- `review impl`
+
+`--from` is valid only with `--retry-from`. It is not supported on standalone stage commands.
+
+### Non-stage context artifacts on resumed retries
+
+Every resumed retry attempt materializes a complete same-run context pack before the selected stage runs:
+
+- `run-request.json` — recreated for the new attempt from the current invocation
+- `issue-intake.json` — copied forward from the source attempt
+- `issue.md` — regenerated from the preserved intake for the new attempt
+
+Earlier-stage history is preserved by copying only the artifacts before the selected resume point into the new attempt directory. Prior run directories remain unchanged.
+
+### Resume matrix
+
+| Resume target | Required in source run | Preserved into new attempt | Regenerated in new attempt |
+|---|---|---|---|
+| `review issue` | `issue-draft.json` | `issue-draft.json` | `issue-review.json` and later artifacts |
+| `plan` | approved `issue-review.json` | `issue-draft.json`, `issue-review.json` | `approved-plan.json` and later artifacts |
+| `review plan` | valid `approved-plan.json` | `issue-draft.json`, `issue-review.json`, `approved-plan.json` | `plan-review.json` and later artifacts |
+| `implement` | valid `approved-plan.json`, approved `plan-review.json` | issue/planning artifacts through `plan-review.json` | implement-stage artifacts and later artifacts |
+| `publish` | approved implement-stage artifacts, preserved decision log, preserved `repair-workspace/repo` | planning + implement artifacts required for publish | `publish-plan.json`, `publish-result.json`, review-impl outputs |
+| `review impl` | `approved-plan.json`, `issue-intake.json`, `publish-plan.json`, published-draft-PR `publish-result.json` | earlier artifacts plus publish artifacts | `impl-review.json`, `post-publish-review-result.json` |
+
+`impl-review.json` is produced by `review impl`. It is not an input to `review impl` resume.

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -373,9 +373,10 @@ def _repair_issue(args: argparse.Namespace) -> int:
     if args.approved_plan_path:
         approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
 
-    # Only load fresh issue intake when not in a retry resume path.
-    # Retry resume paths carry forward the prior run's intake via the coordinator.
-    if retry_from is None:
+    # Only skip intake loading for stage-resume retries (--retry-from with --from).
+    # Plain retries (--retry-from without --from) still need the fresh intake
+    # because the coordinator's non-resume path calls create_issue() which requires intake.
+    if retry_from is None or getattr(args, 'resume_from', None) is None:
         intake = load_issue_intake(args.issue_ref)
     else:
         intake = None

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -23,6 +23,7 @@ from .coordinator import (
     PersistApprovedPlanParams,
     PublishRunParams,
     RepairIssueParams,
+    RetryResumeStage,
     ReviewImplParams,
     ReviewIssueParams,
     ReviewPlanParams,
@@ -71,6 +72,14 @@ _CLI_DOCS_FIRST_EXECUTOR = DocsFirstExecutor
 
 _REPAIR_AGENT_CHOICES = ("opencode", "none", "vercel-ai")
 _DISPLAYED_REPAIR_AGENT_CHOICES = ("opencode", "none")
+_RETRY_RESUME_STAGES: tuple[RetryResumeStage, ...] = (
+    "review issue",
+    "plan",
+    "review plan",
+    "implement",
+    "publish",
+    "review impl",
+)
 
 
 class _StoreOnceAction(argparse.Action):
@@ -181,6 +190,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Path to an approved-plan.json file. Supported as a compatibility ingress; retries "
             "may omit it to carry forward the prior run's approved-plan.json."
+        ),
+    )
+    issue_parser.add_argument(
+        "--from",
+        dest="resume_from",
+        choices=_RETRY_RESUME_STAGES,
+        default=argparse.SUPPRESS,
+        help=(
+            "Resume a retry from one later stage. Supported only with --retry-from. "
+            "Choices: review issue, plan, review plan, implement, publish, review impl."
         ),
     )
     issue_parser.add_argument(
@@ -367,6 +386,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
             review_model=args.review_model,
             review_stages=cast(ReviewStagesOverride | None, getattr(args, "review_stages", None)),
             retry_from=retry_from,
+            resume_from=cast(RetryResumeStage | None, getattr(args, "resume_from", None)),
             approved_plan=approved_plan,
         ),
         intake=intake,
@@ -1200,6 +1220,20 @@ def _validate_repair_issue_args(args: dict[str, Any]) -> None:
     _normalize_optional_path_arg(args, "approved_plan_path")
     _normalize_optional_str_arg(args, "repair_model")
     _normalize_optional_str_arg(args, "review_model")
+    _normalize_optional_str_arg(args, "resume_from")
+    resume_from = args.get("resume_from")
+    retry_from = args.get("retry_from")
+    if resume_from is not None:
+        if retry_from is None:
+            raise ValueError(
+                "--from requires --retry-from. Supported resume stages: "
+                + ", ".join(_RETRY_RESUME_STAGES)
+            )
+        if resume_from not in _RETRY_RESUME_STAGES:
+            raise ValueError(
+                "Unsupported retry resume stage. Supported resume stages: "
+                + ", ".join(_RETRY_RESUME_STAGES)
+            )
 
 
 def _validate_publish_run_args(args: dict[str, Any]) -> None:
@@ -1303,6 +1337,7 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
                 "repair_model",
                 "review_model",
                 "approved_plan_path",
+                "resume_from",
             }
         ),
         defaults={
@@ -1312,6 +1347,7 @@ _COMMAND_CONFIG_SPECS: dict[Callable[[argparse.Namespace], int], _CommandConfigS
             "repair_model": None,
             "review_model": None,
             "retry_from": None,
+            "resume_from": None,
             "fresh": False,
             "approved_plan_path": None,
         },

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -195,7 +195,6 @@ def build_parser() -> argparse.ArgumentParser:
     issue_parser.add_argument(
         "--from",
         dest="resume_from",
-        choices=_RETRY_RESUME_STAGES,
         default=argparse.SUPPRESS,
         help=(
             "Resume a retry from one later stage. Supported only with --retry-from. "
@@ -374,7 +373,12 @@ def _repair_issue(args: argparse.Namespace) -> int:
     if args.approved_plan_path:
         approved_plan = _load_approved_plan(Path(args.approved_plan_path), args.issue_ref)
 
-    intake = load_issue_intake(args.issue_ref)
+    # Only load fresh issue intake when not in a retry resume path.
+    # Retry resume paths carry forward the prior run's intake via the coordinator.
+    if retry_from is None:
+        intake = load_issue_intake(args.issue_ref)
+    else:
+        intake = None
     report = RunCoordinator().repair_issue(
         params=RepairIssueParams(
             issue_ref=args.issue_ref,
@@ -389,10 +393,14 @@ def _repair_issue(args: argparse.Namespace) -> int:
             resume_from=cast(RetryResumeStage | None, getattr(args, "resume_from", None)),
             approved_plan=approved_plan,
         ),
-        intake=intake,
+        # Coordinator ignores this when retry_from is set (uses prior run's intake instead).
+        intake=cast(IssueIntake, intake),
         dependencies=_CliRepairDependencies(),
     )
     record = report.run_record
+    # Use the intake from the report, which is either the passed intake (fresh run)
+    # or the prior run's intake loaded by the coordinator (retry resume path).
+    intake = report.intake
 
     print(f"Issue: {intake.issue.reference}")
     print(f"Title: {intake.issue.title}")

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -47,6 +47,8 @@ from .run_store import (
     IssueReviewNotFoundError,
     IssueReviewValidationError,
     PlanReviewError,
+    PlanReviewNotFoundError,
+    PlanReviewValidationError,
     RunStore,
 )
 
@@ -1462,6 +1464,29 @@ def _validate_resume_prerequisites(
             )
         return review
 
+    def _require_approved_plan_review_for_resume(stage_name: str) -> PlanReview:
+        try:
+            review = RunStore.load_plan_review(
+                previous_run_dir,
+                issue_ref=issue_ref,
+                expected_run_id=previous_record.run_id,
+            )
+        except PlanReviewNotFoundError as exc:
+            raise ValueError(
+                f"Retry resume to {stage_name} requires plan-review.json for the same run."
+            ) from exc
+        except PlanReviewValidationError as exc:
+            raise ValueError(
+                "Retry carry-forward failed because the prior plan-review.json failed "
+                f"structural validation: {exc}"
+            ) from exc
+        if review.review_status != "approved":
+            raise ValueError(
+                "Retry resume to "
+                f"{stage_name} requires approved plan-review.json for the same run."
+            )
+        return review
+
     if resume_from == "review issue":
         _require_file(
             previous_run_dir / "issue-draft.json",
@@ -1483,6 +1508,13 @@ def _validate_resume_prerequisites(
             raise ValueError(str(exc)) from exc
         return
     if resume_from == "publish":
+        _require_file(
+            previous_run_dir / "issue-draft.json",
+            "Retry resume requires issue-draft.json",
+        )
+        _require_approved_issue_review_for_resume("publish")
+        RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
+        _require_approved_plan_review_for_resume("publish")
         _load_preserved_implement_stage(
             previous_run_dir,
             record=previous_record,
@@ -1500,6 +1532,10 @@ def _validate_resume_prerequisites(
         return
     if resume_from == "review impl":
         RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
+        try:
+            RunStore.require_plan_review_for_implement(previous_run_dir, issue_ref=issue_ref)
+        except PlanReviewError as exc:
+            raise ValueError(str(exc)) from exc
         _load_issue_intake_artifact(previous_run_dir, expected_issue_ref=issue_ref)
         publish_plan = _load_publish_plan_artifact(previous_run_dir)
         publish_result = _load_publish_result_artifact(previous_run_dir)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -649,7 +649,7 @@ class RunCoordinator:
             state = _replace_retry_state(state, issue_review=issue_review_report.issue_review)
             if issue_review_report.exit_code != 0:
                 return state
-        else:
+        elif resume_from != "review impl":
             state = _replace_retry_state(
                 state,
                 issue_review=RunStore.load_issue_review(
@@ -659,7 +659,10 @@ class RunCoordinator:
                 ),
             )
 
-        if resume_from is None or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["plan"]:
+        if (
+            resume_from is None
+            or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["plan"]
+        ):
             planning_ingress_plan = effective_approved_plan
             if resume_from == "review issue" and params.approved_plan is None:
                 planning_ingress_plan = None
@@ -682,7 +685,7 @@ class RunCoordinator:
             state = _replace_retry_state(state, plan_review=plan_review_report.plan_review)
             if plan_review_report.exit_code != 0:
                 return state
-        else:
+        elif resume_from != "review impl":
             state = _replace_retry_state(
                 state,
                 plan_review=RunStore.load_plan_review(
@@ -1532,10 +1535,6 @@ def _validate_resume_prerequisites(
         return
     if resume_from == "review impl":
         RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
-        try:
-            RunStore.require_plan_review_for_implement(previous_run_dir, issue_ref=issue_ref)
-        except PlanReviewError as exc:
-            raise ValueError(str(exc)) from exc
         _load_issue_intake_artifact(previous_run_dir, expected_issue_ref=issue_ref)
         publish_plan = _load_publish_plan_artifact(previous_run_dir)
         publish_result = _load_publish_result_artifact(previous_run_dir)

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Callable, Literal, Protocol, cast
+from typing import Any, Callable, Literal, Protocol, cast
 
 from .executor import DocsFirstExecutor
 from .governance import apply_governance, evaluate_run
@@ -178,6 +178,31 @@ class PublishDependencies(Protocol):
 
 
 ReviewStagesOverride = Literal["plan", "all"]
+RetryResumeStage = Literal[
+    "review issue",
+    "plan",
+    "review plan",
+    "implement",
+    "publish",
+    "review impl",
+]
+
+_RETRY_RESUME_STAGES: tuple[RetryResumeStage, ...] = (
+    "review issue",
+    "plan",
+    "review plan",
+    "implement",
+    "publish",
+    "review impl",
+)
+_RETRY_STAGE_ORDER: dict[RetryResumeStage, int] = {
+    "review issue": 0,
+    "plan": 1,
+    "review plan": 2,
+    "implement": 3,
+    "publish": 4,
+    "review impl": 5,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -191,7 +216,32 @@ class RepairIssueParams:
     review_model: str | None
     review_stages: ReviewStagesOverride | None = None
     retry_from: str | None = None
+    resume_from: RetryResumeStage | None = None
     approved_plan: ApprovedPlan | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RetryResumeContext:
+    previous_record: RunRecord
+    previous_run_dir: Path
+    source_intake: IssueIntake
+    resume_from: RetryResumeStage
+    plan_ingress: ApprovedPlan | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RetryStageState:
+    issue_review: IssueReview | None = None
+    plan_review: PlanReview | None = None
+    execution_result: ExecutionResult | None = None
+    evaluation_result: EvaluationResult | None = None
+    governance_verdict: GovernanceVerdict | None = None
+    publish_plan: PublishPlan | None = None
+    publish_result: PublishResult | None = None
+    repair_result: RepairResult | None = None
+    baseline_qa_result: QaResult | None = None
+    qa_result: QaResult | None = None
+    post_publish_review_result: PostPublishReviewResult | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -433,9 +483,9 @@ class RunCoordinator:
     ) -> RepairIssueReport:
         store = RunStore(params.runs_dir)
 
-        # Handle retry logic
         attempt = 1
         previous_run_dir: Path | None = None
+        resume_context: _RetryResumeContext | None = None
         if params.retry_from is not None:
             try:
                 previous_record = store.load_run(params.retry_from)
@@ -445,27 +495,39 @@ class RunCoordinator:
                 previous_run_dir = Path(previous_record.run_dir).resolve()
             except ValueError:
                 return _blocked_retry_report(intake=intake, issue_ref=params.issue_ref)
+            if params.resume_from is not None:
+                resume_context = _prepare_retry_resume_context(
+                    store=store,
+                    params=params,
+                    previous_record=previous_record,
+                )
 
         effective_approved_plan = params.approved_plan
-        if effective_approved_plan is None and previous_run_dir is not None:
+        if resume_context is not None and resume_context.resume_from == "plan":
+            effective_approved_plan = resume_context.plan_ingress
+        elif (
+            effective_approved_plan is None
+            and previous_run_dir is not None
+            and (resume_context is None or resume_context.resume_from != "review issue")
+        ):
+            require_prior_plan = True
             try:
                 effective_approved_plan = RunStore.load_approved_plan(
                     previous_run_dir,
                     issue_ref=params.issue_ref,
                 )
             except ApprovedPlanNotFoundError:
-                raise ValueError(
-                    "Retry requires a prior approved-plan.json when "
-                    "--approved-plan-path is omitted; "
-                    f"missing prior approved-plan.json in {previous_run_dir}."
-                )
+                if require_prior_plan:
+                    raise ValueError(
+                        "Retry requires a prior approved-plan.json when "
+                        "--approved-plan-path is omitted; "
+                        f"missing prior approved-plan.json in {previous_run_dir}."
+                    )
             except ApprovedPlanValidationError as exc:
                 raise ValueError(
                     "Retry carry-forward failed because the prior approved-plan.json failed "
                     f"structural validation: {exc}"
                 ) from exc
-            except ValueError:
-                return _blocked_retry_report(intake=intake, issue_ref=params.issue_ref)
 
         request = RunRequest(issue_ref=params.issue_ref, runs_dir=str(params.runs_dir))
 
@@ -481,20 +543,35 @@ class RunCoordinator:
                 params=params,
             )
 
-        create_report = self.create_issue(
-            params=CreateIssueParams(
-                issue_ref=params.issue_ref,
-                runs_dir=params.runs_dir,
-            ),
-            intake=intake,
-        )
-        record = create_report.run_record
-        run_dir = Path(record.run_dir).resolve()
-
-        # Update attempt counter if retrying
-        if attempt > 1:
-            record = record.with_attempt(attempt)
-            store.write_run_record(record)
+        if resume_context is None:
+            create_report = self.create_issue(
+                params=CreateIssueParams(
+                    issue_ref=params.issue_ref,
+                    runs_dir=params.runs_dir,
+                ),
+                intake=intake,
+            )
+            record = create_report.run_record
+            run_dir = Path(record.run_dir).resolve()
+            if attempt > 1:
+                record = record.with_attempt(attempt)
+                store.write_run_record(record)
+        else:
+            record = store.create_retry_run(
+                request,
+                source_run_dir=resume_context.previous_run_dir,
+                preserved_intake=resume_context.source_intake,
+                attempt=attempt,
+            )
+            run_dir = Path(record.run_dir).resolve()
+            intake = resume_context.source_intake
+            _materialize_retry_history(
+                store=store,
+                resume_context=resume_context,
+                run_dir=run_dir,
+                run_id=record.run_id,
+                attempt=attempt,
+            )
 
         # Handle blocked intake: apply governance and publish directly without review stages
         if intake.assessment.status == "blocked":
@@ -516,189 +593,261 @@ class RunCoordinator:
                 publish_result=publish_result,
                 exit_code=3,
             )
-
-        issue_review_report = self.review_issue(
-            params=ReviewIssueParams(
-                run_id=record.run_id,
-                runs_dir=params.runs_dir,
-            )
-        )
-        if issue_review_report.exit_code != 0:
-            return RepairIssueReport(
-                intake=intake,
-                run_record=record,
-                issue_review=issue_review_report.issue_review,
-                exit_code=issue_review_report.exit_code,
-            )
-
-        compatibility_approved_plan = _build_compatibility_approved_plan(
+        stage_state = self._resume_or_run_repair_chain(
             store=store,
+            params=params,
+            intake=intake,
             record=record,
+            run_dir=run_dir,
             attempt=attempt,
-            previous_run_dir=previous_run_dir,
             effective_approved_plan=effective_approved_plan,
-            review_stages=params.review_stages,
-            retry_from=params.retry_from,
-        )
-
-        # Persist the approved plan only if provided or synthesized for compatibility.
-        approved_plan_to_persist = effective_approved_plan or compatibility_approved_plan
-        if approved_plan_to_persist is not None:
-            self.persist_approved_plan_for_planning(
-                params=PersistApprovedPlanParams(
-                    run_id=record.run_id,
-                    runs_dir=params.runs_dir,
-                    approved_plan=approved_plan_to_persist,
-                )
-            )
-        plan_review_report = self.review_plan(
-            params=ReviewPlanParams(
-                run_id=record.run_id,
-                runs_dir=params.runs_dir,
-            )
-        )
-        if plan_review_report.exit_code != 0:
-            return RepairIssueReport(
-                intake=intake,
-                run_record=record,
-                issue_review=issue_review_report.issue_review,
-                plan_review=plan_review_report.plan_review,
-                exit_code=plan_review_report.exit_code,
-            )
-
-        implementation_report = self.implement_run(
-            params=ImplementRunParams(
-                run_id=record.run_id,
-                runs_dir=params.runs_dir,
-                repo_path=params.repo_path,
-                repair_agent=params.repair_agent,
-                repair_model=params.repair_model,
-            ),
+            previous_run_dir=previous_run_dir,
+            resume_context=resume_context,
             dependencies=dependencies,
         )
-        if implementation_report.governance_verdict.status != "approved":
-            return RepairIssueReport(
-                intake=intake,
-                run_record=record,
-                issue_review=issue_review_report.issue_review,
-                plan_review=plan_review_report.plan_review,
+
+        return RepairIssueReport(
+            intake=intake,
+            run_record=record,
+            issue_review=stage_state.issue_review,
+            plan_review=stage_state.plan_review,
+            execution_result=stage_state.execution_result,
+            evaluation_result=stage_state.evaluation_result,
+            governance_verdict=stage_state.governance_verdict,
+            publish_plan=stage_state.publish_plan,
+            publish_result=stage_state.publish_result,
+            repair_result=stage_state.repair_result,
+            baseline_qa_result=stage_state.baseline_qa_result,
+            qa_result=stage_state.qa_result,
+            post_publish_review_result=stage_state.post_publish_review_result,
+            exit_code=_resume_state_exit_code(stage_state),
+        )
+
+    def _resume_or_run_repair_chain(
+        self,
+        *,
+        store: RunStore,
+        params: RepairIssueParams,
+        intake: IssueIntake,
+        record: RunRecord,
+        run_dir: Path,
+        attempt: int,
+        effective_approved_plan: ApprovedPlan | None,
+        previous_run_dir: Path | None,
+        resume_context: _RetryResumeContext | None,
+        dependencies: RepairDependencies,
+    ) -> _RetryStageState:
+        state = _RetryStageState()
+        resume_from = resume_context.resume_from if resume_context is not None else None
+
+        if resume_from in {None, "review issue"}:
+            issue_review_report = self.review_issue(
+                params=ReviewIssueParams(run_id=record.run_id, runs_dir=params.runs_dir)
+            )
+            state = _replace_retry_state(state, issue_review=issue_review_report.issue_review)
+            if issue_review_report.exit_code != 0:
+                return state
+        else:
+            state = _replace_retry_state(
+                state,
+                issue_review=RunStore.load_issue_review(
+                    run_dir,
+                    issue_ref=record.issue_ref,
+                    expected_run_id=record.run_id,
+                ),
+            )
+
+        if resume_from is None or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["plan"]:
+            planning_ingress_plan = effective_approved_plan
+            if resume_from == "review issue" and params.approved_plan is None:
+                planning_ingress_plan = None
+            if planning_ingress_plan is not None:
+                self.persist_approved_plan_for_planning(
+                    params=PersistApprovedPlanParams(
+                        run_id=record.run_id,
+                        runs_dir=params.runs_dir,
+                        approved_plan=planning_ingress_plan,
+                    )
+                )
+        plan_review_report: ReviewPlanReport | None = None
+        if (
+            resume_from is None
+            or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["review plan"]
+        ):
+            plan_review_report = self.review_plan(
+                params=ReviewPlanParams(run_id=record.run_id, runs_dir=params.runs_dir)
+            )
+            state = _replace_retry_state(state, plan_review=plan_review_report.plan_review)
+            if plan_review_report.exit_code != 0:
+                return state
+        else:
+            state = _replace_retry_state(
+                state,
+                plan_review=RunStore.load_plan_review(
+                    run_dir,
+                    issue_ref=record.issue_ref,
+                    expected_run_id=record.run_id,
+                ),
+            )
+
+        if (
+            resume_from is None
+            or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["implement"]
+        ):
+            implementation_report = self.implement_run(
+                params=ImplementRunParams(
+                    run_id=record.run_id,
+                    runs_dir=params.runs_dir,
+                    repo_path=params.repo_path,
+                    repair_agent=params.repair_agent,
+                    repair_model=params.repair_model,
+                ),
+                dependencies=dependencies,
+            )
+            state = _replace_retry_state(
+                state,
                 execution_result=implementation_report.execution_result,
                 evaluation_result=implementation_report.evaluation_result,
                 governance_verdict=implementation_report.governance_verdict,
                 repair_result=implementation_report.repair_result,
                 baseline_qa_result=implementation_report.baseline_qa_result,
                 qa_result=implementation_report.qa_result,
-                exit_code=implementation_report.exit_code,
-            )
-
-        try:
-            publish_plan = build_publish_plan(
-                intake,
-                record,
-                implementation_report.governance_verdict,
-                implementation_report.repair_result,
-            )
-        except RequiredDecisionLogArtifactMissingError as exc:
-            execution_result = ExecutionResult(
-                status="failed_infra",
-                executor_name=implementation_report.execution_result.executor_name,
-                summary=str(exc),
-                detail_codes=tuple(
-                    dict.fromkeys(
-                        (
-                            *implementation_report.execution_result.detail_codes,
-                            "missing_decision_log_artifact",
-                        )
-                    )
-                ),
-                artifact_dir=implementation_report.execution_result.artifact_dir,
-                stdout_path=implementation_report.execution_result.stdout_path,
-                stderr_path=implementation_report.execution_result.stderr_path,
-                quality=implementation_report.execution_result.quality,
-            )
-            implementation_report = self._evaluate_and_persist_local(
-                store=store,
-                intake=intake,
-                record=record,
-                run_dir=run_dir,
-                execution_result=execution_result,
-                repair_result=None,
-                baseline_qa_result=implementation_report.baseline_qa_result,
-                qa_result=implementation_report.qa_result,
             )
             if implementation_report.governance_verdict.status != "approved":
-                return RepairIssueReport(
+                return state
+        elif resume_from != "review impl":
+            preserved_stage = _load_preserved_implement_stage(run_dir, record=record, intake=intake)
+            state = _replace_retry_state(
+                state,
+                execution_result=preserved_stage.execution_result,
+                evaluation_result=preserved_stage.evaluation_result,
+                governance_verdict=preserved_stage.governance_verdict,
+                repair_result=preserved_stage.repair_result,
+                baseline_qa_result=preserved_stage.baseline_qa_result,
+                qa_result=preserved_stage.qa_result,
+            )
+
+        if resume_from is None or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["publish"]:
+            implementation_report = ImplementRunReport(
+                intake=intake,
+                run_record=record,
+                execution_result=cast(ExecutionResult, state.execution_result),
+                evaluation_result=cast(EvaluationResult, state.evaluation_result),
+                governance_verdict=cast(GovernanceVerdict, state.governance_verdict),
+                repair_result=state.repair_result,
+                baseline_qa_result=state.baseline_qa_result,
+                qa_result=state.qa_result,
+                exit_code=0,
+            )
+            try:
+                publish_plan = build_publish_plan(
+                    intake,
+                    record,
+                    implementation_report.governance_verdict,
+                    implementation_report.repair_result,
+                )
+            except RequiredDecisionLogArtifactMissingError as exc:
+                execution_result = ExecutionResult(
+                    status="failed_infra",
+                    executor_name=implementation_report.execution_result.executor_name,
+                    summary=str(exc),
+                    detail_codes=tuple(
+                        dict.fromkeys(
+                            (
+                                *implementation_report.execution_result.detail_codes,
+                                "missing_decision_log_artifact",
+                            )
+                        )
+                    ),
+                    artifact_dir=implementation_report.execution_result.artifact_dir,
+                    stdout_path=implementation_report.execution_result.stdout_path,
+                    stderr_path=implementation_report.execution_result.stderr_path,
+                    quality=implementation_report.execution_result.quality,
+                )
+                implementation_report = self._evaluate_and_persist_local(
+                    store=store,
                     intake=intake,
-                    run_record=record,
-                    issue_review=issue_review_report.issue_review,
-                    plan_review=plan_review_report.plan_review,
+                    record=record,
+                    run_dir=run_dir,
+                    execution_result=execution_result,
+                    repair_result=None,
+                    baseline_qa_result=implementation_report.baseline_qa_result,
+                    qa_result=implementation_report.qa_result,
+                )
+                state = _replace_retry_state(
+                    state,
                     execution_result=implementation_report.execution_result,
                     evaluation_result=implementation_report.evaluation_result,
                     governance_verdict=implementation_report.governance_verdict,
                     repair_result=implementation_report.repair_result,
                     baseline_qa_result=implementation_report.baseline_qa_result,
                     qa_result=implementation_report.qa_result,
-                    exit_code=implementation_report.exit_code,
                 )
-            publish_plan = build_publish_plan(
-                intake,
-                record,
-                implementation_report.governance_verdict,
-                implementation_report.repair_result,
-            )
-        store.write_publish_plan(run_dir, publish_plan)
-        publish_report = self.publish_run(
-            params=PublishRunParams(
-                run_id=record.run_id,
-                runs_dir=params.runs_dir,
-                review_model=params.review_model,
-                publish=params.publish,
-                run_post_publish_review=False,
-            ),
-            intake=intake,
-            run_record=record,
-            publish_plan=publish_plan,
-            existing_result=None,
-            existing_review_result=None,
-            dependencies=dependencies,
-        )
-
-        post_publish_review_result: PostPublishReviewResult | None = None
-        exit_code = implementation_report.exit_code
-        if (
-            publish_report.publish_result.status == "published"
-            and publish_report.publish_result.target == "draft_pr"
-            and publish_report.publish_result.url
-        ):
-            review_impl_report = self.review_impl(
-                params=ReviewImplParams(
+                if implementation_report.governance_verdict.status != "approved":
+                    return state
+                publish_plan = build_publish_plan(
+                    intake,
+                    record,
+                    implementation_report.governance_verdict,
+                    implementation_report.repair_result,
+                )
+            store.write_publish_plan(run_dir, publish_plan)
+            publish_report = self.publish_run(
+                params=PublishRunParams(
                     run_id=record.run_id,
                     runs_dir=params.runs_dir,
                     review_model=params.review_model,
+                    publish=params.publish,
+                    run_post_publish_review=False,
                 ),
+                intake=intake,
+                run_record=record,
+                publish_plan=publish_plan,
+                existing_result=None,
+                existing_review_result=None,
                 dependencies=dependencies,
             )
-            post_publish_review_result = mirror_impl_review_to_post_publish(
-                review_impl_report.impl_review
+            state = _replace_retry_state(
+                state,
+                publish_plan=publish_plan,
+                publish_result=publish_report.publish_result,
             )
-            exit_code = review_impl_report.exit_code
+        else:
+            state = _replace_retry_state(
+                state,
+                publish_plan=_load_publish_plan_artifact(run_dir),
+                publish_result=_load_publish_result_artifact(run_dir),
+            )
 
-        return RepairIssueReport(
-            intake=intake,
-            run_record=record,
-            issue_review=issue_review_report.issue_review,
-            plan_review=plan_review_report.plan_review,
-            execution_result=implementation_report.execution_result,
-            evaluation_result=implementation_report.evaluation_result,
-            governance_verdict=implementation_report.governance_verdict,
-            publish_plan=publish_plan,
-            publish_result=publish_report.publish_result,
-            repair_result=implementation_report.repair_result,
-            baseline_qa_result=implementation_report.baseline_qa_result,
-            qa_result=implementation_report.qa_result,
-            post_publish_review_result=post_publish_review_result,
-            exit_code=exit_code,
-        )
+        if (
+            resume_from is None
+            or _RETRY_STAGE_ORDER[resume_from] <= _RETRY_STAGE_ORDER["review impl"]
+        ):
+            post_publish_review_result: PostPublishReviewResult | None = None
+            review_impl_should_run = (
+                state.publish_result is not None
+                and state.publish_result.status == "published"
+                and state.publish_result.target == "draft_pr"
+                and state.publish_result.url is not None
+            )
+            if review_impl_should_run:
+                review_impl_report = self.review_impl(
+                    params=ReviewImplParams(
+                        run_id=record.run_id,
+                        runs_dir=params.runs_dir,
+                        review_model=params.review_model,
+                    ),
+                    dependencies=dependencies,
+                )
+                post_publish_review_result = mirror_impl_review_to_post_publish(
+                    review_impl_report.impl_review
+                )
+            state = _replace_retry_state(
+                state,
+                post_publish_review_result=post_publish_review_result,
+            )
+
+        return state
 
     def _run_local_implementation_flow(
         self,
@@ -1206,6 +1355,409 @@ class RunCoordinator:
             publish_result=result,
             post_publish_review_result=review_result,
         )
+
+
+def _replace_retry_state(state: _RetryStageState, /, **changes: Any) -> _RetryStageState:
+    return replace(state, **changes)
+
+
+def _resume_state_exit_code(state: _RetryStageState) -> int:
+    if state.post_publish_review_result is not None:
+        if state.post_publish_review_result.status == "approved":
+            return 0
+        if state.post_publish_review_result.status == "rejected":
+            return 2
+        return 3
+    if state.governance_verdict is not None and state.governance_verdict.status == "blocked":
+        return 4
+    if state.plan_review is not None:
+        if state.plan_review.review_status == "changes_requested":
+            return 2
+        if state.plan_review.review_status == "blocked":
+            return 3
+    if state.issue_review is not None:
+        if state.issue_review.review_status == "changes_requested":
+            return 2
+        if state.issue_review.review_status == "blocked":
+            return 3
+    return 0
+
+
+def _prepare_retry_resume_context(
+    *,
+    store: RunStore,
+    params: RepairIssueParams,
+    previous_record: RunRecord,
+) -> _RetryResumeContext:
+    if params.resume_from is None:
+        raise ValueError("Retry resume context requires an explicit resume stage.")
+    previous_run_dir = Path(previous_record.run_dir).resolve()
+    source_intake = _load_issue_intake_artifact(
+        previous_run_dir,
+        expected_issue_ref=previous_record.issue_ref,
+    )
+    plan_ingress: ApprovedPlan | None = None
+    if params.resume_from == "plan":
+        if params.approved_plan is not None:
+            plan_ingress = params.approved_plan
+        else:
+            try:
+                plan_ingress = RunStore.load_approved_plan(
+                    previous_run_dir,
+                    issue_ref=params.issue_ref,
+                )
+            except ApprovedPlanNotFoundError:
+                raise ValueError(
+                    "Retry requires a prior approved-plan.json when --approved-plan-path is "
+                    f"omitted; missing prior approved-plan.json in {previous_run_dir}."
+                )
+            except ApprovedPlanValidationError as exc:
+                raise ValueError(
+                    "Retry carry-forward failed because the prior approved-plan.json failed "
+                    f"structural validation: {exc}"
+                ) from exc
+
+    _validate_resume_prerequisites(
+        previous_run_dir=previous_run_dir,
+        previous_record=previous_record,
+        issue_ref=params.issue_ref,
+        resume_from=params.resume_from,
+    )
+    return _RetryResumeContext(
+        previous_record=previous_record,
+        previous_run_dir=previous_run_dir,
+        source_intake=source_intake,
+        resume_from=params.resume_from,
+        plan_ingress=plan_ingress,
+    )
+
+
+def _validate_resume_prerequisites(
+    *,
+    previous_run_dir: Path,
+    previous_record: RunRecord,
+    issue_ref: str,
+    resume_from: RetryResumeStage,
+) -> None:
+    def _require_approved_issue_review_for_resume(stage_name: str) -> IssueReview:
+        try:
+            review = RunStore.load_issue_review(
+                previous_run_dir,
+                issue_ref=issue_ref,
+                expected_run_id=previous_record.run_id,
+            )
+        except IssueReviewNotFoundError as exc:
+            raise ValueError(
+                f"Retry resume to {stage_name} requires issue-review.json for the same run."
+            ) from exc
+        except IssueReviewValidationError as exc:
+            raise ValueError(
+                "Retry carry-forward failed because the prior issue-review.json failed "
+                f"structural validation: {exc}"
+            ) from exc
+        if review.review_status != "approved":
+            raise ValueError(
+                "Retry resume to "
+                f"{stage_name} requires approved issue-review.json for the same run."
+            )
+        return review
+
+    if resume_from == "review issue":
+        _require_file(
+            previous_run_dir / "issue-draft.json",
+            "Retry resume requires issue-draft.json",
+        )
+        return
+    if resume_from == "plan":
+        _require_approved_issue_review_for_resume("plan")
+        return
+    if resume_from == "review plan":
+        _require_approved_issue_review_for_resume("review plan")
+        RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
+        return
+    if resume_from == "implement":
+        RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
+        try:
+            RunStore.require_plan_review_for_implement(previous_run_dir, issue_ref=issue_ref)
+        except PlanReviewError as exc:
+            raise ValueError(str(exc)) from exc
+        return
+    if resume_from == "publish":
+        _load_preserved_implement_stage(
+            previous_run_dir,
+            record=previous_record,
+            intake=None,
+            require_qa_results=True,
+        )
+        _require_decision_log_artifact(
+            previous_run_dir,
+            attempt=previous_record.attempt,
+            stage_name="publish",
+        )
+        workspace = previous_run_dir / "repair-workspace" / "repo"
+        if not workspace.is_dir():
+            raise ValueError("Retry resume to publish requires preserved repair-workspace/repo.")
+        return
+    if resume_from == "review impl":
+        RunStore.load_approved_plan(previous_run_dir, issue_ref=issue_ref)
+        _load_issue_intake_artifact(previous_run_dir, expected_issue_ref=issue_ref)
+        publish_plan = _load_publish_plan_artifact(previous_run_dir)
+        publish_result = _load_publish_result_artifact(previous_run_dir)
+        if publish_plan.status != "draft_pr":
+            raise ValueError(
+                "Retry resume to review impl requires publish-plan.json for a draft PR."
+            )
+        if publish_result.status != "published" or publish_result.target != "draft_pr":
+            raise ValueError("Retry resume to review impl requires published draft-PR metadata.")
+        if not publish_result.url or publish_result.pull_number is None:
+            raise ValueError(
+                "Retry resume to review impl requires publish-result.json PR metadata."
+            )
+        return
+
+
+def _materialize_retry_history(
+    *,
+    store: RunStore,
+    resume_context: _RetryResumeContext,
+    run_dir: Path,
+    run_id: str,
+    attempt: int,
+) -> None:
+    artifact_names, copy_decision_log, copy_repair_workspace = _resume_preserved_artifacts(
+        resume_context.resume_from
+    )
+    store.copy_retry_artifacts(
+        source_run_dir=resume_context.previous_run_dir,
+        target_run_dir=run_dir,
+        artifact_names=artifact_names,
+        target_run_id=run_id,
+        source_attempt=resume_context.previous_record.attempt if copy_decision_log else None,
+        target_attempt=attempt if copy_decision_log else None,
+        copy_repair_workspace=copy_repair_workspace,
+    )
+
+
+def _resume_preserved_artifacts(
+    resume_from: RetryResumeStage,
+) -> tuple[tuple[str, ...], bool, bool]:
+    if resume_from == "review issue":
+        return (("issue-draft.json",), False, False)
+    if resume_from == "plan":
+        return (("issue-draft.json", "issue-review.json"), False, False)
+    if resume_from == "review plan":
+        return (("issue-draft.json", "issue-review.json", "approved-plan.json"), False, False)
+    if resume_from == "implement":
+        return (
+            (
+                "issue-draft.json",
+                "issue-review.json",
+                "approved-plan.json",
+                "plan-review.json",
+            ),
+            False,
+            False,
+        )
+    if resume_from == "publish":
+        return (
+            (
+                "issue-draft.json",
+                "issue-review.json",
+                "approved-plan.json",
+                "plan-review.json",
+                "execution-result.json",
+                "repair-result.json",
+                "qa-baseline-result.json",
+                "qa-result.json",
+                "evaluation-result.json",
+                "governance-verdict.json",
+            ),
+            True,
+            True,
+        )
+    return (
+        (
+            "issue-draft.json",
+            "issue-review.json",
+            "approved-plan.json",
+            "plan-review.json",
+            "publish-plan.json",
+            "publish-result.json",
+        ),
+        False,
+        False,
+    )
+
+
+def _require_decision_log_artifact(run_dir: Path, *, attempt: int, stage_name: str) -> None:
+    try:
+        RunStore.load_decision_log(run_dir, attempt=attempt)
+    except FileNotFoundError as exc:
+        missing_path = exc.filename or str(run_dir / f"decision-log.attempt-{attempt}.json")
+        raise ValueError(
+            f"Retry resume to {stage_name} requires decision-log.attempt-{attempt}.json at "
+            f"{missing_path}."
+        ) from exc
+
+
+def _load_preserved_implement_stage(
+    run_dir: Path,
+    *,
+    record: RunRecord,
+    intake: IssueIntake | None,
+    require_qa_results: bool = False,
+) -> ImplementRunReport:
+    execution_result = _load_execution_result_artifact(run_dir)
+    evaluation_result = _load_evaluation_result_artifact(run_dir)
+    governance_verdict = _load_governance_verdict_artifact(run_dir)
+    if governance_verdict.status != "approved":
+        raise ValueError("Retry resume to publish requires approved governance-verdict.json.")
+    repair_result = _load_repair_result_artifact(run_dir)
+    if repair_result.status != "completed" or not repair_result.workspace_path:
+        raise ValueError(
+            "Retry resume to publish requires completed repair-result.json with workspace_path."
+        )
+    if require_qa_results:
+        baseline_qa_result = _load_required_qa_result_artifact(
+            run_dir / "qa-baseline-result.json"
+        )
+        qa_result = _load_required_qa_result_artifact(run_dir / "qa-result.json")
+    else:
+        baseline_qa_result = _load_optional_qa_result_artifact(run_dir / "qa-baseline-result.json")
+        qa_result = _load_optional_qa_result_artifact(run_dir / "qa-result.json")
+    return ImplementRunReport(
+        intake=intake or _load_issue_intake_artifact(run_dir, expected_issue_ref=record.issue_ref),
+        run_record=record,
+        execution_result=execution_result,
+        evaluation_result=evaluation_result,
+        governance_verdict=governance_verdict,
+        repair_result=repair_result,
+        baseline_qa_result=baseline_qa_result,
+        qa_result=qa_result,
+        exit_code=0,
+    )
+
+
+def _blocked_retry_report(*, intake: IssueIntake, issue_ref: str) -> RepairIssueReport:
+    return RepairIssueReport(
+        intake=intake,
+        run_record=RunRecord(
+            run_id="",
+            issue_ref=issue_ref,
+            status="blocked",
+            created_at="",
+            updated_at="",
+            run_dir="",
+        ),
+        exit_code=3,
+    )
+
+
+def _load_execution_result_artifact(run_dir: Path) -> ExecutionResult:
+    payload = _read_json_object(run_dir / "execution-result.json", label="execution-result.json")
+    return ExecutionResult(
+        status=cast(
+            Literal[
+                "pending",
+                "blocked",
+                "failed_infra",
+                "missing_docs",
+                "ambiguous_docs",
+                "completed",
+            ],
+            payload["status"],
+        ),
+        executor_name=cast(str, payload["executor_name"]),
+        summary=cast(str, payload["summary"]),
+        detail_codes=tuple(cast(list[str], payload.get("detail_codes", []))),
+        artifact_dir=cast(str | None, payload.get("artifact_dir")),
+        stdout_path=cast(str | None, payload.get("stdout_path")),
+        stderr_path=cast(str | None, payload.get("stderr_path")),
+        quality=cast(Literal["green", "improved", "degraded"] | None, payload.get("quality")),
+    )
+
+
+def _load_evaluation_result_artifact(run_dir: Path) -> EvaluationResult:
+    payload = _read_json_object(run_dir / "evaluation-result.json", label="evaluation-result.json")
+    return EvaluationResult(
+        status=cast(Literal["success", "blocked", "failed_infra"], payload["status"]),
+        summary=cast(str, payload["summary"]),
+        detail_codes=tuple(cast(list[str], payload.get("detail_codes", []))),
+    )
+
+
+def _load_governance_verdict_artifact(run_dir: Path) -> GovernanceVerdict:
+    payload = _read_json_object(
+        run_dir / "governance-verdict.json",
+        label="governance-verdict.json",
+    )
+    return GovernanceVerdict(
+        status=cast(Literal["approved", "blocked"], payload["status"]),
+        summary=cast(str, payload["summary"]),
+        reason_codes=tuple(cast(list[str], payload.get("reason_codes", []))),
+    )
+
+
+def _load_repair_result_artifact(run_dir: Path) -> RepairResult:
+    payload = _read_json_object(run_dir / "repair-result.json", label="repair-result.json")
+    return RepairResult(
+        status=cast(
+            Literal["not_configured", "blocked", "failed_infra", "completed", "escalated"],
+            payload["status"],
+        ),
+        summary=cast(str, payload["summary"]),
+        detail_codes=tuple(cast(list[str], payload.get("detail_codes", []))),
+        workspace_path=cast(str | None, payload.get("workspace_path")),
+        patch_path=cast(str | None, payload.get("patch_path")),
+        stdout_path=cast(str | None, payload.get("stdout_path")),
+        stderr_path=cast(str | None, payload.get("stderr_path")),
+    )
+
+
+def _load_optional_qa_result_artifact(path: Path) -> QaResult | None:
+    if not path.exists():
+        return None
+    payload = _read_json_object(path, label=path.name)
+    return QaResult(
+        status=cast(
+            Literal["passed", "failed", "unrunnable", "failed_infra", "not_run"],
+            payload["status"],
+        ),
+        summary=cast(str, payload["summary"]),
+        detail_codes=tuple(cast(list[str], payload.get("detail_codes", []))),
+        command=cast(str | None, payload.get("command")),
+        stdout_path=cast(str | None, payload.get("stdout_path")),
+        stderr_path=cast(str | None, payload.get("stderr_path")),
+        phase=cast(Literal["baseline", "repair", "final"], payload.get("phase", "repair")),
+        quality=cast(Literal["green", "improved", "degraded"] | None, payload.get("quality")),
+    )
+
+
+def _load_required_qa_result_artifact(path: Path) -> QaResult:
+    result = _load_optional_qa_result_artifact(path)
+    if result is None:
+        raise ValueError(f"Retry resume requires {path.name} at {path}.")
+    return result
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"Retry resume requires {label} at {path}.")
+    try:
+        with path.open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except JSONDecodeError as exc:
+        raise ValueError(
+            f"Retry resume requires {label} at {path} to be valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Retry resume requires {label} at {path} to be a JSON object.")
+    return cast(dict[str, Any], payload)
+
+
+def _require_file(path: Path, prefix: str) -> None:
+    if not path.is_file():
+        raise ValueError(f"{prefix} at {path}.")
 
 
 def _same_local_issue_ref(left: str, right: str) -> bool:
@@ -1721,21 +2273,6 @@ def _plan_review_summary(*, status: str, finding_count: int) -> str:
     return (
         "Implementation must stop because review plan is blocked by "
         f"{finding_count} prerequisite {noun}."
-    )
-
-
-def _blocked_retry_report(*, intake: IssueIntake, issue_ref: str) -> RepairIssueReport:
-    return RepairIssueReport(
-        intake=intake,
-        run_record=RunRecord(
-            run_id="",
-            issue_ref=issue_ref,
-            status="blocked",
-            created_at="",
-            updated_at="",
-            run_dir="",
-        ),
-        exit_code=3,
     )
 
 

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from dataclasses import asdict
 from datetime import UTC, datetime
 from json import JSONDecodeError
@@ -140,6 +141,102 @@ class RunStore:
         self._write_issue_context(run_dir / "issue.md", intake)
         self._write_json(run_dir / "run-record.json", record)
         return record
+
+    def create_retry_run(
+        self,
+        request: RunRequest,
+        *,
+        source_run_dir: Path,
+        preserved_intake: IssueIntake,
+        attempt: int,
+    ) -> RunRecord:
+        created_at = _utc_now()
+        run_id = _build_run_id(created_at)
+        run_dir = self.root / run_id
+        run_dir.mkdir(parents=True, exist_ok=False)
+
+        status = "blocked" if preserved_intake.assessment.status == "blocked" else "runnable"
+        record = RunRecord(
+            run_id=run_id,
+            issue_ref=request.issue_ref,
+            status=status,
+            created_at=created_at,
+            updated_at=created_at,
+            run_dir=str(run_dir),
+            attempt=attempt,
+        )
+
+        shutil.copy2(source_run_dir / "issue-intake.json", run_dir / "issue-intake.json")
+        self._write_json(run_dir / "run-request.json", request)
+        self._write_issue_context(run_dir / "issue.md", preserved_intake)
+        self._write_json(run_dir / "run-record.json", record)
+        return record
+
+    def copy_retry_artifacts(
+        self,
+        *,
+        source_run_dir: Path,
+        target_run_dir: Path,
+        artifact_names: tuple[str, ...],
+        target_run_id: str | None = None,
+        source_attempt: int | None = None,
+        target_attempt: int | None = None,
+        copy_repair_workspace: bool = False,
+    ) -> None:
+        for artifact_name in artifact_names:
+            source_path = source_run_dir / artifact_name
+            target_path = target_run_dir / artifact_name
+            if not source_path.exists():
+                continue
+            shutil.copy2(source_path, target_path)
+            if (
+                target_run_id is not None
+                and artifact_name in {ISSUE_REVIEW_FILENAME, PLAN_REVIEW_FILENAME}
+            ):
+                self._rewrite_review_run_id(target_path, target_run_id)
+
+        if source_attempt is not None and target_attempt is not None:
+            source_decision_log = source_run_dir / _decision_log_filename(source_attempt)
+            if source_decision_log.exists():
+                target_decision_log = target_run_dir / _decision_log_filename(target_attempt)
+                shutil.copy2(source_decision_log, target_decision_log)
+                self._rewrite_decision_log_attempt(target_decision_log, target_attempt)
+
+        if copy_repair_workspace:
+            source_workspace = source_run_dir / "repair-workspace"
+            target_workspace = target_run_dir / "repair-workspace"
+            if source_workspace.is_dir():
+                shutil.copytree(source_workspace, target_workspace)
+                repair_result_path = target_run_dir / "repair-result.json"
+                if repair_result_path.exists():
+                    self._rewrite_repair_result_workspace_path(
+                        repair_result_path,
+                        workspace_path=str(target_workspace.resolve()),
+                    )
+
+    @staticmethod
+    def _rewrite_review_run_id(path: Path, run_id: str) -> None:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload["run_id"] = run_id
+            provenance = payload.get("provenance")
+            if isinstance(provenance, dict):
+                provenance["run_id"] = run_id
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _rewrite_decision_log_attempt(path: Path, attempt: int) -> None:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload["attempt"] = attempt
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _rewrite_repair_result_workspace_path(path: Path, workspace_path: str) -> None:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload["workspace_path"] = workspace_path
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     def load_issue_draft(self, run_id: str) -> IssueDraft:
         """Load the normalized issue handoff artifact for a run."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4440,3 +4440,219 @@ class TestLoadApprovedPlanValidation:
         assert tuple(ref.name for ref in plan.named_references) == ("src/main.py",)
         assert plan.retrieval_surface_summary == "src/"
         assert plan.approved is True
+
+
+def test_repair_issue_retry_from_with_from_publish_forwards_resume_target_to_coordinator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that --from publish is forwarded correctly to the coordinator."""
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    store.write_approved_plan(Path(record.run_dir), ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Plan",
+        implementation_steps=("Step",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    ))
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured["resume_from"] = params.resume_from
+        captured["retry_from"] = params.retry_from
+        return RepairIssueReport(
+            intake=intake_payload,
+            run_record=RunRecord(
+                run_id="run-next",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(runs_dir / "run-next"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="done",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
+            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
+            publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+            "--retry-from",
+            record.run_id,
+            "--from",
+            "publish",
+        ]
+    )
+
+    assert status == 0
+    assert captured["retry_from"] == record.run_id
+    assert captured["resume_from"] == "publish"
+
+
+def test_repair_issue_retry_from_with_from_review_impl_forwards_resume_target_to_coordinator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that --from 'review impl' is forwarded correctly to the coordinator."""
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    store.write_approved_plan(Path(record.run_dir), ApprovedPlan(
+        issue_ref="owner/repo#1",
+        plan_summary="Plan",
+        implementation_steps=("Step",),
+        named_references=(),
+        retrieval_surface_summary="src/",
+        approved=True,
+    ))
+    monkeypatch.setattr(
+        "precision_squad.cli.load_issue_intake",
+        lambda _: (_ for _ in ()).throw(AssertionError("intake should not run")),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured["resume_from"] = params.resume_from
+        captured["retry_from"] = params.retry_from
+        return RepairIssueReport(
+            intake=intake_payload,
+            run_record=RunRecord(
+                run_id="run-next",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(runs_dir / "run-next"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="done",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
+            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
+            publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+            "--retry-from",
+            record.run_id,
+            "--from",
+            "review impl",
+        ]
+    )
+
+    assert status == 0
+    assert captured["retry_from"] == record.run_id
+    assert captured["resume_from"] == "review impl"
+
+
+def test_repair_issue_from_without_retry_from_fails(capsys, tmp_path: Path) -> None:
+    """Test that --from without --retry-from fails with an error."""
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--from",
+            "publish",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "--from requires --retry-from" in captured.err
+
+
+def test_repair_issue_from_with_unsupported_stage_fails(capsys, tmp_path: Path) -> None:
+    """Test that an unsupported --from value fails with a descriptive error."""
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--retry-from",
+            "some-run-id",
+            "--from",
+            "create issue",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Supported resume stages" in captured.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -4612,6 +4613,106 @@ def test_repair_issue_retry_from_with_from_review_impl_forwards_resume_target_to
     assert status == 0
     assert captured["retry_from"] == record.run_id
     assert captured["resume_from"] == "review impl"
+
+
+def test_repair_issue_retry_from_without_from_loads_intake_and_forwards_to_coordinator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that --retry-from without --from still loads intake and forwards to coordinator.
+
+    This is a regression test for the bug where plain retry
+    (--retry-from without --from) incorrectly skipped intake loading,
+    causing the coordinator to receive intake=None and fail when calling create_issue().
+    """
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    runs_dir.mkdir(parents=True)
+    intake_payload = IssueIntake(
+        issue=GitHubIssue(
+            reference=IssueReference("owner", "repo", 1),
+            title="Issue",
+            body="Body",
+            labels=(),
+            html_url="https://github.com/owner/repo/issues/1",
+        ),
+        summary="Issue",
+        problem_statement="Body",
+        assessment=IssueAssessment(status="runnable", reason_codes=()),
+    )
+    record = store.create_run(
+        RunRequest(issue_ref="owner/repo#1", runs_dir=str(runs_dir)), intake_payload
+    )
+    # intake_load_call_tracker lets us verify load_issue_intake was actually called
+    intake_load_call_tracker = {"called": False, "loaded_intake": None}
+
+    def tracking_load_intake(issue_ref):
+        intake_load_call_tracker["called"] = True
+        intake_load_call_tracker["loaded_intake"] = intake_payload
+        return intake_payload
+
+    monkeypatch.setattr("precision_squad.cli.load_issue_intake", tracking_load_intake)
+
+    captured: dict[str, object] = {}
+
+    def fake_repair_issue(self, *, params, intake, dependencies):
+        del self, dependencies
+        captured["resume_from"] = params.resume_from
+        captured["retry_from"] = params.retry_from
+        captured["intake"] = intake
+        return RepairIssueReport(
+            intake=intake,
+            run_record=RunRecord(
+                run_id="run-next",
+                issue_ref="owner/repo#1",
+                status="runnable",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+                run_dir=str(runs_dir / "run-next"),
+            ),
+            execution_result=ExecutionResult(
+                status="completed",
+                executor_name="docs",
+                summary="done",
+                detail_codes=(),
+            ),
+            evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
+            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
+            publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
+        )
+
+    monkeypatch.setattr("precision_squad.cli.RunCoordinator.repair_issue", fake_repair_issue)
+
+    # Call with --retry-from but WITHOUT --from
+    status = main(
+        [
+            "repair",
+            "issue",
+            "owner/repo#1",
+            "--repo-path",
+            str(tmp_path / "repo"),
+            "--runs-dir",
+            str(runs_dir),
+            "--retry-from",
+            record.run_id,
+            # Note: NO --from argument here - this is the plain retry case
+        ]
+    )
+
+    assert status == 0, f"Expected status 0 but got {status}"
+    assert intake_load_call_tracker["called"], (
+        "load_issue_intake must be called for plain retry (--retry-from without --from)"
+    )
+    assert captured["retry_from"] == record.run_id
+    assert captured["resume_from"] is None, (
+        "resume_from should be None for plain retry without --from"
+    )
+    assert captured["intake"] is not None, (
+        "intake must not be None for plain retry - coordinator needs it for create_issue()"
+    )
+    # Cast to IssueIntake to satisfy type checker
+    received_intake = cast(IssueIntake, captured["intake"])
+    assert received_intake.issue.reference == intake_payload.issue.reference
 
 
 def test_repair_issue_from_without_retry_from_fails(capsys, tmp_path: Path) -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -27,6 +27,7 @@ from precision_squad.models import (
     IssueReviewProvenance,
     PlanReview,
     PlanReviewProvenance,
+    PublishPlan,
     PublishResult,
     QaResult,
     RepairResult,
@@ -726,6 +727,60 @@ def _create_publish_resume_source_run(
     return store, updated
 
 
+def _create_review_impl_resume_source_run(
+    store: RunStore,
+    attempt: int = 1,
+) -> tuple[RunStore, RunRecord]:
+    """Create a source run suitable for review impl resume testing.
+
+    Creates a run with the correct ingress artifacts for review impl resume:
+    - issue-intake.json (written by create_run)
+    - approved-plan.json
+    - publish-plan.json with status: draft_pr
+    - publish-result.json with status: published, target: draft_pr, URL, and PR number
+    """
+    intake = _make_intake()
+    issue_ref = "owner/repo#1"
+    request = RunRequest(issue_ref=issue_ref, runs_dir=str(store.root))
+    record = store.create_run(request, intake)
+
+    updated = RunRecord(
+        run_id=record.run_id,
+        issue_ref=record.issue_ref,
+        status=record.status,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        run_dir=record.run_dir,
+        attempt=attempt,
+    )
+    store.write_run_record(updated)
+    run_dir = Path(updated.run_dir)
+
+    # Write approved-plan.json
+    store.write_approved_plan(run_dir, _approved_plan(issue_ref))
+
+    # Write publish-plan.json with draft_pr status
+    publish_plan = PublishPlan(
+        status="draft_pr",
+        title="Test PR",
+        body="Test body",
+        reason_codes=(),
+    )
+    store.write_publish_plan(run_dir, publish_plan)
+
+    # Write publish-result.json with published status and PR metadata
+    publish_result = PublishResult(
+        status="published",
+        target="draft_pr",
+        summary="Published",
+        url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+    )
+    store.write_publish_result(run_dir, publish_result)
+
+    return store, updated
+
+
 RetryResumeStage = str  # For type alias purposes in tests
 
 
@@ -864,26 +919,63 @@ def test_retry_from_publish_with_non_approved_plan_review_fails(tmp_path: Path) 
 # ---------------------------------------------------------------------------
 
 
-def test_retry_from_review_impl_with_non_approved_plan_review_fails(tmp_path: Path) -> None:
-    """Test that --from review impl fails when plan-review.json is not approved."""
+def test_retry_from_review_impl_succeeds_with_correct_ingress_and_writes_both_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Test that review impl resume succeeds with correct ingress and writes both artifacts.
+
+    Per the governing plan (lines 76 and 121-123), review impl resume requires:
+    - approved-plan.json
+    - issue-intake.json
+    - publish-plan.json with status: draft_pr
+    - publish-result.json with status: published, target: draft_pr, URL, and PR number
+    - NO prior impl-review.json or plan-review.json requirement
+
+    The resumed review impl stage must write both impl-review.json and
+    post-publish-review-result.json to the new attempt directory.
+    """
+    from precision_squad.models import ImplReviewResult
+
     store = RunStore(tmp_path / "runs")
     store.root.mkdir(parents=True, exist_ok=True)
 
-    # Create a basic source run with an unapproved plan-review
-    _, previous = _create_publish_resume_source_run(
-        store,
-        attempt=1,
-        plan_review_approved=False,  # Not approved
+    # Create a source run with the correct review impl resume ingress
+    _, previous = _create_review_impl_resume_source_run(store, attempt=1)
+
+    # Mock the dependency to return a successful impl review result
+    mock_dependencies = MagicMock()
+    # Explicitly set run_impl_review to None so the compatibility path uses
+    # run_post_publish_review_if_needed instead. A bare MagicMock() exposes a
+    # callable run_impl_review attribute by default, which would cause
+    # _run_impl_review_with_compatibility to call the mock and return a non-dataclass
+    # result that fails later with asdict() errors.
+    mock_dependencies.run_impl_review = None
+    mock_dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
+        review_status="approved",
+        summary="Implementation looks good",
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+        pull_head_sha="abc123",
     )
 
     coordinator = RunCoordinator()
 
-    with pytest.raises(
-        ValueError, match="Implement ingress requires plan-review.json.review_status to be 'approved'"
-    ):
-        coordinator.repair_issue(
-            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="review impl"),
-            intake=_make_intake(),
-            dependencies=MagicMock(),
-        )
+    # This should succeed with the correct ingress artifacts
+    report = coordinator.repair_issue(
+        params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="review impl"),
+        intake=_make_intake(),
+        dependencies=mock_dependencies,
+    )
+
+    # Verify the new attempt was created
+    assert report.run_record.attempt == 2
+
+    # Verify both impl-review.json and post-publish-review-result.json were written
+    new_run_dir = Path(report.run_record.run_dir)
+    assert (new_run_dir / "impl-review.json").exists(), (
+        "review impl resume must write impl-review.json to new attempt"
+    )
+    assert (new_run_dir / "post-publish-review-result.json").exists(), (
+        "review impl resume must write post-publish-review-result.json to new attempt"
+    )
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -561,6 +561,16 @@ def _create_publish_resume_source_run(
     include_approved_plan: bool = True,
     include_plan_review: bool = True,
     plan_review_approved: bool = True,
+    include_execution_result: bool = True,
+    include_evaluation_result: bool = True,
+    include_governance_verdict: bool = True,
+    governance_verdict_approved: bool = True,
+    include_repair_result: bool = True,
+    repair_result_completed: bool = True,
+    include_qa_baseline_result: bool = True,
+    include_qa_result: bool = True,
+    include_decision_log: bool = True,
+    include_repair_workspace: bool = True,
 ) -> tuple[RunStore, RunRecord]:
     """Create a source run suitable for publish resume testing.
 
@@ -648,81 +658,94 @@ def _create_publish_resume_source_run(
             )
         store.write_plan_review(run_dir, review)
 
-    # Write governance-verdict.json (approved)
-    store.write_governance_verdict(
-        run_dir,
-        GovernanceVerdict(status="approved", summary="Approved", reason_codes=()),
-    )
+    # Write governance-verdict.json
+    if include_governance_verdict:
+        verdict_status = "approved" if governance_verdict_approved else "blocked"
+        store.write_governance_verdict(
+            run_dir,
+            GovernanceVerdict(status=verdict_status, summary="Reviewed", reason_codes=()),
+        )
 
     # Write execution-result.json
-    store.write_execution_result(
-        run_dir,
-        ExecutionResult(
-            status="completed",
-            executor_name="test",
-            summary="Test execution",
-            detail_codes=(),
-        ),
-    )
+    if include_execution_result:
+        store.write_execution_result(
+            run_dir,
+            ExecutionResult(
+                status="completed",
+                executor_name="test",
+                summary="Test execution",
+                detail_codes=(),
+            ),
+        )
 
     # Write evaluation-result.json
-    store.write_evaluation_result(
-        run_dir,
-        EvaluationResult(status="success", summary="Evaluation passed", detail_codes=()),
-    )
+    if include_evaluation_result:
+        store.write_evaluation_result(
+            run_dir,
+            EvaluationResult(status="success", summary="Evaluation passed", detail_codes=()),
+        )
 
-    # Write repair-result.json (completed with workspace_path)
-    repair_result = RepairResult(
-        status="completed",
-        summary="Repair completed",
-        detail_codes=(),
-        workspace_path=str(run_dir / "repair-workspace" / "repo"),
-    )
-    store.write_repair_result(run_dir, repair_result)
+    # Write repair-result.json
+    if include_repair_result:
+        workspace_path = (
+            str(run_dir / "repair-workspace" / "repo") if repair_result_completed else None
+        )
+        repair_status = "completed" if repair_result_completed else "blocked"
+        repair_result = RepairResult(
+            status=repair_status,
+            summary="Repair completed" if repair_result_completed else "Repair pending",
+            detail_codes=(),
+            workspace_path=workspace_path,
+        )
+        store.write_repair_result(run_dir, repair_result)
 
     # Write qa-baseline-result.json
-    store.write_qa_result(
-        run_dir,
-        QaResult(
-            status="passed",
-            summary="QA passed",
-            detail_codes=(),
-            phase="baseline",
-            quality="green",
-        ),
-    )
+    if include_qa_baseline_result:
+        store.write_qa_result(
+            run_dir,
+            QaResult(
+                status="passed",
+                summary="QA passed",
+                detail_codes=(),
+                phase="baseline",
+                quality="green",
+            ),
+        )
 
     # Write qa-result.json
-    store.write_qa_result(
-        run_dir,
-        QaResult(
-            status="passed",
-            summary="QA passed",
-            detail_codes=(),
-            phase="final",
-            quality="green",
-        ),
-    )
+    if include_qa_result:
+        store.write_qa_result(
+            run_dir,
+            QaResult(
+                status="passed",
+                summary="QA passed",
+                detail_codes=(),
+                phase="final",
+                quality="green",
+            ),
+        )
 
     # Write decision-log artifact
-    decision_log = DecisionLogArtifact(
-        attempt=attempt,
-        entries=(
-            DesignDecision(
-                sequence=1,
-                summary="Initial decision",
-                rationale="This is the first decision",
-                plan_steps=("Step 1",),
-                named_references=(),
-                affected_targets=(),
+    if include_decision_log:
+        decision_log = DecisionLogArtifact(
+            attempt=attempt,
+            entries=(
+                DesignDecision(
+                    sequence=1,
+                    summary="Initial decision",
+                    rationale="This is the first decision",
+                    plan_steps=("Step 1",),
+                    named_references=(),
+                    affected_targets=(),
+                ),
             ),
-        ),
-    )
-    store.write_decision_log(run_dir, decision_log)
+        )
+        store.write_decision_log(run_dir, decision_log)
 
     # Create repair-workspace/repo directory
-    workspace = run_dir / "repair-workspace" / "repo"
-    workspace.mkdir(parents=True, exist_ok=True)
+    if include_repair_workspace:
+        workspace = run_dir / "repair-workspace" / "repo"
+        workspace.mkdir(parents=True, exist_ok=True)
 
     return store, updated
 
@@ -781,14 +804,21 @@ def _create_review_impl_resume_source_run(
     return store, updated
 
 
-RetryResumeStage = str  # For type alias purposes in tests
+RetryResumeStage = Literal[
+    "review issue",
+    "plan",
+    "review plan",
+    "implement",
+    "publish",
+    "review impl",
+]
 
 
 def _make_params_for_resume(
     tmp_path: Path,
     retry_from: str,
     *,
-    resume_from: Literal["publish", "review impl"] | None = None,
+    resume_from: RetryResumeStage | None = None,
 ) -> RepairIssueParams:
     """Create RepairIssueParams for a resume test."""
     return RepairIssueParams(
@@ -912,6 +942,267 @@ def test_retry_from_publish_with_non_approved_plan_review_fails(tmp_path: Path) 
             intake=_make_intake(),
             dependencies=MagicMock(),
         )
+
+
+def test_retry_from_publish_without_execution_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when execution-result.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_execution_result=False,  # Missing execution-result.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires execution-result.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_evaluation_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when evaluation-result.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_evaluation_result=False,  # Missing evaluation-result.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires evaluation-result.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_governance_verdict_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when governance-verdict.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_governance_verdict=False,  # Missing governance-verdict.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires governance-verdict.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_with_non_approved_governance_verdict_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when governance-verdict.json is not approved."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        governance_verdict_approved=False,  # Not approved
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Retry resume to publish requires approved governance-verdict.json"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_repair_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when repair-result.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_repair_result=False,  # Missing repair-result.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires repair-result.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_with_incomplete_repair_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when repair-result.json has status != completed."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        repair_result_completed=False,  # Status is "blocked" instead of "completed"
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Retry resume to publish requires completed repair-result.json with workspace_path"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_qa_baseline_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when qa-baseline-result.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_qa_baseline_result=False,  # Missing qa-baseline-result.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires qa-baseline-result.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_qa_result_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when qa-result.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_qa_result=False,  # Missing qa-result.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires qa-result.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_decision_log_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when decision-log.attempt-{attempt}.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_decision_log=False,  # Missing decision-log artifact
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume to publish requires decision-log.attempt-1.json at"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_repair_workspace_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when repair-workspace/repo is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_repair_workspace=False,  # Missing repair-workspace/repo
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Retry resume to publish requires preserved repair-workspace/repo"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for successful later-stage resume regression
+# ---------------------------------------------------------------------------
+
+
+def test_retry_from_review_plan_succeeds_with_correct_ingress(tmp_path: Path) -> None:
+    """Test that --from review plan succeeds with correct ingress artifacts.
+
+    This is a regression test for successful later-stage resume (minimum happy path).
+    """
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        # All required artifacts for review plan resume are included by default
+        # - issue-draft.json
+        # - issue-review.json (approved)
+        # - approved-plan.json
+    )
+
+    coordinator = RunCoordinator()
+
+    # Mock dependencies needed for plan review
+    mock_dependencies = MagicMock()
+    mock_dependencies.run_plan_review.return_value = PlanReview(
+        run_id=previous.run_id,
+        issue_ref="owner/repo#1",
+        review_status="approved",
+        summary="Plan looks good",
+        feedback=(),
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id=previous.run_id,
+            issue_ref="owner/repo#1",
+        ),
+    )
+
+    # This should succeed with the correct ingress artifacts
+    report = coordinator.repair_issue(
+        params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="review plan"),
+        intake=_make_intake(),
+        dependencies=mock_dependencies,
+    )
+
+    # Verify the new attempt was created
+    assert report.run_record.attempt == 2
+
+    # Verify plan-review.json was written to the new attempt directory
+    new_run_dir = Path(report.run_record.run_dir)
+    assert (new_run_dir / "plan-review.json").exists(), (
+        "review plan resume must write plan-review.json to new attempt"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,13 +12,24 @@ import pytest
 from precision_squad.coordinator import RepairIssueParams, RunCoordinator
 from precision_squad.models import (
     ApprovedPlan,
+    DecisionLogArtifact,
+    DesignDecision,
+    EvaluationResult,
     ExecutionResult,
     GitHubIssue,
     GovernanceVerdict,
     IssueAssessment,
+    IssueDraft,
+    IssueDraftProvenance,
     IssueIntake,
     IssueReference,
+    IssueReview,
+    IssueReviewProvenance,
+    PlanReview,
+    PlanReviewProvenance,
     PublishResult,
+    QaResult,
+    RepairResult,
     RunRecord,
     RunRequest,
 )
@@ -481,3 +493,397 @@ def test_retry_escalation_persists_approved_plan_into_new_run_directory(tmp_path
 
     persisted_plan = RunStore.load_approved_plan(escalated_run_dir, issue_ref="owner/repo#1")
     assert persisted_plan == _approved_plan()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for publish/resume preflight tests
+# ---------------------------------------------------------------------------
+
+
+def _make_issue_review_approved(run_id: str, issue_ref: str) -> IssueReview:
+    return IssueReview(
+        run_id=run_id,
+        issue_ref=issue_ref,
+        review_status="approved",
+        summary="Issue review approved",
+        feedback=(),
+        provenance=IssueReviewProvenance(
+            source_artifact="issue-draft.json",
+            run_id=run_id,
+            issue_ref=issue_ref,
+        ),
+    )
+
+
+def _make_plan_review_approved(run_id: str, issue_ref: str) -> PlanReview:
+    return PlanReview(
+        run_id=run_id,
+        issue_ref=issue_ref,
+        review_status="approved",
+        summary="Plan review approved",
+        feedback=(),
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id=run_id,
+            issue_ref=issue_ref,
+        ),
+    )
+
+
+def _make_issue_draft(issue_ref: str) -> IssueDraft:
+    return IssueDraft(
+        owner="owner",
+        repo="repo",
+        number=1,
+        issue_ref=issue_ref,
+        issue_url=f"https://github.com/{issue_ref.replace('#', '/issues/')}",
+        title="Test issue",
+        summary="Test issue summary",
+        problem_statement="Fix the bug.",
+        labels=(),
+        intake_status="runnable",
+        intake_reason_codes=(),
+        provenance=IssueDraftProvenance(
+            source_artifacts=("issue-intake.json",),
+            requested_issue_ref=issue_ref,
+        ),
+    )
+
+
+def _create_publish_resume_source_run(
+    store: RunStore,
+    attempt: int = 1,
+    *,
+    include_issue_draft: bool = True,
+    include_issue_review: bool = True,
+    issue_review_approved: bool = True,
+    include_approved_plan: bool = True,
+    include_plan_review: bool = True,
+    plan_review_approved: bool = True,
+) -> tuple[RunStore, RunRecord]:
+    """Create a source run suitable for publish resume testing.
+
+    Creates a run with all implement-stage artifacts. Individual artifacts
+    can be excluded or modified via parameters.
+    """
+    intake = _make_intake()
+    issue_ref = "owner/repo#1"
+    request = RunRequest(issue_ref=issue_ref, runs_dir=str(store.root))
+    record = store.create_run(request, intake)
+
+    updated = RunRecord(
+        run_id=record.run_id,
+        issue_ref=record.issue_ref,
+        status=record.status,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        run_dir=record.run_dir,
+        attempt=attempt,
+    )
+    store.write_run_record(updated)
+    run_dir = Path(updated.run_dir)
+
+    # create_run() always writes issue-draft.json, so remove it if not included
+    if not include_issue_draft:
+        (run_dir / "issue-draft.json").unlink(missing_ok=True)
+
+    # Write issue-draft.json directly
+    if include_issue_draft:
+        draft = _make_issue_draft(issue_ref)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "issue-draft.json").write_text(
+            json.dumps(
+                {
+                    "owner": draft.owner,
+                    "repo": draft.repo,
+                    "number": draft.number,
+                    "issue_ref": draft.issue_ref,
+                    "issue_url": draft.issue_url,
+                    "title": draft.title,
+                    "summary": draft.summary,
+                    "problem_statement": draft.problem_statement,
+                    "labels": list(draft.labels),
+                    "intake_status": draft.intake_status,
+                    "intake_reason_codes": list(draft.intake_reason_codes),
+                    "provenance": {
+                        "source_artifacts": list(draft.provenance.source_artifacts),
+                        "requested_issue_ref": draft.provenance.requested_issue_ref,
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    # Write issue-review.json
+    if include_issue_review:
+        review = _make_issue_review_approved(record.run_id, issue_ref)
+        if not issue_review_approved:
+            review = IssueReview(
+                run_id=review.run_id,
+                issue_ref=review.issue_ref,
+                review_status="changes_requested",
+                summary=review.summary,
+                feedback=review.feedback,
+                provenance=review.provenance,
+            )
+        store.write_issue_review(run_dir, review)
+
+    # Write approved-plan.json
+    if include_approved_plan:
+        store.write_approved_plan(run_dir, _approved_plan(issue_ref))
+
+    # Write plan-review.json
+    if include_plan_review:
+        review = _make_plan_review_approved(record.run_id, issue_ref)
+        if not plan_review_approved:
+            review = PlanReview(
+                run_id=review.run_id,
+                issue_ref=review.issue_ref,
+                review_status="changes_requested",
+                summary=review.summary,
+                feedback=review.feedback,
+                provenance=review.provenance,
+            )
+        store.write_plan_review(run_dir, review)
+
+    # Write governance-verdict.json (approved)
+    store.write_governance_verdict(
+        run_dir,
+        GovernanceVerdict(status="approved", summary="Approved", reason_codes=()),
+    )
+
+    # Write execution-result.json
+    store.write_execution_result(
+        run_dir,
+        ExecutionResult(
+            status="completed",
+            executor_name="test",
+            summary="Test execution",
+            detail_codes=(),
+        ),
+    )
+
+    # Write evaluation-result.json
+    store.write_evaluation_result(
+        run_dir,
+        EvaluationResult(status="success", summary="Evaluation passed", detail_codes=()),
+    )
+
+    # Write repair-result.json (completed with workspace_path)
+    repair_result = RepairResult(
+        status="completed",
+        summary="Repair completed",
+        detail_codes=(),
+        workspace_path=str(run_dir / "repair-workspace" / "repo"),
+    )
+    store.write_repair_result(run_dir, repair_result)
+
+    # Write qa-baseline-result.json
+    store.write_qa_result(
+        run_dir,
+        QaResult(
+            status="passed",
+            summary="QA passed",
+            detail_codes=(),
+            phase="baseline",
+            quality="green",
+        ),
+    )
+
+    # Write qa-result.json
+    store.write_qa_result(
+        run_dir,
+        QaResult(
+            status="passed",
+            summary="QA passed",
+            detail_codes=(),
+            phase="final",
+            quality="green",
+        ),
+    )
+
+    # Write decision-log artifact
+    decision_log = DecisionLogArtifact(
+        attempt=attempt,
+        entries=(
+            DesignDecision(
+                sequence=1,
+                summary="Initial decision",
+                rationale="This is the first decision",
+                plan_steps=("Step 1",),
+                named_references=(),
+                affected_targets=(),
+            ),
+        ),
+    )
+    store.write_decision_log(run_dir, decision_log)
+
+    # Create repair-workspace/repo directory
+    workspace = run_dir / "repair-workspace" / "repo"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    return store, updated
+
+
+RetryResumeStage = str  # For type alias purposes in tests
+
+
+def _make_params_for_resume(
+    tmp_path: Path,
+    retry_from: str,
+    *,
+    resume_from: Literal["publish", "review impl"] | None = None,
+) -> RepairIssueParams:
+    """Create RepairIssueParams for a resume test."""
+    return RepairIssueParams(
+        issue_ref="owner/repo#1",
+        runs_dir=tmp_path / "runs",
+        repo_path=tmp_path / "repo",
+        publish=False,
+        repair_agent="none",
+        repair_model=None,
+        review_model=None,
+        retry_from=retry_from,
+        resume_from=resume_from,
+        approved_plan=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for publish resume preflight validation
+# ---------------------------------------------------------------------------
+
+
+def test_retry_from_publish_without_issue_draft_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when issue-draft.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_issue_draft=False,  # Missing issue-draft.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume requires issue-draft.json"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_issue_review_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when issue-review.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_issue_review=False,  # Missing issue-review.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume to publish requires issue-review.json"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_with_non_approved_issue_review_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when issue-review.json is not approved."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        issue_review_approved=False,  # Not approved
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Retry resume to publish requires approved issue-review.json"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_without_plan_review_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when plan-review.json is missing."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        include_plan_review=False,  # Missing plan-review.json
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(ValueError, match="Retry resume to publish requires plan-review.json"):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_with_non_approved_plan_review_fails(tmp_path: Path) -> None:
+    """Test that --from publish fails when plan-review.json is not approved."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        plan_review_approved=False,  # Not approved
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Retry resume to publish requires approved plan-review.json"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for review impl resume preflight validation
+# ---------------------------------------------------------------------------
+
+
+def test_retry_from_review_impl_with_non_approved_plan_review_fails(tmp_path: Path) -> None:
+    """Test that --from review impl fails when plan-review.json is not approved."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+
+    # Create a basic source run with an unapproved plan-review
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        plan_review_approved=False,  # Not approved
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="Implement ingress requires plan-review.json.review_status to be 'approved'"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="review impl"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1270,3 +1270,164 @@ def test_retry_from_review_impl_succeeds_with_correct_ingress_and_writes_both_ar
         "review impl resume must write post-publish-review-result.json to new attempt"
     )
 
+
+# ---------------------------------------------------------------------------
+# Regression tests for context-pack materialization and repair-workspace carry-forward
+# ---------------------------------------------------------------------------
+
+
+def test_retry_context_pack_materialization(tmp_path: Path) -> None:
+    """Test that resumed attempt contains new run-request.json, preserved issue-intake.json, and regenerated issue.md.
+
+    Regression test for the governing plan (issue #116) which requires:
+    - New retry attempt must materialize a new run-request.json
+    - Preserved issue-intake.json from source attempt
+    - Regenerated issue.md derived from preserved intake
+
+    This tests the create_retry_run() contract in run_store.py.
+    """
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        # Include all artifacts needed for a review plan resume
+    )
+    previous_run_dir = Path(previous.run_dir)
+
+    coordinator = RunCoordinator()
+
+    # Mock dependencies needed for plan review
+    mock_dependencies = MagicMock()
+    mock_dependencies.run_plan_review.return_value = PlanReview(
+        run_id=previous.run_id,
+        issue_ref="owner/repo#1",
+        review_status="approved",
+        summary="Plan looks good",
+        feedback=(),
+        provenance=PlanReviewProvenance(
+            source_artifact="approved-plan.json",
+            run_id=previous.run_id,
+            issue_ref="owner/repo#1",
+        ),
+    )
+
+    report = coordinator.repair_issue(
+        params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="review plan"),
+        intake=_make_intake(),
+        dependencies=mock_dependencies,
+    )
+
+    new_run_dir = Path(report.run_record.run_dir)
+
+    # Verify new run-request.json was created (not copied from source)
+    assert (new_run_dir / "run-request.json").exists(), (
+        "resumed attempt must contain new run-request.json"
+    )
+    run_request = json.loads((new_run_dir / "run-request.json").read_text(encoding="utf-8"))
+    assert run_request["issue_ref"] == "owner/repo#1", (
+        "run-request.json should reflect current invocation"
+    )
+
+    # Verify issue-intake.json was preserved from source
+    assert (new_run_dir / "issue-intake.json").exists(), (
+        "resumed attempt must preserve issue-intake.json from source"
+    )
+    # The preserved intake should match the source's intake
+    source_intake_path = previous_run_dir / "issue-intake.json"
+    new_intake_path = new_run_dir / "issue-intake.json"
+    assert source_intake_path.read_text(encoding="utf-8") == new_intake_path.read_text(
+        encoding="utf-8"
+    ), "issue-intake.json content should be preserved from source"
+
+    # Verify issue.md was regenerated from preserved intake
+    assert (new_run_dir / "issue.md").exists(), (
+        "resumed attempt must contain regenerated issue.md"
+    )
+    issue_md_content = (new_run_dir / "issue.md").read_text(encoding="utf-8")
+    assert "Test issue" in issue_md_content, (
+        "issue.md should contain content derived from preserved intake"
+    )
+
+
+def test_retry_publish_resume_carries_forward_repair_workspace(tmp_path: Path) -> None:
+    """Test that publish resume copies repair-workspace and rewrites repair-result.json.workspace_path.
+
+    Regression test for the governing plan (issue #116) which requires for publish resume:
+    - repair-workspace/repo must be copied into the new attempt
+    - repair-result.json.workspace_path must be rewritten to the new attempt-local repair-workspace path
+
+    This tests the copy_retry_artifacts() contract in run_store.py with copy_repair_workspace=True.
+    """
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        # Include all required artifacts for publish resume
+        include_repair_workspace=True,
+        repair_result_completed=True,
+    )
+    previous_run_dir = Path(previous.run_dir)
+
+    # Verify source has the repair workspace before testing
+    source_workspace = previous_run_dir / "repair-workspace" / "repo"
+    assert source_workspace.exists(), "source run must have repair-workspace/repo"
+
+    coordinator = RunCoordinator()
+
+    # Mock dependencies needed for publish
+    mock_dependencies = MagicMock()
+    mock_dependencies.execute_publish_plan.return_value = PublishResult(
+        status="published",
+        target="draft_pr",
+        summary="Published",
+        url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+    )
+    mock_dependencies.run_impl_review = None
+    # review_impl is called after publish when conditions are met, so we need
+    # run_post_publish_review_if_needed to return a valid ImplReviewResult
+    from precision_squad.models import ImplReviewResult
+    mock_dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
+        review_status="approved",
+        summary="Implementation looks good",
+        pull_request_url="https://github.com/owner/repo/pull/1",
+        pull_number=1,
+        pull_head_sha="abc123",
+    )
+
+    report = coordinator.repair_issue(
+        params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+        intake=_make_intake(),
+        dependencies=mock_dependencies,
+    )
+
+    new_run_dir = Path(report.run_record.run_dir)
+
+    # Verify repair-workspace/repo was copied into the new attempt
+    new_workspace = new_run_dir / "repair-workspace" / "repo"
+    assert new_workspace.exists(), (
+        "publish resume must copy repair-workspace/repo into new attempt"
+    )
+
+    # Verify repair-result.json.workspace_path was rewritten to new attempt-local path
+    repair_result_path = new_run_dir / "repair-result.json"
+    assert repair_result_path.exists(), (
+        "publish resume must have repair-result.json in new attempt"
+    )
+    repair_result = json.loads(repair_result_path.read_text(encoding="utf-8"))
+    workspace_path = repair_result.get("workspace_path")
+    assert workspace_path is not None, "repair-result.json must have workspace_path"
+    # workspace_path must be the repair-workspace ROOT, with repo at workspace_path / "repo"
+    expected_workspace_root = str((new_run_dir / "repair-workspace").resolve())
+    assert workspace_path == expected_workspace_root, (
+        f"repair-result.json.workspace_path must point to new attempt-local repair-workspace root; "
+        f"expected {expected_workspace_root}, got {workspace_path}"
+    )
+    # Also verify that repo lives at workspace_path / "repo"
+    assert new_workspace.exists(), "repo must exist at workspace_path / 'repo'"
+
+    # Verify source repair-workspace is unchanged (no destructive mutation)
+    assert source_workspace.exists(), "source repair-workspace must remain intact"
+


### PR DESCRIPTION
## Summary
- add retry resume flow support for `repair issue --retry-from ... --from ...`
- validate resume prerequisites and preserve upstream artifacts across attempts
- document the stage contract and add regression coverage

Closes #116