### PR TITLE
[#174] Surface MVP, V1 assumptions, and non-goals on prompt chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,4 +7,5 @@ See the linked instruction files below for topic-specific guidance.
 - [Governance](./instructions/governance.md) — Governance verdicts and quality tags
 - [Workflow](./instructions/workflow.md) — Issue-driven workflow and side issues
 - [Vocabulary](./instructions/vocabulary.md) — Repair agent, docs fix prompt, project scope, and graph refresh policy
+- [Scope](./instructions/scope.md) — MVP shape, V1 operating assumptions, and V1 non-goals
 - [GitHub Transport](./instructions/github-transport.md) — GitHub transport configuration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,8 @@ That means:
 - a hidden substitute for missing setup or test docs
 - a platform-normalization layer that rewrites one command into another and quietly trusts the result
 
+For V1 non-goals, see [`scope.md`](../instructions/scope.md).
+
 ## Execution Model
 
 The explicit local stage chain is:
@@ -374,6 +376,8 @@ The active architecture does not try to provide:
 - automatic derivation of the right test command when the docs do not say it
 - a database-backed execution service
 - remote runner orchestration
+
+For complete V1 non-goals, see [`scope.md`](../instructions/scope.md).
 
 ## Archived Designs
 

--- a/instructions/scope.md
+++ b/instructions/scope.md
@@ -1,0 +1,46 @@
+# Project Scope
+
+This document surfaces the MVP shape, V1 operating assumptions, and V1 non-goals of precision-squad. It is a short, scannable summary for the cascading prompt chain. The canonical public-facing source for this content is `README.md`.
+
+## MVP Shape
+
+The seven-step MVP control loop:
+
+1. Accept a GitHub issue
+2. Normalize it into a runnable request
+3. Extract the documented local setup and QA contract
+4. Execute the repair workflow
+5. Collect artifacts and evidence
+6. Apply governance
+7. Publish a draft PR or a blocked verdict
+
+For the full text, see `README.md:28-36`.
+
+## V1 Operating Assumptions
+
+### Authentication (Credential Supply)
+- PAT-only credential supply for GitHub operations
+
+### Transport (How GitHub Operations Are Executed)
+- `GITHUB_TRANSPORT=auto|mcp|cli` — see [`instructions/github-transport.md`](./github-transport.md) for transport model details
+- CLI/service first
+- Filesystem-backed run persistence
+- Docs-first execution behind a narrow adapter boundary
+
+For the full text, see `README.md:38-47`.
+
+## V1 Non-Goals
+
+### Authentication
+- No GitHub App authentication
+
+### Transport
+- No deep repo-specific inference machinery
+
+### Persistence
+- No database-backed persistence
+
+### Execution
+- No multi-tenant or broad parallel execution
+
+For the full text, see `README.md:49-60`.

--- a/instructions/vocabulary.md
+++ b/instructions/vocabulary.md
@@ -14,7 +14,7 @@ Retry: manual via `repair issue --retry-from <run-id>`. Up to 3 attempts before 
 
 ## Project Scope
 
-Any project with a documented QA command — code or non-code (e.g., Unreal Engine blueprints). The system does not build test infrastructure; it executes whatever the project owner already documented. Language-agnostic at the architecture level.
+The MVP shape, V1 operating assumptions, and V1 non-goals are documented in [`scope.md`](./scope.md). In brief: any project with a documented QA command — code or non-code (e.g., Unreal Engine blueprints). The system does not build test infrastructure; it executes whatever the project owner already documented. Language-agnostic at the architecture level.
 
 ## Graph Refresh Policy
 


### PR DESCRIPTION
## Summary
Add instructions/scope.md that surfaces MVP shape, V1 operating assumptions, and V1 non-goals on the cascading prompt chain.

## Changes
- Created `instructions/scope.md` with MVP control loop, V1 operating assumptions, and V1 non-goals (with pointers to README.md for full text)
- Linked from `CLAUDE.md` so it sits on the prompt chain
- Cross-linked from `instructions/vocabulary.md` "Project Scope" section
- Cross-linked from `docs/architecture.md` "System Boundary" and "Current Non-Goals" sections

## References
- Issue #174: https://github.com/cracklings3d/precision-squad/issues/174