### PR TITLE
Add ADR-010: Transition from CONTEXT.md to standard CLAUDE.md with cascading prompt support

### DIFF
--- a/docs/adr/adr-010-claude-md-migration.md
+++ b/docs/adr/adr-010-claude-md-migration.md
@@ -1,0 +1,67 @@
+# ADR-010: CLAUDE.md Migration
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-12
+
+## Context
+
+The project currently uses a bespoke `CONTEXT.md` convention that requires custom parsing logic. This convention was established to capture governance verdicts, quality tags, workflow definitions, and domain vocabulary in a single document. However, `CONTEXT.md` is a project-specific convention that offers no portability across agentic coding environments.
+
+In parallel, `CLAUDE.md` has emerged as a de facto standard supported by most agentic coding environments — including Claude Code, GitHub Copilot, Cursor, and Windsurf. Unlike `CONTEXT.md`, the `CLAUDE.md` convention natively supports cascading prompts: topic-specific instructions can live in sub-files (e.g., `instructions/*.md`) that the root `CLAUDE.md` links via standard Markdown syntax, without any custom loader code.
+
+This shift represents both a portability opportunity and a contributor-friction reduction. Any contributor familiar with agentic coding workflows already understands `CLAUDE.md`; `CONTEXT.md` requires project-specific onboarding that provides no lasting value outside this codebase.
+
+## Decision
+
+Outcome: **Adopt `CLAUDE.md` with cascading prompt support; deprecate `CONTEXT.md`**.
+
+The project will transition from the custom `CONTEXT.md` convention to the standard `CLAUDE.md` format. The root `CLAUDE.md` will serve as the entry point, with topic-specific instructions living in a linked `instructions/` subdirectory. `CONTEXT.md` will be deprecated — reduced to a thin redirect shim pointing to `CLAUDE.md` or the relevant `instructions/` file — without full removal in this slice.
+
+**This ADR authorizes only the decision record itself.** Implementation of the migration (creation of `CLAUDE.md`, `instructions/` directory, topic-specific files, and the `CONTEXT.md` redirect shim) is owned by issue #166 and is explicitly out of scope for this ADR.
+
+## Rationale
+
+The decision to adopt `CLAUDE.md` is grounded in three pillars drawn from the migration implementation issue:
+
+### Portability
+
+`CLAUDE.md` is supported as a native convention by most agentic coding environments. This means the project can move between tools without rewriting instruction files. `CONTEXT.md` is a bespoke format with no external tooling support and no ecosystem momentum.
+
+### Contributor-friction
+
+Anyone familiar with agentic coding workflows already knows `CLAUDE.md`. Adopting it eliminates a project-specific learning curve and makes the codebase more accessible to contributors who have not yet read `CONTEXT.md`. Familiar conventions reduce onboarding cost and increase the likelihood of useful contributions.
+
+### Cascading prompts
+
+`CLAUDE.md` natively supports cascading prompts — topic-specific instructions can live in sub-files (`instructions/*.md`) that the root `CLAUDE.md` links via standard Markdown `[](./instructions/foo.md)` syntax, without custom parsing or loader code. This enables modular organization of concern-specific documentation (governance, workflow, vocabulary, GitHub transport) while keeping the root document readable. `CONTEXT.md` does not support this pattern without custom code.
+
+## Consequences
+
+### What this ADR authorizes
+
+- This ADR artifact (`docs/adr/adr-010-claude-md-migration.md`) is produced and committed.
+- The decision to adopt `CLAUDE.md` with cascading prompt support is formally recorded.
+- `CONTEXT.md` is formally deprecated as a future state (full removal is deferred to a follow-on issue).
+- No implementation code, scripts, or file changes are authorized by this ADR.
+
+### What this ADR does NOT authorize
+
+- Creation of `CLAUDE.md` at the workspace root.
+- Creation of `instructions/` directory or any topic-specific files.
+- Changes to `CONTEXT.md` (it will be demoted to a redirect shim by issue #166).
+- Any changes to run-store schema, artifact formats, or workflow controller logic.
+- Any changes to `skills/`, `src/`, `tests/`, or existing ADRs.
+
+### Ownership of downstream work
+
+Issue #166 owns the implementation of this decision. That issue will produce `CLAUDE.md`, the `instructions/` directory with topic-specific files, and the `CONTEXT.md` redirect shim. This ADR and issue #166 together complete the full migration slice.
+
+## References
+
+- [Issue #166: Migrate from CONTEXT.md to standard CLAUDE.md with cascading prompt support](https://github.com/cracklings3d/precision-squad/issues/166) — downstream implementation issue
+- [ADR-009: FSM Workflow Controller Architecture](./adr-009-fsm-workflow-controller.md) — ADR format template

--- a/docs/issue-plans/issue-167.md
+++ b/docs/issue-plans/issue-167.md
@@ -1,0 +1,99 @@
+---
+issue: github.com/cracklings3d/precision-squad#167
+title: Add ADR-010 documenting the CONTEXT.md → CLAUDE.md transition decision
+status: draft
+plan_status: proposed
+review_status: pending
+source: issue
+owner: architect
+created_at: 2026-06-12
+updated_at: 2026-06-12
+approved_by: null
+approved_at: null
+review_artifact: null
+related_branch: issue/167-adr-010-claude-md
+related_pr: null
+replaces: null
+supersedes: null
+change_scope:
+  files:
+    - docs/adr/adr-010-claude-md-migration.md
+  directories: []
+  modules: []
+  artifacts: []
+---
+
+# Summary
+
+Create ADR-010 to formally document the decision to transition from the custom `CONTEXT.md` convention to the standard `CLAUDE.md` format with cascading prompt support. The ADR captures the rationale (portability, contributor-friction reduction, native cascading prompt support) and does not authorize any implementation changes — those are owned by issue #166.
+
+# Problem
+
+The project currently uses a bespoke `CONTEXT.md` convention that requires custom parsing logic. This creates friction for contributors familiar with standard agentic coding conventions (Claude Code, GitHub Copilot, Cursor, Windsurf) which natively support `CLAUDE.md`. Additionally, `CONTEXT.md` does not support cascading prompts — topic-specific instructions cannot live in sub-files linked from a root document without custom loader code.
+
+# Acceptance Criteria
+
+- `docs/adr/adr-010-claude-md-migration.md` exists on `master`
+- ADR follows the existing `adr-009-fsm-workflow-controller.md` format (Status, Date, Context, Decision, Rationale, Consequences, References)
+- ADR explicitly cross-references #166 as the implementation issue
+- ADR status is `Proposed` (not yet Accepted)
+- PR links to this issue and is mergeable
+
+# In Scope
+
+- Synthesizing the decision rationale from #166's Motivation section (portability, contributor-friction, cascading prompts)
+- Authoring the ADR with Context, Decision, Rationale, and Consequences sections
+- Establishing ADR-010 status as `Proposed`
+- Adding References section pointing to #166 (migration issue) and ADR-009 (format template)
+- NOT citing CONTEXT.md as a forward-looking authority
+
+# Out Of Scope
+
+- Implementation of the CLAUDE.md migration (owned by #166)
+- Creation of `instructions/` directory or any topic-specific files
+- Changes to `CONTEXT.md` itself (will be demoted to redirect shim by #166)
+- Any changes to run-store schema, artifact formats, or workflow controller logic
+- Any changes to skills/, src/, tests/, or existing ADRs
+
+# Constraints
+
+- ADR must follow the section order and style of ADR-009 (Status, Date, Context, Decision, Rationale, Consequences, References)
+- References section must NOT reference `CONTEXT.md` as a forward-looking authority
+- Status field must be `Proposed`, not `Accepted`
+
+# Proposed Approach
+
+1. Draft `docs/adr/adr-010-claude-md-migration.md` following ADR-009 format
+2. **Context section**: Describe the current state (CONTEXT.md bespoke convention, custom parsing required) and the emergence of CLAUDE.md as a de facto standard
+3. **Decision section**: State that the project will adopt CLAUDE.md with cascading prompt support, and that CONTEXT.md will be deprecated (not removed in this slice)
+4. **Rationale section**: Synthesize from #166's Motivation:
+   - Portability: CLAUDE.md is supported by most agentic coding environments
+   - Contributor-friction: familiar convention reduces onboarding
+   - Cascading prompts: native support for topic-specific sub-files without custom loader code
+5. **Consequences section**: Document what this decision authorizes (the ADR itself) and what it does not authorize (implementation changes)
+6. **References section**: Point to #166 (the migration implementation issue) and ADR-009 (the format template)
+
+# Impacted Areas
+
+- `docs/adr/adr-010-claude-md-migration.md` (new file)
+
+# Validation Plan
+
+- File `docs/adr/adr-010-claude-md-migration.md` exists on branch `issue/167-adr-010-claude-md`
+- File contains all required sections: Status, Date, Context, Decision, Rationale, Consequences, References
+- Status field value is `Proposed`
+- References section contains #166 and ADR-009, does not contain CONTEXT.md as forward-looking authority
+- PR for this ADR links to issue #167
+
+# Risks
+
+- None identified. This is a documentation-only ADR that does not authorize implementation changes.
+
+# Open Questions
+
+- None. The substantive decision content is already captured in #166's Motivation section.
+
+# Approval Notes
+
+- Stage B review identified that the issue defines the ADR container but not the substantive decision content. The Context/Decision/Rationale prose must be synthesized from #166's Motivation section plus upstream decision context.
+- Stage B review also confirmed that references must NOT cite CONTEXT.md as forward-looking authority since #166 will demote CONTEXT.md to a redirect shim.


### PR DESCRIPTION
## Summary

Adds [ADR-010](./docs/adr/adr-010-claude-md-migration.md) documenting the architectural decision to transition from the custom `CONTEXT.md` convention to the standard `CLAUDE.md` format with cascading prompt support.

## Closes

- Closes #167 (this ADR's tracking issue)

## Related

- #166 — downstream implementation issue (the actual migration work, separate PR/issue)

## What

- Adds `docs/adr/adr-010-claude-md-migration.md` (Status: Proposed)
- Follows the existing ADR-009 format (Status, Date, Context, Decision, Rationale, Consequences, References)
- No code changes
- No existing files modified

## Why

`CONTEXT.md` is a bespoke convention requiring custom parsing. `CLAUDE.md` is a de facto standard supported by most agentic coding environments (Claude Code, GitHub Copilot, Cursor, Windsurf, etc.) and natively supports cascading prompts — topic-specific instructions can live in sub-files (`instructions/*.md`) linked from the root `CLAUDE.md`, without custom loader code.

The decision is **Go**: adopt CLAUDE.md, deprecate CONTEXT.md, implement cascading prompts. The ADR explicitly defers the actual migration steps to #166 (a separate, scoped implementation issue).

## Out of scope (deferred to #166)

- Creating `CLAUDE.md` and `instructions/*.md` at the workspace root
- Deprecating / shimming `CONTEXT.md`
- Updating doc references from `CONTEXT.md` → `CLAUDE.md`
- Validating cascading prompt behavior in a real runtime

## Acceptance Criteria

- [ ] ADR-010 file exists on `master`
- [ ] ADR follows the ADR-009 format
- [ ] ADR cross-references #166 and #167
- [ ] ADR status is `Proposed` (not yet `Accepted`)

## Files Changed

- `docs/adr/adr-010-claude-md-migration.md` (new, +67 lines)