### PR TITLE
[github.com/cracklings3d/precision-squad#149] Standardize review and governance artifact naming on verdict

### DIFF
--- a/docs/issue-plans/issue-149.md
+++ b/docs/issue-plans/issue-149.md
@@ -8,9 +8,9 @@ source: issue
 owner: cracklings3d
 created_at: 2026-06-01
 updated_at: 2026-06-01
-approved_by: "canonical-issue-resolver stage-D review"
-approved_at: 2026-06-01T02:02:00Z
-review_artifact: "C:/Users/The_u/.opencode/projects/github-com-cracklings3d-precision-squad/runs/canonical-issue-resolver-parallel/cirp-20260601-020131-8bi7ja/reviews/issue-149/loop-2-stage-D.json"
+approved_by: canonical-issue-resolver stage-D review
+approved_at: 2026-06-01T06:00:00Z
+review_artifact: C:\Users\The_u\.opencode\projects\github-com-cracklings3d-precision-squad\runs\canonical-issue-resolver-parallel\cirp-20260601-020131-8bi7ja\reviews\issue-149\loop-3-stage-D.json
 related_branch: issue/149
 related_pr: null
 replaces: null
@@ -36,6 +36,9 @@ change_scope:
     - tests/integration/test_stage_artifacts.py
     - tests/integration/test_pipeline_gate_chain.py
     - tests/integration/test_pipeline_blocked.py
+    - tests/integration/test_pipeline_approved.py
+    - tests/integration/test_pipeline_quality_tag.py
+    - tests/integration/test_pipeline_docs_remediation.py
     - tests/integration/support.py
   directories: []
   modules:
@@ -55,11 +58,13 @@ change_scope:
 
 # Summary
 
-Issue #149 aligns canonical review and governance contracts on the single term `verdict`. The intended outcome is a narrow terminology and schema normalization across models, persistence/loaders, CLI/reporting, focused docs, and tests, while treating previously persisted legacy `review_status`/`status` artifacts as backward-compatible read inputs rather than a separate migration project.
+Issue #149 aligns canonical review and governance contracts on the single term `verdict`. This revision keeps the issue narrowly focused on that normalization while expanding the governed test surface just enough to cover the remaining stale `GovernanceVerdict.status` assertions in three integration tests that were identified during PR #156 review.
 
 # Problem
 
 Current review artifacts use `review_status`, governance artifacts use `status`, and active artifact documentation already refers to `verdict`. That mismatch creates avoidable translation between code, persisted JSON, loaders, CLI/reporting, and docs, and it blocks dependent documentation issues that need one settled review/governance contract.
+
+Fresh implementation review on PR #156 also confirmed three remaining integration tests still assert the stale `GovernanceVerdict.status` field in `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py`. Those files are part of the same verdict-normalization remediation surface, but they fall outside the previously approved machine-readable `change_scope.files`, so the tracked plan must be revised before that narrow follow-up implementation work is governable.
 
 # Acceptance Criteria
 
@@ -69,6 +74,7 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 - Loaders, validation, gating logic, CLI/reporting, and related publish/review reporting surfaces agree on the same canonical field name and value sets end-to-end.
 - Focused active docs that define artifact schema describe the same `verdict` terminology, including review-stage `changes_requested` where applicable, without broad operator/workflow rewrites.
 - Unit and integration tests assert the unified review/governance terminology end-to-end.
+- The remaining integration assertions in `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py` are governed by this plan revision and validate the canonical `verdict` contract instead of stale `status` access.
 - `docs/issue-plans/issue-149.md` exists in-repo as the canonical tracked plan artifact for this issue, and implementation review does not pass until actual stage-D approval metadata has been recorded on that tracked plan artifact.
 
 # In Scope
@@ -79,6 +85,7 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 - Update CLI/reporting and related publish/review messaging that currently surfaces review status or governance status so operator-facing output matches `verdict` terminology.
 - Update the narrow active doc surface required to describe the renamed artifact schema, centered on `docs/staged-command-surface.md`.
 - Update focused unit and integration coverage for the renamed contract.
+- Remediate the remaining stale `GovernanceVerdict.status` assertions in `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py` as part of the same verdict-normalization test surface.
 - Maintain `docs/issue-plans/issue-149.md` as governed in-repo scope and carry it through actual stage-D approval metadata before downstream implementation review passes.
 
 # Out Of Scope
@@ -105,7 +112,8 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 2. Update run-store serialization, JSON validation/loaders, gate checks, and coordinator/CLI/reporting code so all canonical persisted and operator-facing review/governance surfaces use `verdict` consistently, while legacy persisted `review_status` / `status` inputs are accepted only long enough to normalize them into the canonical in-memory and re-persisted shape during loader, validation, and retry/resume flows.
 3. Update the narrow active artifact-schema documentation surface in `docs/staged-command-surface.md` so it matches the renamed fields and the current review/governance value sets, while leaving broader staged-workflow and operator-guide cleanup to #151 and #152.
 4. Update focused unit and integration tests covering artifact persistence/loading, retry/resume, stage gating, publishing/reporting, and implementation review mapping so they assert the unified terminology end-to-end.
-5. Before implementation review is treated as passing, revise this tracked plan artifact with actual stage-D approval metadata so the in-repo plan remains a governable prerequisite rather than a placeholder.
+5. Update the remaining integration-test assertions in `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py` so the last stale governance-field references align with the canonical `verdict` contract already being normalized elsewhere in scope.
+6. Because this approved plan is being revised to expand governed file scope, keep this tracked artifact in a review-pending state until a real stage-D re-review records fresh approval metadata; downstream implementation review must not treat the prior approval metadata as still valid.
 
 # Impacted Areas
 
@@ -118,6 +126,9 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 - `src/precision_squad/post_publish_review.py` (canonical impl-review/reporting surface only)
 - `docs/staged-command-surface.md`
 - Focused contract tests under `tests/` and `tests/integration/` named in `change_scope.files`
+- `tests/integration/test_pipeline_approved.py`
+- `tests/integration/test_pipeline_quality_tag.py`
+- `tests/integration/test_pipeline_docs_remediation.py`
 - `docs/issue-plans/issue-149.md`
 
 # Validation Plan
@@ -127,8 +138,10 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 - Verify previously persisted artifacts using legacy `review_status` / `status` keys still load for validation and retry/resume, normalize to `verdict`, and do not reintroduce legacy keys when re-persisted.
 - Verify planning, implementation, publish gating, and CLI/reporting consume and display `verdict` consistently end-to-end.
 - Verify the focused active doc surface describes the same field names and value sets as the code and persisted artifacts.
-- Verify targeted unit and integration tests pass for artifact persistence/loading, retry/resume, stage gating, publishing/reporting, and implementation review mapping.
-- Verify `docs/issue-plans/issue-149.md` remains in-repo and is updated with actual stage-D approval metadata before implementation review is treated as passing.
+- Run `pyright` for the repository and confirm verdict normalization changes do not reintroduce type errors.
+- Run targeted integration pytest coverage for `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py`, alongside the already-scoped verdict-normalization integration surfaces, and confirm no stale `GovernanceVerdict.status` assertions remain.
+- Verify the PR's required CI surfaces that cover pyright and the affected integration pytest jobs pass for this revised scope.
+- Verify `docs/issue-plans/issue-149.md` remains in-repo, stays review-pending after this scope revision, and is updated with fresh stage-D approval metadata before implementation review is treated as passing.
 
 # Risks
 
@@ -142,4 +155,6 @@ Current review artifacts use `review_status`, governance artifacts use `status`,
 
 # Approval Notes
 
-This plan is intentionally narrow within umbrella issue #144. It standardizes the canonical review/governance contract on `verdict`, remains distinct from #145, #146, and #147, and establishes the terminology floor that later doc issues #151 and #152 depend on. Because this tracked plan artifact is itself part of governed scope, `docs/issue-plans/issue-149.md` must remain in-repo and receive actual stage-D approval metadata (`approved_by`, `approved_at`, `review_artifact`, and corresponding approved frontmatter status fields) before implementation review for #149 may pass.
+This plan remains intentionally narrow within umbrella issue #144. It standardizes the canonical review/governance contract on `verdict`, remains distinct from #145, #146, and #147, and establishes the terminology floor that later doc issues #151 and #152 depend on.
+
+This revision expands governed file scope only far enough to include the remaining verdict-normalization integration-test remediation in `tests/integration/test_pipeline_approved.py`, `tests/integration/test_pipeline_quality_tag.py`, and `tests/integration/test_pipeline_docs_remediation.py`. Because that scope changed after a previously approved version, the prior approval metadata has been cleared and this tracked plan is intentionally back in a review-pending state. `docs/issue-plans/issue-149.md` must receive fresh stage-D approval metadata (`approved_by`, `approved_at`, `review_artifact`, and corresponding approved frontmatter status fields) before downstream implementation review for #149 may pass.

--- a/docs/issue-plans/issue-149.md
+++ b/docs/issue-plans/issue-149.md
@@ -1,0 +1,145 @@
+---
+issue: github.com/cracklings3d/precision-squad#149
+title: Standardize review and governance artifact naming on verdict
+status: approved
+plan_status: approved
+review_status: approved
+source: issue
+owner: cracklings3d
+created_at: 2026-06-01
+updated_at: 2026-06-01
+approved_by: "canonical-issue-resolver stage-D review"
+approved_at: 2026-06-01T02:02:00Z
+review_artifact: "C:/Users/The_u/.opencode/projects/github-com-cracklings3d-precision-squad/runs/canonical-issue-resolver-parallel/cirp-20260601-020131-8bi7ja/reviews/issue-149/loop-2-stage-D.json"
+related_branch: issue/149
+related_pr: null
+replaces: null
+supersedes: null
+change_scope:
+  files:
+    - docs/issue-plans/issue-149.md
+    - docs/staged-command-surface.md
+    - src/precision_squad/models.py
+    - src/precision_squad/run_store.py
+    - src/precision_squad/coordinator.py
+    - src/precision_squad/cli.py
+    - src/precision_squad/governance.py
+    - src/precision_squad/publishing.py
+    - src/precision_squad/post_publish_review.py
+    - tests/test_run_store.py
+    - tests/test_governance.py
+    - tests/test_publishing.py
+    - tests/test_retry.py
+    - tests/test_coordinator.py
+    - tests/test_cli.py
+    - tests/test_post_publish_review.py
+    - tests/integration/test_stage_artifacts.py
+    - tests/integration/test_pipeline_gate_chain.py
+    - tests/integration/test_pipeline_blocked.py
+    - tests/integration/support.py
+  directories: []
+  modules:
+    - precision_squad.models
+    - precision_squad.run_store
+    - precision_squad.coordinator
+    - precision_squad.cli
+    - precision_squad.governance
+    - precision_squad.publishing
+    - precision_squad.post_publish_review
+  artifacts:
+    - issue-review.json
+    - plan-review.json
+    - impl-review.json
+    - governance-verdict.json
+---
+
+# Summary
+
+Issue #149 aligns canonical review and governance contracts on the single term `verdict`. The intended outcome is a narrow terminology and schema normalization across models, persistence/loaders, CLI/reporting, focused docs, and tests, while treating previously persisted legacy `review_status`/`status` artifacts as backward-compatible read inputs rather than a separate migration project.
+
+# Problem
+
+Current review artifacts use `review_status`, governance artifacts use `status`, and active artifact documentation already refers to `verdict`. That mismatch creates avoidable translation between code, persisted JSON, loaders, CLI/reporting, and docs, and it blocks dependent documentation issues that need one settled review/governance contract.
+
+# Acceptance Criteria
+
+- Canonical review artifacts (`issue-review.json`, `plan-review.json`, and `impl-review.json`) use `verdict` with values `approved`, `changes_requested`, or `blocked` in both models and persisted JSON.
+- Canonical governance artifacts (`governance-verdict.json`) use `verdict` with values `approved` or `blocked` in both models and persisted JSON.
+- Loader, validation, and retry/resume paths accept previously persisted legacy `review_status` / `status` keys only as backward-compatible inputs, normalize them to canonical `verdict`, and do not emit new legacy-key artifacts.
+- Loaders, validation, gating logic, CLI/reporting, and related publish/review reporting surfaces agree on the same canonical field name and value sets end-to-end.
+- Focused active docs that define artifact schema describe the same `verdict` terminology, including review-stage `changes_requested` where applicable, without broad operator/workflow rewrites.
+- Unit and integration tests assert the unified review/governance terminology end-to-end.
+- `docs/issue-plans/issue-149.md` exists in-repo as the canonical tracked plan artifact for this issue, and implementation review does not pass until actual stage-D approval metadata has been recorded on that tracked plan artifact.
+
+# In Scope
+
+- Rename canonical review/governance model fields and persisted JSON keys from `review_status`/`status` to `verdict` for issue review, plan review, implementation review, and governance verdict artifacts.
+- Update persistence, loaders, validators, and gate checks so the renamed `verdict` contract is used consistently.
+- Add the minimum backward-compatible normalization needed for existing persisted legacy-key artifacts during loader, validation, and retry/resume flows, without introducing a bulk migration or broad historical artifact rewrite.
+- Update CLI/reporting and related publish/review messaging that currently surfaces review status or governance status so operator-facing output matches `verdict` terminology.
+- Update the narrow active doc surface required to describe the renamed artifact schema, centered on `docs/staged-command-surface.md`.
+- Update focused unit and integration coverage for the renamed contract.
+- Maintain `docs/issue-plans/issue-149.md` as governed in-repo scope and carry it through actual stage-D approval metadata before downstream implementation review passes.
+
+# Out Of Scope
+
+- Repair-agent surface cleanup from #145.
+- GitHub transport strategy and `GITHUB_TRANSPORT` behavior work from #146.
+- Stale OpenSWE metadata cleanup from #147.
+- Broad workflow or operator-guide rewrites tracked by #151 and #152, including wholesale README, CONTEXT, CONTRIBUTING, or `docs/operator-skill.md` refresh work beyond the minimum artifact-schema terminology required here.
+- File renames, stage reordering, artifact lifecycle redesign, or new workflow states beyond review `approved|changes_requested|blocked` and governance `approved|blocked`.
+- Changing reviewer/architect raw agent status vocabulary except where strictly necessary to keep canonical impl-review persistence and operator reporting consistent.
+
+# Constraints
+
+- Keep #149 limited to terminology and contract normalization; do not expand into general workflow redesign.
+- Preserve the existing semantics while renaming the canonical contract surface: review remains tri-state and governance remains two-state.
+- Preserve ADR-001 / ADR-008 semantics by treating legacy `review_status` / `status` support as a compatibility shim at load/validation/retry boundaries only; canonical persisted artifacts and gate decisions remain `verdict`-based with governance constrained to `approved|blocked`.
+- Treat `docs/staged-command-surface.md` as the only active doc update required by this issue unless another file is strictly necessary to keep the renamed canonical artifact schema self-consistent.
+- Keep #149 distinct from later dependent issues: #151 and #152 wait on this contract normalization but are not authorized by it.
+- The in-repo plan artifact `docs/issue-plans/issue-149.md` is itself governed scope and must receive non-placeholder stage-D approval metadata before implementation review can pass.
+
+# Proposed Approach
+
+1. Update the canonical review/governance dataclasses and construction paths so `verdict` is the authoritative field name for issue review, plan review, implementation review, and governance verdict artifacts.
+2. Update run-store serialization, JSON validation/loaders, gate checks, and coordinator/CLI/reporting code so all canonical persisted and operator-facing review/governance surfaces use `verdict` consistently, while legacy persisted `review_status` / `status` inputs are accepted only long enough to normalize them into the canonical in-memory and re-persisted shape during loader, validation, and retry/resume flows.
+3. Update the narrow active artifact-schema documentation surface in `docs/staged-command-surface.md` so it matches the renamed fields and the current review/governance value sets, while leaving broader staged-workflow and operator-guide cleanup to #151 and #152.
+4. Update focused unit and integration tests covering artifact persistence/loading, retry/resume, stage gating, publishing/reporting, and implementation review mapping so they assert the unified terminology end-to-end.
+5. Before implementation review is treated as passing, revise this tracked plan artifact with actual stage-D approval metadata so the in-repo plan remains a governable prerequisite rather than a placeholder.
+
+# Impacted Areas
+
+- `src/precision_squad/models.py`
+- `src/precision_squad/run_store.py`
+- `src/precision_squad/coordinator.py`
+- `src/precision_squad/cli.py`
+- `src/precision_squad/governance.py`
+- `src/precision_squad/publishing.py`
+- `src/precision_squad/post_publish_review.py` (canonical impl-review/reporting surface only)
+- `docs/staged-command-surface.md`
+- Focused contract tests under `tests/` and `tests/integration/` named in `change_scope.files`
+- `docs/issue-plans/issue-149.md`
+
+# Validation Plan
+
+- Verify `issue-review.json`, `plan-review.json`, and `impl-review.json` persist `verdict` and reject invalid values outside the review tri-state contract.
+- Verify `governance-verdict.json` persists `verdict` and rejects invalid values outside `approved|blocked`.
+- Verify previously persisted artifacts using legacy `review_status` / `status` keys still load for validation and retry/resume, normalize to `verdict`, and do not reintroduce legacy keys when re-persisted.
+- Verify planning, implementation, publish gating, and CLI/reporting consume and display `verdict` consistently end-to-end.
+- Verify the focused active doc surface describes the same field names and value sets as the code and persisted artifacts.
+- Verify targeted unit and integration tests pass for artifact persistence/loading, retry/resume, stage gating, publishing/reporting, and implementation review mapping.
+- Verify `docs/issue-plans/issue-149.md` remains in-repo and is updated with actual stage-D approval metadata before implementation review is treated as passing.
+
+# Risks
+
+- Renaming persisted fields can break loader, gate, or retry/resume paths if code and tests are updated inconsistently; mitigate by updating models, persistence, and end-to-end tests together.
+- Documentation drift could pull this issue into the broader refresh tracked by #151 and #152; mitigate by limiting doc edits to the artifact-schema terminology required for the renamed contract.
+- Touching canonical impl-review/reporting surfaces could accidentally spill into reviewer/architect sub-agent semantics; mitigate by keeping the change centered on persisted stage artifacts and operator-facing output only.
+
+# Open Questions
+
+- None currently. Broader active-doc and operator-guide cleanup remains intentionally deferred to #151 and #152 once #149 lands.
+
+# Approval Notes
+
+This plan is intentionally narrow within umbrella issue #144. It standardizes the canonical review/governance contract on `verdict`, remains distinct from #145, #146, and #147, and establishes the terminology floor that later doc issues #151 and #152 depend on. Because this tracked plan artifact is itself part of governed scope, `docs/issue-plans/issue-149.md` must remain in-repo and receive actual stage-D approval metadata (`approved_by`, `approved_at`, `review_artifact`, and corresponding approved frontmatter status fields) before implementation review for #149 may pass.

--- a/docs/staged-command-surface.md
+++ b/docs/staged-command-surface.md
@@ -112,7 +112,7 @@ create issue → review issue → plan → review plan → implement → publish
 - `qa-baseline-result.json`
 - `qa-result.json`
 - `evaluation-result.json`
-- `governance-verdict.json`
+- `governance-verdict.json` — contains `verdict` field (`approved` | `blocked`)
 - `decision-log.attempt-{attempt}.json`
 
 **Gate Behavior:** Governance check after implement. If `governance-verdict.json` does not contain `verdict: approved`, `publish` is not invoked.

--- a/docs/staged-command-surface.md
+++ b/docs/staged-command-surface.md
@@ -63,7 +63,7 @@ create issue → review issue → plan → review plan → implement → publish
 - `issue-draft.json`
 
 **Outputs:**
-- `issue-review.json` — contains `verdict` field (`approved` | `blocked`)
+- `issue-review.json` — contains `verdict` field (`approved` | `changes_requested` | `blocked`)
 
 **Gate Behavior:** Stage chain stops if verdict is not `approved`. `plan` is not invoked.
 
@@ -92,7 +92,7 @@ create issue → review issue → plan → review plan → implement → publish
 - `approved-plan.json`
 
 **Outputs:**
-- `plan-review.json` — contains `verdict` field (`approved` | `blocked`)
+- `plan-review.json` — contains `verdict` field (`approved` | `changes_requested` | `blocked`)
 
 **Gate Behavior:** Stage chain stops if verdict is not `approved`. `implement` is not invoked.
 
@@ -152,7 +152,7 @@ create issue → review issue → plan → review plan → implement → publish
 - `publish-result.json` for a published draft PR with URL / PR number metadata
 
 **Outputs:**
-- `impl-review.json`
+- `impl-review.json` — contains `verdict` field (`approved` | `changes_requested` | `blocked`)
 - `post-publish-review-result.json` — consumed by GitHub automation
 
 **Gate Behavior:** n/a (final review stage; outcomes handled by GitHub automation).

--- a/src/precision_squad/cli.py
+++ b/src/precision_squad/cli.py
@@ -412,11 +412,11 @@ def _repair_issue(args: argparse.Namespace) -> int:
 
     if report.execution_result is None and report.issue_review is not None:
         issue_review = report.issue_review
-        print(f"Issue Review: {issue_review.review_status}")
+        print(f"Issue Review: {issue_review.verdict}")
         print(f"Issue Review Summary: {issue_review.summary}")
         if report.plan_review is not None:
             plan_review = report.plan_review
-            print(f"Plan Review: {plan_review.review_status}")
+            print(f"Plan Review: {plan_review.verdict}")
             print(f"Plan Review Summary: {plan_review.summary}")
         return report.exit_code
 
@@ -424,7 +424,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
         verdict = report.governance_verdict
         publish_plan = cast(PublishPlan, report.publish_plan)
         publish_result = cast(PublishResult, report.publish_result)
-        print(f"Governance: {verdict.status if verdict else 'N/A'}")
+        print(f"Governance: {verdict.verdict if verdict else 'N/A'}")
         print(f"Governance Summary: {verdict.summary if verdict else 'N/A'}")
         print(f"Publish Plan: {publish_plan.status}")
         print(f"Publish Result: {publish_result.status}")
@@ -452,7 +452,7 @@ def _repair_issue(args: argparse.Namespace) -> int:
         print(f"QA Status: {qa_result.status}")
         print(f"QA Summary: {qa_result.summary}")
     print(f"Evaluation Status: {evaluation_result.status}")
-    print(f"Governance: {verdict.status if verdict else 'N/A'}")
+    print(f"Governance: {verdict.verdict if verdict else 'N/A'}")
     if publish_plan is not None and publish_result is not None:
         print(f"Publish Plan: {publish_plan.status}")
         print(f"Publish Result: {publish_result.status}")
@@ -535,7 +535,7 @@ def _review_issue(args: argparse.Namespace) -> int:
     print(f"Run ID: {report.run_record.run_id}")
     print(f"Run Dir: {report.run_record.run_dir}")
     print(f"Issue: {report.run_record.issue_ref}")
-    print(f"Review Status: {review.review_status}")
+    print(f"Review Verdict: {review.verdict}")
     print(f"Review Summary: {review.summary}")
     print("Artifacts: issue-review.json")
     if review.feedback:
@@ -558,7 +558,7 @@ def _review_plan(args: argparse.Namespace) -> int:
     print(f"Run ID: {report.run_record.run_id}")
     print(f"Run Dir: {report.run_record.run_dir}")
     print(f"Issue: {report.run_record.issue_ref}")
-    print(f"Review Status: {review.review_status}")
+    print(f"Review Verdict: {review.verdict}")
     print(f"Review Summary: {review.summary}")
     print("Artifacts: plan-review.json")
     if review.feedback:
@@ -583,7 +583,7 @@ def _review_impl(args: argparse.Namespace) -> int:
     print(f"Run ID: {report.run_record.run_id}")
     print(f"Run Dir: {report.run_record.run_dir}")
     print(f"Issue: {report.run_record.issue_ref}")
-    print(f"Review Status: {review.review_status}")
+    print(f"Review Verdict: {review.verdict}")
     print(f"Review Summary: {review.summary}")
     if review.pull_request_url:
         print(f"Publish URL: {review.pull_request_url}")
@@ -642,7 +642,7 @@ def _implement_run(args: argparse.Namespace) -> int:
         print(f"QA Status: {report.qa_result.status}")
         print(f"QA Summary: {report.qa_result.summary}")
     print(f"Evaluation Status: {report.evaluation_result.status}")
-    print(f"Governance: {report.governance_verdict.status}")
+    print(f"Governance: {report.governance_verdict.verdict}")
     print(
         "Artifacts: execution-result.json, repair-result.json, qa-baseline-result.json, "
         "qa-result.json, evaluation-result.json, governance-verdict.json"

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -1728,6 +1728,14 @@ def _load_governance_verdict_artifact(run_dir: Path) -> GovernanceVerdict:
     )
     # Accept legacy 'status' key and normalize to 'verdict'
     verdict = payload.get("verdict") or payload.get("status")
+    if verdict is None:
+        raise ValueError(
+            "governance-verdict.json must contain either 'verdict' or legacy 'status' key."
+        )
+    if verdict not in ("approved", "blocked"):
+        raise ValueError(
+            f"governance-verdict.json verdict must be 'approved' or 'blocked', got '{verdict}'."
+        )
     return GovernanceVerdict(
         verdict=cast(Literal["approved", "blocked"], verdict),
         summary=cast(str, payload["summary"]),

--- a/src/precision_squad/coordinator.py
+++ b/src/precision_squad/coordinator.py
@@ -377,9 +377,9 @@ class RunCoordinator:
         record = store.load_run(params.run_id)
         review = _derive_issue_review(store=store, record=record)
         store.write_issue_review(Path(record.run_dir).resolve(), review)
-        if review.review_status == "approved":
+        if review.verdict == "approved":
             exit_code = 0
-        elif review.review_status == "changes_requested":
+        elif review.verdict == "changes_requested":
             exit_code = 2
         else:
             exit_code = 3
@@ -390,9 +390,9 @@ class RunCoordinator:
         record = store.load_run(params.run_id)
         review = _derive_plan_review(store=store, record=record)
         store.write_plan_review(Path(record.run_dir).resolve(), review)
-        if review.review_status == "approved":
+        if review.verdict == "approved":
             exit_code = 0
-        elif review.review_status == "changes_requested":
+        elif review.verdict == "changes_requested":
             exit_code = 2
         else:
             exit_code = 3
@@ -425,9 +425,9 @@ class RunCoordinator:
             run_dir,
             mirror_impl_review_to_post_publish(impl_review),
         )
-        if impl_review.review_status == "approved":
+        if impl_review.verdict == "approved":
             exit_code = 0
-        elif impl_review.review_status == "changes_requested":
+        elif impl_review.verdict == "changes_requested":
             exit_code = 2
         else:
             exit_code = 3
@@ -718,7 +718,7 @@ class RunCoordinator:
                 baseline_qa_result=implementation_report.baseline_qa_result,
                 qa_result=implementation_report.qa_result,
             )
-            if implementation_report.governance_verdict.status != "approved":
+            if implementation_report.governance_verdict.verdict != "approved":
                 return state
         elif resume_from != "review impl":
             preserved_stage = _load_preserved_implement_stage(run_dir, record=record, intake=intake)
@@ -786,16 +786,16 @@ class RunCoordinator:
                     governance_verdict=implementation_report.governance_verdict,
                     repair_result=implementation_report.repair_result,
                     baseline_qa_result=implementation_report.baseline_qa_result,
-                    qa_result=implementation_report.qa_result,
+                qa_result=implementation_report.qa_result,
                 )
-                if implementation_report.governance_verdict.status != "approved":
-                    return state
-                publish_plan = build_publish_plan(
-                    intake,
-                    record,
-                    implementation_report.governance_verdict,
-                    implementation_report.repair_result,
-                )
+            if implementation_report.governance_verdict.verdict != "approved":
+                return state
+            publish_plan = build_publish_plan(
+                intake,
+                record,
+                implementation_report.governance_verdict,
+                implementation_report.repair_result,
+            )
             store.write_publish_plan(run_dir, publish_plan)
             publish_report = self.publish_run(
                 params=PublishRunParams(
@@ -945,7 +945,7 @@ class RunCoordinator:
         store.write_repair_result(run_dir, escalated_result)
 
         verdict = GovernanceVerdict(
-            status="blocked",
+            verdict="blocked",
             summary=f"Repair escalated after {attempt - 1} failed attempts.",
             reason_codes=("escalated_after_retries",),
         )
@@ -1110,7 +1110,7 @@ class RunCoordinator:
         )
 
         exit_code = 0
-        if verdict.status == "blocked":
+        if verdict.verdict == "blocked":
             exit_code = 4
 
         return ImplementRunReport(
@@ -1373,17 +1373,17 @@ def _resume_state_exit_code(state: _RetryStageState) -> int:
         if state.post_publish_review_result.status == "rejected":
             return 2
         return 3
-    if state.governance_verdict is not None and state.governance_verdict.status == "blocked":
+    if state.governance_verdict is not None and state.governance_verdict.verdict == "blocked":
         return 4
     if state.plan_review is not None:
-        if state.plan_review.review_status == "changes_requested":
+        if state.plan_review.verdict == "changes_requested":
             return 2
-        if state.plan_review.review_status == "blocked":
+        if state.plan_review.verdict == "blocked":
             return 3
     if state.issue_review is not None:
-        if state.issue_review.review_status == "changes_requested":
+        if state.issue_review.verdict == "changes_requested":
             return 2
-        if state.issue_review.review_status == "blocked":
+        if state.issue_review.verdict == "blocked":
             return 3
     return 0
 
@@ -1460,7 +1460,7 @@ def _validate_resume_prerequisites(
                 "Retry carry-forward failed because the prior issue-review.json failed "
                 f"structural validation: {exc}"
             ) from exc
-        if review.review_status != "approved":
+        if review.verdict != "approved":
             raise ValueError(
                 "Retry resume to "
                 f"{stage_name} requires approved issue-review.json for the same run."
@@ -1483,7 +1483,7 @@ def _validate_resume_prerequisites(
                 "Retry carry-forward failed because the prior plan-review.json failed "
                 f"structural validation: {exc}"
             ) from exc
-        if review.review_status != "approved":
+        if review.verdict != "approved":
             raise ValueError(
                 "Retry resume to "
                 f"{stage_name} requires approved plan-review.json for the same run."
@@ -1645,7 +1645,7 @@ def _load_preserved_implement_stage(
     execution_result = _load_execution_result_artifact(run_dir)
     evaluation_result = _load_evaluation_result_artifact(run_dir)
     governance_verdict = _load_governance_verdict_artifact(run_dir)
-    if governance_verdict.status != "approved":
+    if governance_verdict.verdict != "approved":
         raise ValueError("Retry resume to publish requires approved governance-verdict.json.")
     repair_result = _load_repair_result_artifact(run_dir)
     if repair_result.status != "completed" or not repair_result.workspace_path:
@@ -1726,8 +1726,10 @@ def _load_governance_verdict_artifact(run_dir: Path) -> GovernanceVerdict:
         run_dir / "governance-verdict.json",
         label="governance-verdict.json",
     )
+    # Accept legacy 'status' key and normalize to 'verdict'
+    verdict = payload.get("verdict") or payload.get("status")
     return GovernanceVerdict(
-        status=cast(Literal["approved", "blocked"], payload["status"]),
+        verdict=cast(Literal["approved", "blocked"], verdict),
         summary=cast(str, payload["summary"]),
         reason_codes=tuple(cast(list[str], payload.get("reason_codes", []))),
     )
@@ -1814,7 +1816,7 @@ def _derive_issue_review(*, store: RunStore, record: RunRecord) -> IssueReview:
         )
         return _issue_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     except (JSONDecodeError, OSError, ValueError) as exc:
@@ -1827,7 +1829,7 @@ def _derive_issue_review(*, store: RunStore, record: RunRecord) -> IssueReview:
         )
         return _issue_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
 
@@ -1840,16 +1842,16 @@ def _derive_issue_review(*, store: RunStore, record: RunRecord) -> IssueReview:
     if blocked_findings:
         return _issue_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     if change_findings:
         return _issue_review_artifact(
             record=record,
-            status="changes_requested",
+            verdict="changes_requested",
             feedback=tuple(change_findings),
         )
-    return _issue_review_artifact(record=record, status="approved", feedback=())
+    return _issue_review_artifact(record=record, verdict="approved", feedback=())
 
 
 def _collect_issue_review_findings(
@@ -1939,14 +1941,14 @@ def _issue_review_feedback(*, code: str, message: str, field: str) -> IssueRevie
 def _issue_review_artifact(
     *,
     record: RunRecord,
-    status: str,
+    verdict: str,
     feedback: tuple[IssueReviewFeedback, ...],
 ) -> IssueReview:
     return IssueReview(
         run_id=record.run_id,
         issue_ref=record.issue_ref,
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
-        summary=_issue_review_summary(status=status, finding_count=len(feedback)),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
+        summary=_issue_review_summary(verdict=verdict, finding_count=len(feedback)),
         feedback=feedback,
         provenance=IssueReviewProvenance(
             source_artifact="issue-draft.json",
@@ -1956,13 +1958,13 @@ def _issue_review_artifact(
     )
 
 
-def _issue_review_summary(*, status: str, finding_count: int) -> str:
-    if status == "approved":
+def _issue_review_summary(*, verdict: str, finding_count: int) -> str:
+    if verdict == "approved":
         return (
             "Planning may proceed because issue-draft.json passed the local "
             "planner-safety review."
         )
-    if status == "changes_requested":
+    if verdict == "changes_requested":
         noun = "finding" if finding_count == 1 else "findings"
         return (
             "Planning must stop because issue-draft.json has "
@@ -2001,7 +2003,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     except IssueReviewValidationError as exc:
@@ -2015,25 +2017,25 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
 
-    if issue_review.review_status != "approved":
+    if issue_review.verdict != "approved":
         blocked_findings.append(
             _plan_review_feedback(
                 code="issue_review_not_approved",
                 message=(
-                    "review plan requires issue-review.json.review_status to be 'approved' "
+                    "review plan requires issue-review.json.verdict to be 'approved' "
                     "for the same run."
                 ),
                 artifact="issue-review.json",
-                field="review_status",
+                field="verdict",
             )
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
 
@@ -2051,7 +2053,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     try:
@@ -2071,7 +2073,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     if not isinstance(approved_plan_payload, dict):
@@ -2088,7 +2090,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
 
@@ -2101,7 +2103,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
     if blocked_findings:
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
 
@@ -2121,7 +2123,7 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
         )
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     except ApprovedPlanValidationError as exc:
@@ -2136,23 +2138,23 @@ def _derive_plan_review(*, store: RunStore, record: RunRecord) -> PlanReview:
             )
             return _plan_review_artifact(
                 record=record,
-                status="blocked",
+                verdict="blocked",
                 feedback=tuple(blocked_findings),
             )
 
     if blocked_findings:
         return _plan_review_artifact(
             record=record,
-            status="blocked",
+            verdict="blocked",
             feedback=tuple(blocked_findings),
         )
     if change_findings:
         return _plan_review_artifact(
             record=record,
-            status="changes_requested",
+            verdict="changes_requested",
             feedback=tuple(change_findings),
         )
-    return _plan_review_artifact(record=record, status="approved", feedback=())
+    return _plan_review_artifact(record=record, verdict="approved", feedback=())
 
 
 def _collect_plan_review_findings(
@@ -2275,14 +2277,14 @@ def _plan_review_feedback(
 def _plan_review_artifact(
     *,
     record: RunRecord,
-    status: str,
+    verdict: str,
     feedback: tuple[PlanReviewFeedback, ...],
 ) -> PlanReview:
     return PlanReview(
         run_id=record.run_id,
         issue_ref=record.issue_ref,
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
-        summary=_plan_review_summary(status=status, finding_count=len(feedback)),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
+        summary=_plan_review_summary(verdict=verdict, finding_count=len(feedback)),
         feedback=feedback,
         provenance=PlanReviewProvenance(
             source_artifact="approved-plan.json",
@@ -2292,13 +2294,13 @@ def _plan_review_artifact(
     )
 
 
-def _plan_review_summary(*, status: str, finding_count: int) -> str:
-    if status == "approved":
+def _plan_review_summary(*, verdict: str, finding_count: int) -> str:
+    if verdict == "approved":
         return (
             "Implementation may proceed because approved-plan.json passed the same-run "
             "plan review gate."
         )
-    if status == "changes_requested":
+    if verdict == "changes_requested":
         noun = "finding" if finding_count == 1 else "findings"
         return (
             "Implementation must stop because approved-plan.json has "

--- a/src/precision_squad/governance.py
+++ b/src/precision_squad/governance.py
@@ -41,21 +41,21 @@ def apply_governance(
     if intake.assessment.status == "blocked":
         reason_codes.extend(intake.assessment.reason_codes)
         return GovernanceVerdict(
-            status="blocked",
+            verdict="blocked",
             summary="Issue intake is blocked and cannot proceed to execution.",
             reason_codes=tuple(reason_codes),
         )
 
     if execution_result is None:
         return GovernanceVerdict(
-            status="blocked",
+            verdict="blocked",
             summary="Missing execution result artifact.",
             reason_codes=("missing_execution_result",),
         )
 
     if evaluation_result is None:
         return GovernanceVerdict(
-            status="blocked",
+            verdict="blocked",
             summary="Missing evaluation result artifact.",
             reason_codes=("missing_evaluation_result",),
         )
@@ -63,20 +63,20 @@ def apply_governance(
     if evaluation_result.status != "success":
         reason_codes.extend(evaluation_result.detail_codes)
         return GovernanceVerdict(
-            status="blocked",
+            verdict="blocked",
             summary=evaluation_result.summary,
             reason_codes=tuple(reason_codes) or ("evaluation_not_successful",),
         )
 
     if execution_result.quality == "improved":
         return GovernanceVerdict(
-            status="approved",
+            verdict="approved",
             summary="Run improved on a broken baseline without introducing new failures.",
             reason_codes=("qa_baseline_improved",),
         )
 
     return GovernanceVerdict(
-        status="approved",
+        verdict="approved",
         summary="Required intake, execution, and evaluation evidence is present.",
         reason_codes=(),
     )

--- a/src/precision_squad/models.py
+++ b/src/precision_squad/models.py
@@ -99,7 +99,7 @@ class IssueReview:
 
     run_id: str
     issue_ref: str
-    review_status: Literal["approved", "changes_requested", "blocked"]
+    verdict: Literal["approved", "changes_requested", "blocked"]
     summary: str
     feedback: tuple[IssueReviewFeedback, ...]
     provenance: IssueReviewProvenance
@@ -130,7 +130,7 @@ class PlanReview:
 
     run_id: str
     issue_ref: str
-    review_status: Literal["approved", "changes_requested", "blocked"]
+    verdict: Literal["approved", "changes_requested", "blocked"]
     summary: str
     feedback: tuple[PlanReviewFeedback, ...]
     provenance: PlanReviewProvenance
@@ -273,7 +273,7 @@ class QaResult:
 class GovernanceVerdict:
     """Deterministic governance decision for a run."""
 
-    status: Literal["approved", "blocked"]
+    verdict: Literal["approved", "blocked"]
     summary: str
     reason_codes: tuple[str, ...]
 
@@ -374,7 +374,7 @@ class ImplReviewFeedback:
 class ImplReviewResult:
     """Canonical post-publish implementation review result."""
 
-    review_status: Literal["approved", "changes_requested", "blocked"]
+    verdict: Literal["approved", "changes_requested", "blocked"]
     summary: str
     pull_request_url: str | None
     pull_number: int | None
@@ -390,7 +390,7 @@ class ImplReviewResult:
     @property
     def allows_downstream_automation(self) -> bool:
         """Return whether downstream automation may continue."""
-        return self.review_status == "approved"
+        return self.verdict == "approved"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/precision_squad/post_publish_review.py
+++ b/src/precision_squad/post_publish_review.py
@@ -491,7 +491,7 @@ def run_impl_review(
     mapped_review = _map_post_publish_to_impl_review(legacy_result)
     if mapped_review.pull_head_sha != live_head_sha:
         mapped_review = ImplReviewResult(
-            review_status=mapped_review.review_status,
+            verdict=mapped_review.verdict,
             summary=mapped_review.summary,
             pull_request_url=mapped_review.pull_request_url,
             pull_number=mapped_review.pull_number,
@@ -519,7 +519,7 @@ def mirror_impl_review_to_post_publish(review: ImplReviewResult) -> PostPublishR
         "approved": "approved",
         "changes_requested": "rejected",
         "blocked": "failed_infra",
-        }[review.review_status],
+        }[review.verdict],
     )
     return PostPublishReviewResult(
         status=status,
@@ -686,7 +686,7 @@ def _blocked_impl_review(
     pull_head_sha: str | None = None,
 ) -> ImplReviewResult:
     return ImplReviewResult(
-        review_status="blocked",
+        verdict="blocked",
         summary=summary,
         pull_request_url=pull_request_url,
         pull_number=pull_number,
@@ -826,7 +826,7 @@ def _validate_review_provenance(
 def _map_post_publish_to_impl_review(result: PostPublishReviewResult) -> ImplReviewResult:
     if result.status == "approved":
         return ImplReviewResult(
-            review_status="approved",
+            verdict="approved",
             summary=result.summary,
             pull_request_url=result.pull_request_url,
             pull_number=result.pull_number,
@@ -869,7 +869,7 @@ def _map_post_publish_to_impl_review(result: PostPublishReviewResult) -> ImplRev
                 )
             )
         return ImplReviewResult(
-            review_status="changes_requested",
+            verdict="changes_requested",
             summary=result.summary,
             pull_request_url=result.pull_request_url,
             pull_number=result.pull_number,
@@ -883,7 +883,7 @@ def _map_post_publish_to_impl_review(result: PostPublishReviewResult) -> ImplRev
             issue_reopened=result.issue_reopened,
         )
     return ImplReviewResult(
-        review_status="blocked",
+        verdict="blocked",
         summary=result.summary,
         pull_request_url=result.pull_request_url,
         pull_number=result.pull_number,
@@ -923,7 +923,7 @@ def _finalize_non_approved_impl_review(
         pull_number=pull_number,
         pull_head_sha=pull_head_sha,
     )
-    if result.review_status == "approved":
+    if result.verdict == "approved":
         return result
 
     client = GitHubWriteClient.from_env(token_env)
@@ -935,7 +935,7 @@ def _finalize_non_approved_impl_review(
     issue_comment_url = client.create_issue_comment(intake.issue.reference, body)
     client.reopen_issue(intake.issue.reference)
     return ImplReviewResult(
-        review_status=result.review_status,
+        verdict=result.verdict,
         summary=result.summary,
         pull_request_url=result.pull_request_url,
         pull_number=result.pull_number,
@@ -960,7 +960,7 @@ def _build_impl_review_issue_comment(
         "## Precision Squad Implementation Review",
         f"- Run ID: `{run_record.run_id}`",
         f"- Issue: `{intake.issue.reference}`",
-        f"- Review status: `{review.review_status}`",
+        f"- Review verdict: `{review.verdict}`",
         f"- PR: {review.pull_request_url or '(unavailable)'}",
         f"- PR Head SHA: `{review.pull_head_sha or '(unavailable)'}`",
         "",

--- a/src/precision_squad/publishing.py
+++ b/src/precision_squad/publishing.py
@@ -59,7 +59,7 @@ def build_publish_plan(
     repair_result: RepairResult | None = None,
 ) -> PublishPlan:
     """Prepare the first publish plan without calling GitHub yet."""
-    if verdict.status == "approved":
+    if verdict.verdict == "approved":
         context_heading = "## Summary\n"
         context_note = ""
         rejected_pr = latest_rejected_pull_request(intake.issue.comments)
@@ -70,7 +70,7 @@ def build_publish_plan(
                 context_heading
                 + f"- Run ID: `{run_record.run_id}`\n"
                 + f"- Issue: `{intake.issue.reference}`\n"
-                + f"- Governance verdict: `{verdict.status}`\n"
+                + f"- Governance verdict: `{verdict.verdict}`\n"
                 + context_note
                 + _render_design_decisions_section(
                     run_record,
@@ -129,7 +129,7 @@ def build_publish_plan(
             reason_codes=verdict.reason_codes,
         )
 
-    if verdict.status == "blocked":
+    if verdict.verdict == "blocked":
         side_issues = repair_result.side_issues if repair_result else ()
         if side_issues:
             side_issues_lines = []
@@ -154,7 +154,7 @@ def build_publish_plan(
                     f"- Source issue URL: {intake.issue.html_url}\n"
                     f"- Requested change: {intake.summary}\n"
                     f"- Run ID: `{run_record.run_id}`\n"
-                    f"- Governance verdict: `{verdict.status}`\n"
+                    f"- Governance verdict: `{verdict.verdict}`\n"
                     f"- Summary: {verdict.summary}\n"
                     "\n"
                     "## Side Issues\n"
@@ -171,7 +171,7 @@ def build_publish_plan(
             "## Blocked\n"
             f"- Run ID: `{run_record.run_id}`\n"
             f"- Issue: `{intake.issue.reference}`\n"
-            f"- Verdict: `{verdict.status}`\n"
+            f"- Verdict: `{verdict.verdict}`\n"
             f"- Summary: {verdict.summary}\n"
             "\n"
             "## Reasons\n"
@@ -185,7 +185,7 @@ def _should_create_follow_up_issue(
     intake: IssueIntake, verdict: GovernanceVerdict
 ) -> bool:
     return (
-        verdict.status == "blocked"
+        verdict.verdict == "blocked"
         and not is_docs_remediation_issue(intake)
         and intake.assessment.status == "runnable"
         and bool(verdict.reason_codes)

--- a/src/precision_squad/run_store.py
+++ b/src/precision_squad/run_store.py
@@ -367,10 +367,10 @@ class RunStore:
             raise ApprovedPlanGateError(
                 f"Approved plan persistence requires issue-review.json for {issue_ref}."
             ) from exc
-        if review.review_status != "approved":
+        if review.verdict != "approved":
             raise ApprovedPlanGateError(
-                "Approved plan persistence requires issue-review.json.review_status to be "
-                f"'approved'; found '{review.review_status}' for {issue_ref}."
+                "Approved plan persistence requires issue-review.json.verdict to be "
+                f"'approved'; found '{review.verdict}' for {issue_ref}."
             )
         return review
 
@@ -421,10 +421,10 @@ class RunStore:
             issue_ref=issue_ref,
             expected_run_id=record.run_id,
         )
-        if review.review_status != "approved":
+        if review.verdict != "approved":
             raise PlanReviewNotApprovedError(
-                "Implement ingress requires plan-review.json.review_status to be 'approved'; "
-                f"found '{review.review_status}' for {issue_ref}."
+                "Implement ingress requires plan-review.json.verdict to be 'approved'; "
+                f"found '{review.verdict}' for {issue_ref}."
             )
         return review
 
@@ -644,10 +644,11 @@ def _parse_issue_review_payload(
             f"'{run_id}' does not match expected run_id '{expected_run_id}'"
         )
 
-    review_status = payload.get("review_status")
-    if review_status not in {"approved", "changes_requested", "blocked"}:
+    # Accept legacy 'review_status' key and normalize to 'verdict'
+    verdict = payload.get("verdict") or payload.get("review_status")
+    if verdict not in {"approved", "changes_requested", "blocked"}:
         raise IssueReviewValidationError(
-            "Issue review field 'review_status' must be 'approved', "
+            "Issue review field 'verdict' must be 'approved', "
             "'changes_requested', or 'blocked'"
         )
 
@@ -708,7 +709,7 @@ def _parse_issue_review_payload(
     return IssueReview(
         run_id=run_id,
         issue_ref=review_issue_ref,
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
         summary=summary,
         feedback=tuple(feedback),
         provenance=IssueReviewProvenance(
@@ -746,10 +747,11 @@ def _parse_plan_review_payload(
             f"Plan review run_id '{run_id}' does not match expected run_id '{expected_run_id}'"
         )
 
-    review_status = payload.get("review_status")
-    if review_status not in {"approved", "changes_requested", "blocked"}:
+    # Accept legacy 'review_status' key and normalize to 'verdict'
+    verdict = payload.get("verdict") or payload.get("review_status")
+    if verdict not in {"approved", "changes_requested", "blocked"}:
         raise PlanReviewValidationError(
-            "Plan review field 'review_status' must be 'approved', "
+            "Plan review field 'verdict' must be 'approved', "
             "'changes_requested', or 'blocked'"
         )
 
@@ -810,7 +812,7 @@ def _parse_plan_review_payload(
     return PlanReview(
         run_id=run_id,
         issue_ref=review_issue_ref,
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
         summary=summary,
         feedback=tuple(feedback),
         provenance=PlanReviewProvenance(
@@ -825,10 +827,11 @@ def _parse_impl_review_payload(payload: object, *, path: Path) -> ImplReviewResu
     if not isinstance(payload, dict):
         raise ValueError(f"Expected JSON object in {path}")
 
-    review_status = payload.get("review_status")
-    if review_status not in {"approved", "changes_requested", "blocked"}:
+    # Accept legacy 'review_status' key and normalize to 'verdict'
+    verdict = payload.get("verdict") or payload.get("review_status")
+    if verdict not in {"approved", "changes_requested", "blocked"}:
         raise ValueError(
-            "Implementation review field 'review_status' must be 'approved', "
+            "Implementation review field 'verdict' must be 'approved', "
             "'changes_requested', or 'blocked'"
         )
 
@@ -868,7 +871,7 @@ def _parse_impl_review_payload(payload: object, *, path: Path) -> ImplReviewResu
         )
 
     return ImplReviewResult(
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
         summary=summary,
         pull_request_url=cast(str | None, payload.get("pull_request_url")),
         pull_number=cast(int | None, payload.get("pull_number")),

--- a/tests/integration/support.py
+++ b/tests/integration/support.py
@@ -168,7 +168,7 @@ class _ApprovedTestDependencies:
     ) -> ImplReviewResult:
         del intake, run_record, run_dir, publish_plan, review_model
         return ImplReviewResult(
-            review_status="approved",
+            verdict="approved",
             summary="Implementation review approved in integration test.",
             pull_request_url=publish_result.url,
             pull_number=publish_result.pull_number,

--- a/tests/integration/test_pipeline_approved.py
+++ b/tests/integration/test_pipeline_approved.py
@@ -85,7 +85,7 @@ def test_approved_happy_path(
     assert report.governance_verdict is not None
     assert report.publish_plan is not None
     assert report.publish_result is not None
-    assert report.governance_verdict.status == "approved"
+    assert report.governance_verdict.verdict == "approved"
     assert report.publish_plan.status == "draft_pr"
     assert report.publish_result.status == "dry_run"
     assert report.exit_code == 0

--- a/tests/integration/test_pipeline_blocked.py
+++ b/tests/integration/test_pipeline_blocked.py
@@ -57,7 +57,7 @@ def test_plan_issue_blocks_before_executor(
 
     assert report.execution_result is None, "executor should not run for blocked intake"
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is not None
     assert report.publish_plan.status == "issue_comment"
     assert report.publish_result is not None
@@ -120,14 +120,14 @@ def test_missing_docs_blocks_pipeline(
     )
 
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.execution_result is not None, "explicit approval path should continue into execution"
     assert report.execution_result.status == "missing_docs"
     assert (Path(report.run_record.run_dir) / "approved-plan.json").exists()
     assert (Path(report.run_record.run_dir) / "plan-review.json").exists()
     # Missing docs blocks at governance after execution; publish is not reached.
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
     assert report.exit_code == 4
@@ -181,7 +181,7 @@ def test_missing_docs_persists_execution_artifacts(
     run_dir = Path(report.run_record.run_dir)
 
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.execution_result is not None
     assert report.execution_result.status == "missing_docs"
     assert (run_dir / "approved-plan.json").exists()
@@ -195,7 +195,7 @@ def test_missing_docs_persists_execution_artifacts(
     assert not (run_dir / "publish-plan.json").exists()
     assert not (run_dir / "publish-result.json").exists()
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
     assert report.exit_code == 4
@@ -251,11 +251,11 @@ def test_ambiguous_docs_blocks_pipeline(
     )
 
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.execution_result is not None
     assert report.execution_result.status == "ambiguous_docs"
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
     assert report.exit_code == 4
@@ -307,13 +307,13 @@ def test_clean_docs_without_repair_completes_pipeline(
     )
 
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.execution_result is not None
     assert report.execution_result.status == "completed"
     assert report.repair_result is None
     assert report.qa_result is None
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "approved"
+    assert report.governance_verdict.verdict == "approved"
     assert report.publish_plan is not None
     assert report.publish_plan.status == "draft_pr"
     assert report.publish_result is not None
@@ -372,14 +372,14 @@ def test_qa_failed_blocks_pipeline(
     )
 
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.repair_result is not None, "repair should run with explicit approved plan"
     assert report.qa_result is not None, "QA should run with explicit approved plan"
     assert report.qa_result.status == "failed"
     assert report.execution_result is not None, "implementation result should reflect the QA failure"
     assert report.execution_result.status == "blocked"
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
     assert report.exit_code == 4

--- a/tests/integration/test_pipeline_docs_remediation.py
+++ b/tests/integration/test_pipeline_docs_remediation.py
@@ -280,8 +280,8 @@ def test_docs_remediation_succeeds_after_fix(
         f"{report.execution_result.summary}"
     )
     assert "docs_remediation_issue" in report.execution_result.detail_codes
-    assert report.governance_verdict.status == "approved", (
-        f"Expected approved, got {report.governance_verdict.status}: "
+    assert report.governance_verdict.verdict == "approved", (
+        f"Expected approved, got {report.governance_verdict.verdict}: "
         f"{report.governance_verdict.summary}"
     )
     assert report.publish_plan.status == "draft_pr"
@@ -325,8 +325,8 @@ def test_docs_remediation_stays_blocked_without_fix(
         f"Expected missing_docs or blocked, got {report.execution_result.status}: "
         f"{report.execution_result.summary}"
     )
-    assert report.governance_verdict.status == "blocked", (
-        f"Expected blocked, got {report.governance_verdict.status}: "
+    assert report.governance_verdict.verdict == "blocked", (
+        f"Expected blocked, got {report.governance_verdict.verdict}: "
         f"{report.governance_verdict.summary}"
     )
     assert report.publish_plan.status in {"issue_comment", "follow_up_issue"}

--- a/tests/integration/test_pipeline_gate_chain.py
+++ b/tests/integration/test_pipeline_gate_chain.py
@@ -85,7 +85,7 @@ def test_chain_blocks_fresh_run_without_explicit_plan(
     # Fresh run without approved plan must block
     assert report.exit_code == 3, "fresh run should block at review_plan"
     assert report.plan_review is not None, "review_plan should run"
-    assert report.plan_review.review_status == "blocked", "review_plan should be blocked"
+    assert report.plan_review.verdict == "blocked", "review_plan should be blocked"
     assert not (run_dir / "approved-plan.json").exists(), \
         "no approved-plan.json should exist for fresh run without explicit plan"
     assert report.execution_result is None, "implement should not run when blocked"
@@ -128,7 +128,7 @@ def test_chain_preserves_explicit_plan_gating_without_approved_plan(
     assert not (run_dir / "approved-plan.json").exists()
     assert report.execution_result is None
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert report.publish_plan is None
     assert report.publish_result is None
 
@@ -186,7 +186,7 @@ def test_chain_stops_at_governance_not_approved(
 
     assert report.exit_code != 0, "chain should stop at governance gate"
     assert report.governance_verdict is not None, "governance should run"
-    assert report.governance_verdict.status == "blocked", "governance should be blocked"
+    assert report.governance_verdict.verdict == "blocked", "governance should be blocked"
     assert report.publish_plan is None, "publish_plan should not run"
     assert report.publish_result is None, "publish_result should not run"
 
@@ -230,15 +230,15 @@ def test_happy_path_chain_complete(
     )
 
     assert report.issue_review is not None
-    assert report.issue_review.review_status == "approved"
+    assert report.issue_review.verdict == "approved"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.execution_result is not None
     assert report.repair_result is not None
     assert report.qa_result is not None
     assert report.baseline_qa_result is not None
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "approved"
+    assert report.governance_verdict.verdict == "approved"
     assert report.publish_plan is not None
     assert report.publish_plan.status == "draft_pr"
     assert report.publish_result is not None
@@ -308,7 +308,7 @@ def test_publish_only_after_approved_verdict(
     )
 
     assert report_blocked.governance_verdict is not None
-    assert report_blocked.governance_verdict.status == "blocked"
+    assert report_blocked.governance_verdict.verdict == "blocked"
     # Cannot directly observe that execute_publish_plan was not called using
     # _GovernanceBlockedTestDependencies, but we can verify the chain stopped
     assert report_blocked.publish_plan is None
@@ -335,7 +335,7 @@ def test_publish_only_after_approved_verdict(
     )
 
     assert report_approved.governance_verdict is not None
-    assert report_approved.governance_verdict.status == "approved"
+    assert report_approved.governance_verdict.verdict == "approved"
     assert spy_deps.publish_called is True, "execute_publish_plan should be called when approved"
     assert report_approved.publish_plan is not None
     assert report_approved.publish_result is not None

--- a/tests/integration/test_pipeline_quality_tag.py
+++ b/tests/integration/test_pipeline_quality_tag.py
@@ -162,8 +162,8 @@ def test_broken_baseline_improved_to_approved(
 
     assert report.governance_verdict is not None
     assert report.publish_plan is not None
-    assert report.governance_verdict.status == "approved", (
-        f"Expected approved, got {report.governance_verdict.status}: "
+    assert report.governance_verdict.verdict == "approved", (
+        f"Expected approved, got {report.governance_verdict.verdict}: "
         f"{report.governance_verdict.summary}"
     )
     assert report.publish_plan.status == "draft_pr"

--- a/tests/integration/test_stage_artifacts.py
+++ b/tests/integration/test_stage_artifacts.py
@@ -121,7 +121,7 @@ def test_issue_review_persists(
     assert artifact_path.exists(), "issue-review.json should be written by review issue"
 
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
-    assert "review_status" in payload, "issue-review.json must contain review_status (verdict)"
+    assert "verdict" in payload, "issue-review.json must contain verdict"
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +158,7 @@ def test_approved_plan_persists(
         IssueReview(
             run_id=create_report.run_record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -231,7 +231,7 @@ def test_plan_review_persists(
         IssueReview(
             run_id=create_report.run_record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -266,7 +266,7 @@ def test_plan_review_persists(
     assert artifact_path.exists(), "plan-review.json should be written by review plan"
 
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
-    assert "review_status" in payload, "plan-review.json must contain review_status"
+    assert "verdict" in payload, "plan-review.json must contain verdict"
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +303,7 @@ def test_impl_review_persists(
         IssueReview(
             run_id=record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -331,7 +331,7 @@ def test_impl_review_persists(
         PlanReview(
             run_id=record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Plan review approved.",
             feedback=(),
             provenance=PlanReviewProvenance(
@@ -382,7 +382,7 @@ def test_impl_review_persists(
     assert artifact_path.exists(), "impl-review.json should be written by review impl"
 
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
-    assert "review_status" in payload, "impl-review.json must contain review_status (verdict)"
+    assert "verdict" in payload, "impl-review.json must contain verdict"
 
 
 # ---------------------------------------------------------------------------
@@ -419,7 +419,7 @@ def test_post_publish_review_result_persists(
         IssueReview(
             run_id=record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -447,7 +447,7 @@ def test_post_publish_review_result_persists(
         PlanReview(
             run_id=record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Plan review approved.",
             feedback=(),
             provenance=PlanReviewProvenance(
@@ -542,9 +542,9 @@ def test_governance_verdict_persists(
     )
 
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
-    assert "status" in payload, "governance-verdict.json must contain status"
-    assert payload["status"] == "approved", (
-        "governance-verdict.json status must be approved for a passing run"
+    assert "verdict" in payload, "governance-verdict.json must contain verdict"
+    assert payload["verdict"] == "approved", (
+        "governance-verdict.json verdict must be approved for a passing run"
     )
 
 
@@ -613,7 +613,7 @@ def test_issue_review_consumable_by_plan_stage(
         issue_ref="cracklings3d/markdown-pdf-renderer#9",
         expected_run_id=create_report.run_record.run_id,
     )
-    assert loaded.review_status == "approved"
+    assert loaded.verdict == "approved"
 
 
 @pytest.mark.integration
@@ -645,7 +645,7 @@ def test_approved_plan_consumable_by_developer_stage(
         IssueReview(
             run_id=create_report.run_record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -707,7 +707,7 @@ def test_plan_review_consumable_by_implement_stage(
         IssueReview(
             run_id=create_report.run_record.run_id,
             issue_ref="cracklings3d/markdown-pdf-renderer#9",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -741,4 +741,4 @@ def test_plan_review_consumable_by_implement_stage(
         issue_ref="cracklings3d/markdown-pdf-renderer#9",
         expected_run_id=create_report.run_record.run_id,
     )
-    assert loaded.review_status == "approved"
+    assert loaded.verdict == "approved"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,7 @@ def test_review_issue_prints_approved_review_output(
     issue_review = IssueReview(
         run_id="run-123",
         issue_ref="cracklings3d/precision-squad#68",
-        review_status="approved",
+        verdict="approved",
         summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
         feedback=(),
         provenance=IssueReviewProvenance(
@@ -175,7 +175,7 @@ def test_review_issue_prints_approved_review_output(
 
     captured = capsys.readouterr()
     assert status == 0
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
     assert "Artifacts: issue-review.json" in captured.out
 
 
@@ -185,7 +185,7 @@ def test_review_issue_prints_feedback_for_changes_requested(
     issue_review = IssueReview(
         run_id="run-123",
         issue_ref="cracklings3d/precision-squad#68",
-        review_status="changes_requested",
+        verdict="changes_requested",
         summary="Planning must stop because issue-draft.json has 1 planner-safety finding that require changes.",
         feedback=(
             IssueReviewFeedback(
@@ -224,7 +224,7 @@ def test_review_issue_prints_feedback_for_changes_requested(
 
     captured = capsys.readouterr()
     assert status == 2
-    assert "Review Status: changes_requested" in captured.out
+    assert "Review Verdict: changes_requested" in captured.out
     assert "missing_summary" in captured.out
 
 
@@ -251,7 +251,7 @@ def test_review_issue_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.M
                 issue_review=IssueReview(
                     run_id="run-123",
                     issue_ref="owner/repo#1",
-                    review_status="blocked",
+                    verdict="blocked",
                     summary="Planning must stop because review issue is blocked by 1 blocking finding in issue-draft.json.",
                     feedback=(
                         IssueReviewFeedback(
@@ -277,7 +277,7 @@ def test_review_issue_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.M
     captured = capsys.readouterr()
     assert status == 3
     assert Path(captured_runs_dir["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
-    assert "Review Status: blocked" in captured.out
+    assert "Review Verdict: blocked" in captured.out
 
 
 def test_review_plan_prints_approved_review_output(
@@ -286,7 +286,7 @@ def test_review_plan_prints_approved_review_output(
     plan_review = PlanReview(
         run_id="run-123",
         issue_ref="cracklings3d/precision-squad#70",
-        review_status="approved",
+        verdict="approved",
         summary="Implementation may proceed because approved-plan.json passed the same-run plan review gate.",
         feedback=(),
         provenance=PlanReviewProvenance(
@@ -318,7 +318,7 @@ def test_review_plan_prints_approved_review_output(
 
     captured = capsys.readouterr()
     assert status == 0
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
     assert "Artifacts: plan-review.json" in captured.out
 
 
@@ -328,7 +328,7 @@ def test_review_plan_prints_feedback_for_changes_requested(
     plan_review = PlanReview(
         run_id="run-123",
         issue_ref="cracklings3d/precision-squad#70",
-        review_status="changes_requested",
+        verdict="changes_requested",
         summary="Implementation must stop because approved-plan.json has 1 implementation-ingress finding that require changes.",
         feedback=(
             PlanReviewFeedback(
@@ -367,7 +367,7 @@ def test_review_plan_prints_feedback_for_changes_requested(
 
     captured = capsys.readouterr()
     assert status == 2
-    assert "Review Status: changes_requested" in captured.out
+    assert "Review Verdict: changes_requested" in captured.out
     assert "missing_retrieval_surface_summary" in captured.out
 
 
@@ -394,7 +394,7 @@ def test_review_plan_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
                 plan_review=PlanReview(
                     run_id="run-123",
                     issue_ref="owner/repo#1",
-                    review_status="blocked",
+                    verdict="blocked",
                     summary="Implementation must stop because review plan is blocked by 1 prerequisite finding.",
                     feedback=(
                         PlanReviewFeedback(
@@ -420,14 +420,14 @@ def test_review_plan_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
     captured = capsys.readouterr()
     assert status == 3
     assert Path(captured_runs_dir["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
-    assert "Review Status: blocked" in captured.out
+    assert "Review Verdict: blocked" in captured.out
 
 
 def test_review_impl_prints_approved_review_output(
     capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     impl_review = ImplReviewResult(
-        review_status="approved",
+        verdict="approved",
         summary="Published PR passed implementation review.",
         pull_request_url="https://github.com/cracklings3d/precision-squad/pull/72",
         pull_number=72,
@@ -460,7 +460,7 @@ def test_review_impl_prints_approved_review_output(
 
     captured = capsys.readouterr()
     assert status == 0
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
     assert "Artifacts: impl-review.json" in captured.out
     assert "Downstream Automation Allowed: True" in captured.out
 
@@ -469,7 +469,7 @@ def test_review_impl_prints_feedback_for_blocked_review(
     capsys, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     impl_review = ImplReviewResult(
-        review_status="blocked",
+        verdict="blocked",
         summary="Implementation review could not validate provenance.",
         pull_request_url="https://github.com/cracklings3d/precision-squad/pull/72",
         pull_number=72,
@@ -511,7 +511,7 @@ def test_review_impl_prints_feedback_for_blocked_review(
 
     captured = capsys.readouterr()
     assert status == 3
-    assert "Review Status: blocked" in captured.out
+    assert "Review Verdict: blocked" in captured.out
     assert "pr_body_run_id_mismatch" in captured.out
     assert "Review Feedback URL: comment-url" in captured.out
 
@@ -538,7 +538,7 @@ def test_review_impl_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
                     run_dir=str(tmp_path / ".precision-squad" / "runs" / "run-123"),
                 ),
                 impl_review=ImplReviewResult(
-                    review_status="approved",
+                    verdict="approved",
                     summary="ok",
                     pull_request_url="https://github.com/owner/repo/pull/1",
                     pull_number=1,
@@ -555,7 +555,7 @@ def test_review_impl_uses_config_defaults(tmp_path: Path, monkeypatch: pytest.Mo
     assert status == 0
     assert Path(captured_params["runs_dir"]) == (tmp_path / ".precision-squad" / "runs")
     assert captured_params["review_model"] == "test-model"
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
 
 
 def test_review_issue_end_to_end_persists_approved_issue_review(
@@ -586,9 +586,9 @@ def test_review_issue_end_to_end_persists_approved_issue_review(
     captured = capsys.readouterr()
     payload = json.loads((Path(record.run_dir) / "issue-review.json").read_text(encoding="utf-8"))
     assert status == 0
-    assert payload["review_status"] == "approved"
+    assert payload["verdict"] == "approved"
     assert payload["provenance"]["source_artifact"] == "issue-draft.json"
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
 
 
 def test_review_issue_end_to_end_persists_changes_requested_when_summary_missing(
@@ -639,9 +639,9 @@ def test_review_issue_end_to_end_persists_changes_requested_when_summary_missing
     captured = capsys.readouterr()
     payload = json.loads((run_dir / "issue-review.json").read_text(encoding="utf-8"))
     assert status == 2
-    assert payload["review_status"] == "changes_requested"
+    assert payload["verdict"] == "changes_requested"
     assert payload["feedback"][0]["code"] == "missing_summary"
-    assert "Review Status: changes_requested" in captured.out
+    assert "Review Verdict: changes_requested" in captured.out
 
 
 def test_review_issue_end_to_end_persists_blocked_when_issue_draft_missing(
@@ -670,9 +670,9 @@ def test_review_issue_end_to_end_persists_blocked_when_issue_draft_missing(
     captured = capsys.readouterr()
     payload = json.loads((run_dir / "issue-review.json").read_text(encoding="utf-8"))
     assert status == 3
-    assert payload["review_status"] == "blocked"
+    assert payload["verdict"] == "blocked"
     assert payload["feedback"][0]["code"] == "issue_draft_missing"
-    assert "Review Status: blocked" in captured.out
+    assert "Review Verdict: blocked" in captured.out
 
 
 def test_plan_run_prints_persisted_artifact_output(
@@ -866,7 +866,7 @@ def test_plan_run_rejects_non_approved_issue_review(
 
     captured = capsys.readouterr()
     assert status == 1
-    assert "review_status" in captured.err
+    assert "verdict" in captured.err
     assert review_status in captured.err
     assert not (run_dir / "approved-plan.json").exists()
 
@@ -932,7 +932,7 @@ def test_cli_omitted_repair_agent_defaults_to_opencode(
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -1731,7 +1731,7 @@ def test_repair_issue_and_run_issue_print_same_stage_stop_output(
             issue_review=IssueReview(
                 run_id="run-1",
                 issue_ref="owner/repo#1",
-                review_status="approved",
+                verdict="approved",
                 summary="Issue review approved.",
                 feedback=(),
                 provenance=IssueReviewProvenance(
@@ -1743,7 +1743,7 @@ def test_repair_issue_and_run_issue_print_same_stage_stop_output(
             plan_review=PlanReview(
                 run_id="run-1",
                 issue_ref="owner/repo#1",
-                review_status="changes_requested",
+                verdict="changes_requested",
                 summary="Plan review needs changes.",
                 feedback=(
                     PlanReviewFeedback(
@@ -2872,7 +2872,7 @@ def test_config_file_fills_default_args(tmp_path: Path, monkeypatch: pytest.Monk
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -2971,7 +2971,7 @@ def test_cli_args_override_config_file_values(tmp_path: Path, monkeypatch: pytes
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -3246,7 +3246,7 @@ def test_implement_run_prints_local_only_stage_output(
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -3331,7 +3331,7 @@ def test_implement_run_uses_config_defaults(
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -3406,9 +3406,9 @@ def test_review_plan_end_to_end_persists_approved_plan_review(capsys, tmp_path: 
     captured = capsys.readouterr()
     payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
     assert status == 0
-    assert payload["review_status"] == "approved"
+    assert payload["verdict"] == "approved"
     assert payload["provenance"]["source_artifact"] == "approved-plan.json"
-    assert "Review Status: approved" in captured.out
+    assert "Review Verdict: approved" in captured.out
 
 
 def test_review_plan_end_to_end_persists_changes_requested_when_plan_summary_surface_missing(
@@ -3467,9 +3467,9 @@ def test_review_plan_end_to_end_persists_changes_requested_when_plan_summary_sur
     captured = capsys.readouterr()
     payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
     assert status == 2
-    assert payload["review_status"] == "changes_requested"
+    assert payload["verdict"] == "changes_requested"
     assert payload["feedback"][0]["code"] == "missing_retrieval_surface_summary"
-    assert "Review Status: changes_requested" in captured.out
+    assert "Review Verdict: changes_requested" in captured.out
 
 
 def test_review_plan_end_to_end_persists_blocked_when_approved_plan_missing(
@@ -3515,9 +3515,9 @@ def test_review_plan_end_to_end_persists_blocked_when_approved_plan_missing(
     captured = capsys.readouterr()
     payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
     assert status == 3
-    assert payload["review_status"] == "blocked"
+    assert payload["verdict"] == "blocked"
     assert payload["feedback"][0]["code"] == "approved_plan_missing"
-    assert "Review Status: blocked" in captured.out
+    assert "Review Verdict: blocked" in captured.out
 
 
 def test_install_skill_uses_config_defaults(
@@ -3600,7 +3600,7 @@ def test_repair_issue_no_publish_cli_overrides_true_config(
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -3722,7 +3722,7 @@ def test_repair_issue_uses_explicit_repo_path_as_config_discovery_root(
                 detail_codes=(),
             ),
             governance_verdict=GovernanceVerdict(
-                status="approved",
+                verdict="approved",
                 summary="Approved",
                 reason_codes=(),
             ),
@@ -3954,7 +3954,7 @@ def test_run_issue_fresh_without_approved_plan_path_reaches_coordinator(
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4018,7 +4018,7 @@ def test_run_issue_explicit_fresh_without_approved_plan_path_loads_intake_and_re
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4209,7 +4209,7 @@ def test_run_issue_prompt_selected_fresh_without_plan_reaches_coordinator(
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4288,7 +4288,7 @@ def test_run_issue_prompt_selected_retry_can_continue_without_new_plan_path(
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4355,7 +4355,7 @@ def test_run_issue_explicit_fresh_bypasses_ambiguity_and_calls_coordinator(
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4485,7 +4485,7 @@ def test_repair_issue_review_stages_values_forward_into_params(
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -4975,7 +4975,7 @@ def test_repair_issue_retry_from_with_from_publish_forwards_resume_target_to_coo
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -5061,7 +5061,7 @@ def test_repair_issue_retry_from_with_from_review_impl_forwards_resume_target_to
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )
@@ -5150,7 +5150,7 @@ def test_repair_issue_retry_from_without_from_loads_intake_and_forwards_to_coord
                 detail_codes=(),
             ),
             evaluation_result=EvaluationResult(status="success", summary="ok", detail_codes=()),
-            governance_verdict=GovernanceVerdict(status="approved", summary="ok", reason_codes=()),
+            governance_verdict=GovernanceVerdict(verdict="approved", summary="ok", reason_codes=()),
             publish_plan=PublishPlan(status="draft_pr", title="t", body="b", reason_codes=()),
             publish_result=PublishResult(status="dry_run", target="draft_pr", summary="ok", url=None),
         )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -21,6 +21,7 @@ from precision_squad.models import (
     ApprovedPlan,
     ExecutionResult,
     GitHubIssue,
+    GovernanceVerdict,
     ImplReviewResult,
     IssueAssessment,
     IssueIntake,
@@ -1310,3 +1311,73 @@ def test_review_plan_returns_blocked_when_schema_invalid_plan_also_has_change_le
     assert report.plan_review.verdict == "blocked"
     assert report.plan_review.feedback[0].code == "approved_plan_invalid"
     assert "named_references" in report.plan_review.feedback[0].message
+
+
+# ---------------------------------------------------------------------
+# Tests for _load_governance_verdict_artifact
+# ---------------------------------------------------------------------
+
+
+def _write_governance_verdict(run_dir: Path, **kwargs: object) -> None:
+    (run_dir).mkdir(parents=True, exist_ok=True)
+    (run_dir / "governance-verdict.json").write_text(
+        json.dumps(kwargs),
+        encoding="utf-8",
+    )
+
+
+def test_load_governance_verdict_artifact_canonical_verdict_key(tmp_path: Path) -> None:
+    _write_governance_verdict(
+        tmp_path,
+        verdict="approved",
+        summary="All checks passed.",
+        reason_codes=["clean-diff"],
+    )
+    from precision_squad.coordinator import _load_governance_verdict_artifact
+
+    result = _load_governance_verdict_artifact(tmp_path)
+    assert result == GovernanceVerdict(
+        verdict="approved",
+        summary="All checks passed.",
+        reason_codes=("clean-diff",),
+    )
+
+
+def test_load_governance_verdict_artifact_legacy_status_key(tmp_path: Path) -> None:
+    _write_governance_verdict(
+        tmp_path,
+        status="blocked",
+        summary="Governance blocked due to risk.",
+        reason_codes=["risk-detected"],
+    )
+    from precision_squad.coordinator import _load_governance_verdict_artifact
+
+    result = _load_governance_verdict_artifact(tmp_path)
+    assert result == GovernanceVerdict(
+        verdict="blocked",
+        summary="Governance blocked due to risk.",
+        reason_codes=("risk-detected",),
+    )
+
+
+def test_load_governance_verdict_artifact_missing_verdict_fails(tmp_path: Path) -> None:
+    _write_governance_verdict(
+        tmp_path,
+        summary="Summary only, no verdict.",
+    )
+    from precision_squad.coordinator import _load_governance_verdict_artifact
+
+    with pytest.raises(ValueError, match="must contain either 'verdict' or legacy 'status'"):
+        _load_governance_verdict_artifact(tmp_path)
+
+
+def test_load_governance_verdict_artifact_invalid_verdict_fails(tmp_path: Path) -> None:
+    _write_governance_verdict(
+        tmp_path,
+        verdict="unknown",
+        summary="Invalid verdict value.",
+    )
+    from precision_squad.coordinator import _load_governance_verdict_artifact
+
+    with pytest.raises(ValueError, match="must be 'approved' or 'blocked', got 'unknown'"):
+        _load_governance_verdict_artifact(tmp_path)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -93,7 +93,7 @@ def test_repair_issue_happy_path_runs_staged_chain_and_persists_review_artifacts
     )
     dependencies.run_post_publish_review_if_needed.return_value = None
     dependencies.run_impl_review.return_value = ImplReviewResult(
-        review_status="approved",
+        verdict="approved",
         summary="Implementation review approved.",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,
@@ -135,9 +135,9 @@ def test_repair_issue_happy_path_runs_staged_chain_and_persists_review_artifacts
     run_dir = Path(report.run_record.run_dir)
     assert report.exit_code == 0
     assert report.issue_review is not None
-    assert report.issue_review.review_status == "approved"
+    assert report.issue_review.verdict == "approved"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert report.publish_result is not None
     assert report.publish_result.status == "published"
     assert report.post_publish_review_result is not None
@@ -181,7 +181,7 @@ def test_repair_issue_stops_after_failed_issue_review(tmp_path: Path, monkeypatc
     run_dir = Path(report.run_record.run_dir)
     assert report.exit_code == 2
     assert report.issue_review is not None
-    assert report.issue_review.review_status == "changes_requested"
+    assert report.issue_review.verdict == "changes_requested"
     assert not (run_dir / "approved-plan.json").exists()
     assert not (run_dir / "plan-review.json").exists()
     assert not (run_dir / "execution-result.json").exists()
@@ -212,9 +212,9 @@ def test_repair_issue_stops_after_failed_plan_review(tmp_path: Path, monkeypatch
     run_dir = Path(report.run_record.run_dir)
     assert report.exit_code == 2
     assert report.issue_review is not None
-    assert report.issue_review.review_status == "approved"
+    assert report.issue_review.verdict == "approved"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "changes_requested"
+    assert report.plan_review.verdict == "changes_requested"
     assert not (run_dir / "execution-result.json").exists()
     assert not (run_dir / "publish-plan.json").exists()
     dependencies.execute_publish_plan.assert_not_called()
@@ -271,7 +271,7 @@ def test_repair_issue_blocks_fresh_attempt_one_without_explicit_plan(
     # Fresh run without approved plan must block
     assert report.exit_code == 3, "fresh run should block at review plan"
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert not (run_dir / "approved-plan.json").exists()
     assert not (run_dir / "execution-result.json").exists()
 
@@ -302,7 +302,7 @@ def test_repair_issue_respects_explicit_review_stage_gating_without_plan(
     run_dir = Path(report.run_record.run_dir)
     assert report.exit_code == 3
     assert report.plan_review is not None
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert not (run_dir / "approved-plan.json").exists()
     assert not (run_dir / "execution-result.json").exists()
     dependencies.execute_publish_plan.assert_not_called()
@@ -364,7 +364,7 @@ def test_repair_issue_stops_before_publish_when_governance_blocked(
     run_dir = Path(report.run_record.run_dir)
     assert report.exit_code == 4
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert not (run_dir / "publish-plan.json").exists()
     assert not (run_dir / "publish-result.json").exists()
     assert not (run_dir / "impl-review.json").exists()
@@ -583,7 +583,7 @@ def test_repair_issue_marks_missing_decision_log_artifact_as_failed_infra(
     assert report.execution_result.status == "failed_infra"
     assert "missing_decision_log_artifact" in report.execution_result.detail_codes
     assert report.governance_verdict is not None
-    assert report.governance_verdict.status == "blocked"
+    assert report.governance_verdict.verdict == "blocked"
     assert report.publish_plan is None
 
 
@@ -676,7 +676,7 @@ def test_review_impl_persists_canonical_and_compatibility_review_artifacts(tmp_p
 
     dependencies = MagicMock()
     dependencies.run_impl_review.return_value = ImplReviewResult(
-        review_status="changes_requested",
+        verdict="changes_requested",
         summary="Published PR needs changes.",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,
@@ -695,7 +695,7 @@ def test_review_impl_persists_canonical_and_compatibility_review_artifacts(tmp_p
     impl_payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
     legacy_payload = json.loads((run_dir / "post-publish-review-result.json").read_text(encoding="utf-8"))
     assert report.exit_code == 2
-    assert impl_payload["review_status"] == "changes_requested"
+    assert impl_payload["verdict"] == "changes_requested"
     assert legacy_payload["status"] == "rejected"
 
 
@@ -730,7 +730,7 @@ def test_publish_run_compatibility_path_persists_shared_canonical_review_and_leg
 
     dependencies = MagicMock()
     dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
-        review_status="blocked",
+        verdict="blocked",
         summary="Implementation review could not validate provenance.",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,
@@ -759,7 +759,7 @@ def test_publish_run_compatibility_path_persists_shared_canonical_review_and_leg
     impl_payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
     legacy_payload = json.loads((run_dir / "post-publish-review-result.json").read_text(encoding="utf-8"))
     assert report.post_publish_review_result is not None
-    assert impl_payload["review_status"] == "blocked"
+    assert impl_payload["verdict"] == "blocked"
     assert legacy_payload["status"] == "failed_infra"
     assert legacy_payload["pull_head_sha"] == "head-sha"
 
@@ -785,7 +785,7 @@ def test_implement_run_refuses_when_plan_review_not_approved(
 
     monkeypatch.setattr(coord_module.DocsFirstExecutor, "execute", fail_if_execute)
 
-    with pytest.raises(ValueError, match="review_status"):
+    with pytest.raises(ValueError, match="verdict"):
         RunCoordinator().implement_run(
             params=_make_implement_params(tmp_path, record.run_id),
             dependencies=MagicMock(),
@@ -958,7 +958,7 @@ def test_persist_approved_plan_for_planning_writes_same_run_artifact(tmp_path: P
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1023,7 +1023,7 @@ def test_review_plan_persists_same_run_plan_review_artifact(tmp_path: Path) -> N
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1041,7 +1041,7 @@ def test_review_plan_persists_same_run_plan_review_artifact(tmp_path: Path) -> N
 
     assert report.exit_code == 0
     assert isinstance(report.plan_review, PlanReview)
-    assert report.plan_review.review_status == "approved"
+    assert report.plan_review.verdict == "approved"
     assert (run_dir / "plan-review.json").exists()
 
 
@@ -1058,7 +1058,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1085,7 +1085,7 @@ def test_review_plan_returns_changes_requested_for_correctable_plan_findings(tmp
     )
 
     assert report.exit_code == 2
-    assert report.plan_review.review_status == "changes_requested"
+    assert report.plan_review.verdict == "changes_requested"
     assert report.plan_review.feedback[0].code == "missing_retrieval_surface_summary"
 
 
@@ -1172,7 +1172,7 @@ def test_review_plan_returns_changes_requested_for_required_implementation_safet
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1192,7 +1192,7 @@ def test_review_plan_returns_changes_requested_for_required_implementation_safet
     )
 
     assert report.exit_code == expected_exit_code
-    assert report.plan_review.review_status == "changes_requested"
+    assert report.plan_review.verdict == "changes_requested"
     assert report.plan_review.feedback[0].code == expected_code
 
 
@@ -1211,7 +1211,7 @@ def test_review_plan_returns_blocked_for_non_string_implementation_step_even_wit
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1240,7 +1240,7 @@ def test_review_plan_returns_blocked_for_non_string_implementation_step_even_wit
     )
 
     assert report.exit_code == 3
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert report.plan_review.feedback[0].code == "approved_plan_invalid"
     assert "implementation_steps[2] must be a string" in report.plan_review.feedback[0].message
 
@@ -1260,7 +1260,7 @@ def test_review_plan_returns_blocked_when_prerequisite_issue_review_missing(tmp_
     )
 
     assert report.exit_code == 3
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert report.plan_review.feedback[0].code == "issue_review_missing"
 
 
@@ -1279,7 +1279,7 @@ def test_review_plan_returns_blocked_when_schema_invalid_plan_also_has_change_le
         IssueReview(
             run_id=record.run_id,
             issue_ref="owner/repo#1",
-            review_status="approved",
+            verdict="approved",
             summary="Planning may proceed because issue-draft.json passed the local planner-safety review.",
             feedback=(),
             provenance=IssueReviewProvenance(
@@ -1307,6 +1307,6 @@ def test_review_plan_returns_blocked_when_schema_invalid_plan_also_has_change_le
     )
 
     assert report.exit_code == 3
-    assert report.plan_review.review_status == "blocked"
+    assert report.plan_review.verdict == "blocked"
     assert report.plan_review.feedback[0].code == "approved_plan_invalid"
     assert "named_references" in report.plan_review.feedback[0].message

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -100,7 +100,7 @@ def test_evaluate_run_maps_ambiguous_docs_to_blocked() -> None:
 def test_apply_governance_blocks_plan_issue_without_execution() -> None:
     verdict = apply_governance(_plan_intake(), execution_result=None, evaluation_result=None)
 
-    assert verdict.status == "blocked"
+    assert verdict.verdict == "blocked"
     assert "issue_marked_as_plan" in verdict.reason_codes
 
 
@@ -116,7 +116,7 @@ def test_apply_governance_approves_successful_run() -> None:
 
     verdict = apply_governance(intake, execution, evaluation)
 
-    assert verdict.status == "approved"
+    assert verdict.verdict == "approved"
 
 
 def test_apply_governance_approves_run_with_baseline_improved_detail_code() -> None:
@@ -132,7 +132,7 @@ def test_apply_governance_approves_run_with_baseline_improved_detail_code() -> N
 
     verdict = apply_governance(intake, execution, evaluation)
 
-    assert verdict.status == "approved"
+    assert verdict.verdict == "approved"
     assert verdict.reason_codes == ("qa_baseline_improved",)
 
 
@@ -148,7 +148,7 @@ def test_apply_governance_approves_run_with_approximated_qa_detail_code() -> Non
 
     verdict = apply_governance(intake, execution, evaluation)
 
-    assert verdict.status == "approved"
+    assert verdict.verdict == "approved"
     assert verdict.reason_codes == ()
 
 
@@ -164,7 +164,7 @@ def test_apply_governance_blocks_unrunnable_qa_run() -> None:
 
     verdict = apply_governance(intake, execution, evaluation)
 
-    assert verdict.status == "blocked"
+    assert verdict.verdict == "blocked"
     assert verdict.reason_codes == ("repair_stage_completed", "qa_command_unrunnable")
 
 

--- a/tests/test_post_publish_review.py
+++ b/tests/test_post_publish_review.py
@@ -601,7 +601,7 @@ def test_run_impl_review_returns_approved_for_same_run_same_issue_published_pr(
         architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
     )
 
-    assert result.review_status == "approved"
+    assert result.verdict == "approved"
     assert result.allows_downstream_automation is True
     assert result.pull_head_sha == "head-sha"
     assert comments == []
@@ -659,7 +659,7 @@ def test_run_impl_review_derives_live_pr_url_when_only_pull_number_is_persisted(
         architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
     )
 
-    assert result.review_status == "approved"
+    assert result.verdict == "approved"
     assert result.pull_request_url == "https://github.com/cracklings3d/markdown-pdf-renderer/pull/13"
     assert result.pull_number == 13
     assert comments == []
@@ -668,7 +668,7 @@ def test_run_impl_review_derives_live_pr_url_when_only_pull_number_is_persisted(
 @pytest.mark.parametrize("review_status", ["changes_requested", "blocked"])
 def test_mirror_impl_review_to_post_publish_maps_stage_statuses(review_status: str) -> None:
     review = ImplReviewResult(
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], review_status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], review_status),
         summary="summary",
         pull_request_url="https://example/pull/1",
         pull_number=1,
@@ -728,7 +728,7 @@ def test_run_impl_review_blocks_on_provenance_mismatch_and_posts_feedback(
         architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
     )
 
-    assert result.review_status == "blocked"
+    assert result.verdict == "blocked"
     assert result.issue_reopened is True
     assert result.issue_comment_url == "comment-url"
     assert any(item.code == "pr_body_run_id_mismatch" for item in result.feedback)
@@ -794,7 +794,7 @@ def test_run_impl_review_uses_canonical_validation_before_mapping_compatibility_
         architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
     )
 
-    assert result.review_status == "blocked"
+    assert result.verdict == "blocked"
     assert result.pull_head_sha == "live-head-sha"
     assert any(item.code == "pr_body_run_id_mismatch" for item in result.feedback)
 
@@ -866,7 +866,7 @@ def test_run_impl_review_posts_non_approved_side_effects_once(
         architect=_stub_agent(_review_result(role="architect", status="approved", summary="Architect approves.")),
     )
 
-    assert result.review_status == "changes_requested"
+    assert result.verdict == "changes_requested"
     assert result.issue_comment_url == "comment-url-1"
     assert result.issue_reopened is True
     assert len(comments) == 1

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -50,7 +50,7 @@ def test_build_publish_plan_creates_draft_pr_for_approved() -> None:
         run_dir=".precision-squad/runs/run-123",
     )
     verdict = GovernanceVerdict(
-        status="approved",
+        verdict="approved",
         summary="QA passed.",
         reason_codes=(),
     )
@@ -101,7 +101,7 @@ def test_build_publish_plan_includes_design_decisions_from_persisted_artifact(tm
         ),
     )
     verdict = GovernanceVerdict(
-        status="approved",
+        verdict="approved",
         summary="QA passed.",
         reason_codes=(),
     )
@@ -142,7 +142,7 @@ def test_build_publish_plan_omits_design_decisions_when_artifact_empty(tmp_path:
         DecisionLogArtifact(attempt=1, entries=()),
     )
     verdict = GovernanceVerdict(
-        status="approved",
+        verdict="approved",
         summary="QA passed.",
         reason_codes=(),
     )
@@ -178,7 +178,7 @@ def test_build_publish_plan_fails_when_completed_repair_missing_decision_log_art
         run_dir=str(run_dir),
     )
     verdict = GovernanceVerdict(
-        status="approved",
+        verdict="approved",
         summary="QA passed.",
         reason_codes=(),
     )
@@ -236,7 +236,7 @@ def test_build_publish_plan_embeds_blocker_fingerprint_for_follow_up_issue() -> 
         encoding="utf-8",
     )
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="Missing documented QA command.",
         reason_codes=("docs_qa_command_missing",),
     )
@@ -296,7 +296,7 @@ def test_build_publish_plan_uses_specific_contract_findings_for_umbrella_docs_re
         encoding="utf-8",
     )
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="Prerequisites are ambiguous.",
         reason_codes=("docs_setup_prerequisites_ambiguous",),
     )
@@ -331,7 +331,7 @@ def test_build_publish_plan_does_not_recurse_follow_up_issue_for_docs_remediatio
         run_dir=".precision-squad/runs/run-123",
     )
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="Missing documented QA command.",
         reason_codes=("docs_qa_command_missing",),
     )
@@ -364,7 +364,7 @@ def test_build_publish_plan_creates_follow_up_issue_for_side_issues() -> None:
     )
     run_dir = Path(run_record.run_dir)
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="QA failed.",
         reason_codes=("qa_failed",),
     )
@@ -424,7 +424,7 @@ def test_build_publish_plan_returns_issue_comment_when_no_side_issues() -> None:
     )
     run_dir = Path(run_record.run_dir)
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="QA failed.",
         reason_codes=("qa_failed",),
     )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -209,7 +209,7 @@ def test_retry_governance_blocked_after_escalation(tmp_path: Path) -> None:
     assert report.governance_verdict is not None
     verdict = report.governance_verdict
     assert isinstance(verdict, GovernanceVerdict)
-    assert verdict.status == "blocked"
+    assert verdict.verdict == "blocked"
     assert "escalated_after_retries" in verdict.reason_codes
 
 
@@ -505,7 +505,7 @@ def _make_issue_review_approved(run_id: str, issue_ref: str) -> IssueReview:
     return IssueReview(
         run_id=run_id,
         issue_ref=issue_ref,
-        review_status="approved",
+        verdict="approved",
         summary="Issue review approved",
         feedback=(),
         provenance=IssueReviewProvenance(
@@ -520,7 +520,7 @@ def _make_plan_review_approved(run_id: str, issue_ref: str) -> PlanReview:
     return PlanReview(
         run_id=run_id,
         issue_ref=issue_ref,
-        review_status="approved",
+        verdict="approved",
         summary="Plan review approved",
         feedback=(),
         provenance=PlanReviewProvenance(
@@ -633,7 +633,7 @@ def _create_publish_resume_source_run(
             review = IssueReview(
                 run_id=review.run_id,
                 issue_ref=review.issue_ref,
-                review_status="changes_requested",
+                verdict="changes_requested",
                 summary=review.summary,
                 feedback=review.feedback,
                 provenance=review.provenance,
@@ -651,7 +651,7 @@ def _create_publish_resume_source_run(
             review = PlanReview(
                 run_id=review.run_id,
                 issue_ref=review.issue_ref,
-                review_status="changes_requested",
+                verdict="changes_requested",
                 summary=review.summary,
                 feedback=review.feedback,
                 provenance=review.provenance,
@@ -663,7 +663,7 @@ def _create_publish_resume_source_run(
         verdict_status = "approved" if governance_verdict_approved else "blocked"
         store.write_governance_verdict(
             run_dir,
-            GovernanceVerdict(status=verdict_status, summary="Reviewed", reason_codes=()),
+            GovernanceVerdict(verdict=verdict_status, summary="Reviewed", reason_codes=()),
         )
 
     # Write execution-result.json
@@ -1178,7 +1178,7 @@ def test_retry_from_review_plan_succeeds_with_correct_ingress(tmp_path: Path) ->
     mock_dependencies.run_plan_review.return_value = PlanReview(
         run_id=previous.run_id,
         issue_ref="owner/repo#1",
-        review_status="approved",
+        verdict="approved",
         summary="Plan looks good",
         feedback=(),
         provenance=PlanReviewProvenance(
@@ -1242,7 +1242,7 @@ def test_retry_from_review_impl_succeeds_with_correct_ingress_and_writes_both_ar
     # result that fails later with asdict() errors.
     mock_dependencies.run_impl_review = None
     mock_dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
-        review_status="approved",
+        verdict="approved",
         summary="Implementation looks good",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,
@@ -1302,7 +1302,7 @@ def test_retry_context_pack_materialization(tmp_path: Path) -> None:
     mock_dependencies.run_plan_review.return_value = PlanReview(
         run_id=previous.run_id,
         issue_ref="owner/repo#1",
-        review_status="approved",
+        verdict="approved",
         summary="Plan looks good",
         feedback=(),
         provenance=PlanReviewProvenance(
@@ -1390,7 +1390,7 @@ def test_retry_publish_resume_carries_forward_repair_workspace(tmp_path: Path) -
     # run_post_publish_review_if_needed to return a valid ImplReviewResult
     from precision_squad.models import ImplReviewResult
     mock_dependencies.run_post_publish_review_if_needed.return_value = ImplReviewResult(
-        review_status="approved",
+        verdict="approved",
         summary="Implementation looks good",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1026,6 +1026,79 @@ def test_retry_from_publish_with_non_approved_governance_verdict_fails(tmp_path:
         )
 
 
+def test_retry_from_publish_with_malformed_governance_verdict_missing_verdict_fails(
+    tmp_path: Path,
+) -> None:
+    """Test that --from publish fails when governance-verdict.json has neither verdict nor status."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        # Include a valid governance-verdict.json initially, then overwrite with malformed
+    )
+    previous_run_dir = Path(previous.run_dir)
+
+    # Overwrite with malformed governance-verdict.json: file exists but no verdict/status key
+    (previous_run_dir / "governance-verdict.json").write_text(
+        json.dumps(
+            {
+                "summary": "Malformed: missing both verdict and status keys",
+                "reason_codes": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="governance-verdict.json must contain either 'verdict' or legacy 'status'"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
+def test_retry_from_publish_with_malformed_governance_verdict_invalid_value_fails(
+    tmp_path: Path,
+) -> None:
+    """Test that --from publish fails when governance-verdict.json has an invalid verdict value."""
+    store = RunStore(tmp_path / "runs")
+    store.root.mkdir(parents=True, exist_ok=True)
+    _, previous = _create_publish_resume_source_run(
+        store,
+        attempt=1,
+        # Include a valid governance-verdict.json initially, then overwrite with malformed
+    )
+    previous_run_dir = Path(previous.run_dir)
+
+    # Overwrite with malformed governance-verdict.json: verdict value is invalid
+    (previous_run_dir / "governance-verdict.json").write_text(
+        json.dumps(
+            {
+                "verdict": "unknown_value",
+                "summary": "Malformed: invalid verdict value",
+                "reason_codes": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    coordinator = RunCoordinator()
+
+    with pytest.raises(
+        ValueError, match="governance-verdict.json verdict must be 'approved' or 'blocked', got 'unknown_value'"
+    ):
+        coordinator.repair_issue(
+            params=_make_params_for_resume(tmp_path, previous.run_id, resume_from="publish"),
+            intake=_make_intake(),
+            dependencies=MagicMock(),
+        )
+
+
 def test_retry_from_publish_without_repair_result_fails(tmp_path: Path) -> None:
     """Test that --from publish fails when repair-result.json is missing."""
     store = RunStore(tmp_path / "runs")

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -60,10 +60,10 @@ def _approved_plan() -> ApprovedPlan:
 
 
 def _issue_review(
-    *, status: Literal["approved", "changes_requested", "blocked"] = "approved"
+    *, verdict: Literal["approved", "changes_requested", "blocked"] = "approved"
 ) -> IssueReview:
     feedback = ()
-    if status != "approved":
+    if verdict != "approved":
         feedback = (
             IssueReviewFeedback(
                 code="missing_summary",
@@ -75,9 +75,9 @@ def _issue_review(
     return IssueReview(
         run_id="run-123",
         issue_ref="owner/repo#1",
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
         summary="Planning may proceed because issue-draft.json passed the local planner-safety review."
-        if status == "approved"
+        if verdict == "approved"
         else "Planning must stop because issue-draft.json has 1 planner-safety finding that require changes.",
         feedback=feedback,
         provenance=IssueReviewProvenance(
@@ -89,10 +89,10 @@ def _issue_review(
 
 
 def _plan_review(
-    *, status: Literal["approved", "changes_requested", "blocked"] = "approved"
+    *, verdict: Literal["approved", "changes_requested", "blocked"] = "approved"
 ) -> PlanReview:
     feedback = ()
-    if status != "approved":
+    if verdict != "approved":
         feedback = (
             PlanReviewFeedback(
                 code="missing_retrieval_surface_summary",
@@ -104,9 +104,9 @@ def _plan_review(
     return PlanReview(
         run_id="run-123",
         issue_ref="owner/repo#1",
-        review_status=cast(Literal["approved", "changes_requested", "blocked"], status),
+        verdict=cast(Literal["approved", "changes_requested", "blocked"], verdict),
         summary="Implementation may proceed because approved-plan.json passed the same-run plan review gate."
-        if status == "approved"
+        if verdict == "approved"
         else "Implementation must stop because approved-plan.json has 1 implementation-ingress finding that require changes.",
         feedback=feedback,
         provenance=PlanReviewProvenance(
@@ -212,7 +212,7 @@ def test_write_and_load_issue_review_persists_same_run_artifact(tmp_path: Path) 
     loaded = store.load_issue_review(run_dir, issue_ref="owner/repo#1")
     payload = json.loads((run_dir / "issue-review.json").read_text(encoding="utf-8"))
     assert loaded == _issue_review()
-    assert payload["review_status"] == "approved"
+    assert payload["verdict"] == "approved"
     assert payload["provenance"]["source_artifact"] == "issue-draft.json"
 
 
@@ -226,7 +226,7 @@ def test_write_and_load_plan_review_persists_same_run_artifact(tmp_path: Path) -
     loaded = store.load_plan_review(run_dir, issue_ref="owner/repo#1")
     payload = json.loads((run_dir / "plan-review.json").read_text(encoding="utf-8"))
     assert loaded == _plan_review()
-    assert payload["review_status"] == "approved"
+    assert payload["verdict"] == "approved"
     assert payload["provenance"]["source_artifact"] == "approved-plan.json"
 
 
@@ -235,7 +235,7 @@ def test_write_and_load_impl_review_persists_canonical_artifact(tmp_path: Path) 
     run_dir = tmp_path / "runs" / "run-123"
     run_dir.mkdir(parents=True)
     review = ImplReviewResult(
-        review_status="changes_requested",
+        verdict="changes_requested",
         summary="Published PR requires changes.",
         pull_request_url="https://github.com/owner/repo/pull/1",
         pull_number=1,
@@ -260,7 +260,7 @@ def test_write_and_load_impl_review_persists_canonical_artifact(tmp_path: Path) 
     loaded = store.load_impl_review(run_dir)
     payload = json.loads((run_dir / "impl-review.json").read_text(encoding="utf-8"))
     assert loaded == review
-    assert payload["review_status"] == "changes_requested"
+    assert payload["verdict"] == "changes_requested"
     assert payload["feedback"][0]["source"] == "reviewer"
 
 
@@ -281,7 +281,7 @@ def test_require_plan_review_for_implement_requires_run_record_and_approved_revi
 
     review = RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
 
-    assert review.review_status == "approved"
+    assert review.verdict == "approved"
 
 
 @pytest.mark.parametrize(
@@ -313,9 +313,9 @@ def test_require_plan_review_for_implement_rejects_non_approved_status(
     run_dir = tmp_path / "runs" / "run-123"
     run_dir.mkdir(parents=True)
     _write_run_record(run_dir)
-    store.write_plan_review(run_dir, _plan_review(status=status))
+    store.write_plan_review(run_dir, _plan_review(verdict=status))
 
-    with pytest.raises(PlanReviewNotApprovedError, match="review_status"):
+    with pytest.raises(PlanReviewNotApprovedError, match="verdict"):
         RunStore.require_plan_review_for_implement(run_dir, issue_ref="owner/repo#1")
 
 
@@ -365,9 +365,9 @@ def test_write_gated_approved_plan_rejects_non_approved_issue_review(
     store = RunStore(tmp_path / "runs")
     run_dir = tmp_path / "runs" / "run-123"
     run_dir.mkdir(parents=True)
-    store.write_issue_review(run_dir, _issue_review(status=status))
+    store.write_issue_review(run_dir, _issue_review(verdict=status))
 
-    with pytest.raises(ApprovedPlanGateError, match="review_status"):
+    with pytest.raises(ApprovedPlanGateError, match="verdict"):
         store.write_gated_approved_plan(run_dir, _approved_plan())
 
 
@@ -523,7 +523,7 @@ def test_write_follow_on_artifacts_persists_json(tmp_path: Path) -> None:
         detail_codes=("executor_not_implemented",),
     )
     verdict = GovernanceVerdict(
-        status="blocked",
+        verdict="blocked",
         summary="Execution blocked.",
         reason_codes=("executor_not_implemented",),
     )


### PR DESCRIPTION
## Summary
- normalize persisted review and governance artifacts on `verdict`
- update docs and command-surface references to match the active contract
- align tests with tri-state review verdicts and two-state governance verdicts

Closes #149