### PR TITLE
[precision-squad#184] Reconcile architecture.md stage chain with 7-stage model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,8 @@ The explicit local stage chain is:
 3. `plan`
 4. `review plan`
 5. `implement`
-6. `publish run`
+6. `publish`
+7. `review impl`
 
 `implement` is the local-only boundary between reviewed planning and publish-side behavior. It reuses the same docs-first execution, repair, QA, evaluation, and governance persistence flow as the compatibility `repair issue` path, but stops before publish planning, GitHub mutation, or post-publish review.
 


### PR DESCRIPTION
## Summary
Reconcile architecture.md stage chain with the 7-stage model. Changes the 6-stage numbered list in docs/architecture.md to a 7-stage list, renaming 'publish run' to 'publish' and adding 'review impl' as stage 7.

## Changes
- Modified `docs/architecture.md` lines 44-52: expanded the numbered stage list from 6 to 7 stages
- Renamed 'publish run' to 'publish'
- Added 'review impl' as stage 7

## Verification
- [ ] Diff touches only lines 44-52 of docs/architecture.md
- [ ] Numbered list shows exactly 7 stages in canonical order
- [ ] `publish run` does not appear anywhere in docs/architecture.md
- [ ] Existing references to 'review impl' at lines 262, 279, 286, 329-330 remain unchanged

## Issue
Fixes #184