### PR TITLE
Retire docs/operator-skill.md (issue #152)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,4 +162,4 @@ Before requesting review:
 
 ## Getting Help
 
-If you are unsure whether a contribution is in scope, open a discussion issue first. For questions about the repair workflow, governance model, or the docs-first principle, the `docs/operator-skill.md` provides a practical walkthrough.
+If you are unsure whether a contribution is in scope, open a discussion issue first. For questions about the current workflow, governance model, or the docs-first principle, see `docs/architecture.md` and the ADRs in `docs/adr/`.

--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ If you use the `skills` ecosystem directly, this repo also exposes a skill packa
 ## Key Documents
 
 - `docs/architecture.md` - current docs-first architecture
-- `docs/operator-skill.md` - practical operator/agent workflow guide for GitHub + precision-squad
 - `docs/archive/architecture-v1.md` - archived bootstrap architecture for historical reference
 - `docs/archive/PRECISION_SQUAD_HANDOFF.md` - archived handoff from the earlier `orchestrator` exploration
+- `docs/archive/operator-skill.md` - **retired** operator guide (pre-canonical-resolver era; see architecture.md for current model)
 
 ## Issue Workflow
 

--- a/docs/archive/operator-skill.md
+++ b/docs/archive/operator-skill.md
@@ -1,3 +1,14 @@
+# ⚠️ RETIRED — Precision Squad Operator Skill
+
+> **This document has been retired as of 2026-06-04.**
+> The content below describes the pre-canonical-resolver era of `precision-squad`, when the primary interface was a single-shot `repair issue` CLI with provisional governance. That era has ended.
+>
+> The project now uses a **7-stage canonical issue resolver** (create → review issue → plan → review plan → implement → publish → review impl) with only two governance verdicts: `approved` and `blocked`. There is no provisional.
+>
+> To contribute or operate in this project, file a well-scoped GitHub issue and let the resolver work it. For architecture context, see `docs/architecture.md` and `docs/adr/`.
+
+---
+
 # Precision Squad Operator Skill
 
 Use this document when an AI agent or human operator is driving normal development work with GitHub and `precision-squad` together.


### PR DESCRIPTION
## Summary

Retires `docs/operator-skill.md` — the pre-canonical-resolver operator guide that described an obsolete interface.

## Changes

- **Archive**: `docs/operator-skill.md` → `docs/archive/operator-skill.md` with a retirement banner at the top explaining why it was retired
- **README.md**: Removed `docs/operator-skill.md` from the Key Documents list; added it to the archive section with a note pointing to `architecture.md`
- **CONTRIBUTING.md**: Replaced the reference to `docs/operator-skill.md` with a reference to `docs/architecture.md` and `docs/adr/`

## Why this is correct

The `operator-skill.md` described:
- Two top-level commands: `repair issue` and `publish run`
- A **single-shot repair agent** as the primary interface
- **Provisional governance** — a quality tier that no longer exists (ADR-001 retired it)

The project now runs a **7-stage canonical issue resolver** with only `approved` and `blocked` governance verdicts (ADR-008). There is no `repair issue` workflow in the canonical resolver. The document was actively misleading.

## Closes

#152