### PR TITLE
[#173] ADR verifiability: add Verification sections to ADR-001, ADR-008, ADR-009

### DIFF
--- a/docs/adr/adr-001-governance-two-verdicts.md
+++ b/docs/adr/adr-001-governance-two-verdicts.md
@@ -81,6 +81,14 @@ Quality tags are **informational only**. The verdict (approved/blocked) is what 
 - Integration tests verify quality tags separately from verdicts.
 - The publish plan body uses the quality tag for context but does not gate on it.
 
+## Verification
+
+- [ ] No source file under `src/precision_squad/` references `provisional` as a governance verdict
+- [ ] `ExecutionResult` carries the `quality` field with values `green | improved | degraded | None`
+- [ ] `apply_governance` returns only `approved` or `blocked`
+- [ ] `governance-verdict.json` artifacts contain `verdict` with values from `{approved, blocked}` only
+- [ ] Tests assert quality-tag behaviour independently of verdict
+
 ## References
 
 - [CONTEXT.md](../../CONTEXT.md) — Governance Verdicts, Quality Tag

--- a/docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md
+++ b/docs/adr/adr-008-resolve-implement-and-review-impl-stage-semantics.md
@@ -107,6 +107,13 @@ The workflow timing is locked down as follows:
 - Documentation and future implementation work should treat persisted implementation artifacts and persisted publish artifacts as distinct handoff points.
 - Issue closure remains governed elsewhere and is not implied by `implement`, `publish`, or draft PR creation.
 
+## Verification
+
+- [ ] `implement` stage does not call the GitHub transport to create a branch or PR
+- [ ] `publish` stage is the only stage that produces `publish-plan.json` and `publish-result.json`
+- [ ] `review impl` consumes the published draft PR (URL or number + head SHA), not an unpublished local-only workspace
+- [ ] PR creation occurs after `governance-verdict.json` records `verdict: approved`
+
 ## References
 
 - [CONTEXT.md](../../CONTEXT.md) — Governance Verdicts

--- a/docs/adr/adr-009-fsm-workflow-controller.md
+++ b/docs/adr/adr-009-fsm-workflow-controller.md
@@ -156,13 +156,19 @@ If a subsequent issue implements the FSM controller in code, it must and must no
 
 If this ADR were to recommend No-go, the dominant reason would be: the current implicit orchestration is functional and low-risk, and the FSM model's inspectability and testability benefits do not justify the code-slice implementation cost unless a concrete use case (e.g., deterministic transition test fixtures) demands it. The smallest useful follow-up would be to add an informal state-diagram section to [architecture.md](../architecture.md) so the implicit model is at least documented visually.
 
+## Verification
+
+- [ ] This ADR is the only output of the slice (no production code, no run-store schema change, no edits to staged-command-surface or architecture docs)
+- [ ] The eleven FSM states and seventeen events named in the ADR are the reference design for any future code-slice implementation
+- [ ] The Must / Must-not rules in the "Future code-slice envelope" are falsifiable checks for the future code slice
+
 ## References
 
 - [CONTEXT.md](../../CONTEXT.md) — Governance verdicts, `approved` gates `publish`
 - [architecture.md](../architecture.md) — Persistence model, run state, stage chain
 - [staged-command-surface.md](./staged-command-surface.md) — Seven-stage chain, per-stage subagents, resume matrix, repair contract
 - [ADR-001: Governance Two-Verdict Model](./adr-001-governance-two-verdicts.md) — Two-state governance vocabulary
-- [ADR-002: LLM Abstraction](./adr-002-llm-abstraction.md) — Per-stage subagent designation
+- [ADR-002: LLM Abstraction](./adr-002-SUPERSEDED.md) — Per-stage subagent designation
 - [ADR-005: Tool-Backed Repair Agent Adapters](./adr-005-tool-backed-repair-agent-adapters.md) — Repair agent architecture
 - [ADR-008: Resolve Implement and Review Impl Stage Semantics](./adr-008-resolve-implement-and-review-impl-stage-semantics.md) — implement/publish/review impl boundaries
 - [Canonical tracked plan for this issue](./issue-plans/issue-153.md)


### PR DESCRIPTION
## Summary
Add ## Verification sections to ADR-001, ADR-008, and ADR-009 modeled on the falsifiable 5-item checklist in ADR-005.

## Changes
- **ADR-001**: Added ## Verification section with 5 checkable items (governance verdict checks, quality tag checks, ExecutionResult checks)
- **ADR-008**: Added ## Verification section with 4 checkable items (stage boundary checks for implement/publish/review impl)
- **ADR-009**: Added ## Verification section with 3 checkable items (documentation-only slice checks, FSM states/events as reference design)
- Updated ADR-009 reference to ADR-002 to use SUPERSEDED pointer

## References
- Issue #173: https://github.com/cracklings3d/precision-squad/issues/173